### PR TITLE
docs(jeeves): sync env example and README config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,13 @@ APP_LOG_LEVEL=INFO
 # === Database ===
 DATABASE_URL=postgresql+asyncpg://jeeves:jeeves@localhost:5432/jeeves
 
+# === Security ===
+API_KEY=change-me
+
 # === LLM Routing ===
 DEFAULT_MODE=local_first
+ENABLE_CLOUD_FALLBACK=true
+MOCK_PROVIDER_ENABLED=false
 
 # === Ollama (local provider) ===
 OLLAMA_BASE_URL=http://localhost:11434
@@ -16,13 +21,10 @@ OLLAMA_MODEL_DEFAULT=llama3
 OLLAMA_TIMEOUT_SECONDS=30
 
 # === OpenRouter (cloud fallback) ===
-OPENROUTER_API_KEY=sk-or-...
+OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 OPENROUTER_MODEL_DEFAULT=openai/gpt-4o-mini
 OPENROUTER_TIMEOUT_SECONDS=60
-
-# === Routing policy ===
-ENABLE_CLOUD_FALLBACK=true
 
 # === Tools ===
 TOOL_SHELL_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -100,16 +100,22 @@ The app boots fine without Ollama. If Ollama is unavailable and `ENABLE_CLOUD_FA
 
 | Variable | Default | Description |
 |---|---|---|
-| `APP_ENV` | `development` | Environment tag |
+| `APP_ENV` | `development` | Environment tag (`development`, `production`, `test`) |
+| `APP_HOST` | `0.0.0.0` | API bind host |
 | `APP_PORT` | `8000` | API listen port |
+| `APP_LOG_LEVEL` | `INFO` | Application log level |
 | `DATABASE_URL` | `postgresql+asyncpg://...` | PostgreSQL connection string |
+| `API_KEY` | `dev-secret-key` | API key value. Use a strong secret outside local development |
 | `DEFAULT_MODE` | `local_first` | Provider strategy (`local_first`, `cloud_first`, `cheapest`, `strongest`) |
+| `ENABLE_CLOUD_FALLBACK` | `true` | Allow fallback to OpenRouter if local inference fails |
+| `MOCK_PROVIDER_ENABLED` | `false` | Enable the mock LLM provider for local/testing scenarios |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server URL |
 | `OLLAMA_MODEL_DEFAULT` | `llama3` | Default Ollama model |
 | `OLLAMA_TIMEOUT_SECONDS` | `30` | Request timeout for Ollama |
 | `OPENROUTER_API_KEY` | _(empty)_ | OpenRouter API key |
+| `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1` | OpenRouter API base URL |
 | `OPENROUTER_MODEL_DEFAULT` | `openai/gpt-4o-mini` | Default OpenRouter model |
-| `ENABLE_CLOUD_FALLBACK` | `true` | Allow fallback to OpenRouter if local fails |
+| `OPENROUTER_TIMEOUT_SECONDS` | `60` | Request timeout for OpenRouter |
 | `TOOL_SHELL_ENABLED` | `false` | Enable shell execution tool |
 | `TOOL_FILESYSTEM_ENABLED` | `false` | Enable filesystem tool |
 | `TOOL_HTTP_ENABLED` | `false` | Enable HTTP fetch tool |


### PR DESCRIPTION
## Summary
- Syncs .env.example with app/core/config.py settings.
- Updates README configuration table.
- Documents API_KEY, MOCK_PROVIDER_ENABLED, OPENROUTER_BASE_URL, OPENROUTER_TIMEOUT_SECONDS and related settings.

## Validation
- Changed files are limited to .env.example and README.md.
- No runtime code changed.
- No tests, migrations, deployment files, or secrets changed.

## Review
ChatGPT should review before merge.