### PR TITLE
feat(jeeves): add proposal-only action contracts

### DIFF
--- a/app/actions/__init__.py
+++ b/app/actions/__init__.py
@@ -1,0 +1,15 @@
+from app.actions.contracts import (
+    ActionApproval,
+    ActionProposal,
+    ActionResult,
+    ActionRisk,
+    ActionStatus,
+)
+
+__all__ = [
+    "ActionApproval",
+    "ActionProposal",
+    "ActionResult",
+    "ActionRisk",
+    "ActionStatus",
+]

--- a/app/actions/contracts.py
+++ b/app/actions/contracts.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ActionRisk(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+    critical = "critical"
+
+
+class ActionStatus(str, Enum):
+    proposed = "proposed"
+    approved = "approved"
+    rejected = "rejected"
+    completed = "completed"
+    failed = "failed"
+
+
+class ActionProposal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id: str = Field(..., min_length=1)
+    action_type: str = Field(..., min_length=1)
+    title: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+    risk: ActionRisk = ActionRisk.medium
+    status: ActionStatus = ActionStatus.proposed
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    requires_approval: bool = True
+
+    @model_validator(mode="after")
+    def proposal_must_remain_proposed(self) -> Self:
+        if self.status is not ActionStatus.proposed:
+            raise ValueError("action proposals must use proposed status")
+        return self
+
+
+class ActionApproval(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id: str = Field(..., min_length=1)
+    approved: bool
+    status: ActionStatus
+    approved_by: str | None = None
+    reason: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def approve(
+        cls,
+        proposal_id: str,
+        *,
+        approved_by: str | None = None,
+        reason: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Self:
+        return cls(
+            proposal_id=proposal_id,
+            approved=True,
+            approved_by=approved_by,
+            reason=reason,
+            metadata=metadata or {},
+        )
+
+    @classmethod
+    def reject(
+        cls,
+        proposal_id: str,
+        *,
+        approved_by: str | None = None,
+        reason: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Self:
+        return cls(
+            proposal_id=proposal_id,
+            approved=False,
+            approved_by=approved_by,
+            reason=reason,
+            metadata=metadata or {},
+        )
+
+    @model_validator(mode="before")
+    @classmethod
+    def add_default_status(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or "approved" not in data or data.get("status") is not None:
+            return data
+
+        status = ActionStatus.approved if data["approved"] else ActionStatus.rejected
+        return {**data, "status": status}
+
+    @model_validator(mode="after")
+    def status_must_match_approval(self) -> Self:
+        expected_status = ActionStatus.approved if self.approved else ActionStatus.rejected
+        if self.status is not expected_status:
+            raise ValueError("approval status must match approved flag")
+        return self
+
+
+class ActionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id: str = Field(..., min_length=1)
+    success: bool = True
+    status: ActionStatus
+    output: Any = None
+    error: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def add_default_status(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or data.get("status") is not None:
+            return data
+
+        status = ActionStatus.completed if data.get("success", True) else ActionStatus.failed
+        return {**data, "status": status}
+
+    @model_validator(mode="after")
+    def status_must_match_success(self) -> Self:
+        expected_status = ActionStatus.completed if self.success else ActionStatus.failed
+        if self.status is not expected_status:
+            raise ValueError("result status must match success flag")
+        return self

--- a/app/actions/contracts.py
+++ b/app/actions/contracts.py
@@ -46,7 +46,7 @@ class ActionApproval(BaseModel):
 
     proposal_id: str = Field(..., min_length=1)
     approved: bool
-    status: ActionStatus
+    status: ActionStatus = ActionStatus.approved
     approved_by: str | None = None
     reason: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -107,7 +107,7 @@ class ActionResult(BaseModel):
 
     proposal_id: str = Field(..., min_length=1)
     success: bool = True
-    status: ActionStatus
+    status: ActionStatus = ActionStatus.completed
     output: Any = None
     error: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_action_contracts.py
+++ b/tests/test_action_contracts.py
@@ -84,6 +84,20 @@ def test_action_approval_normalizes_default_status():
     assert rejection.status is ActionStatus.rejected
 
 
+def test_action_approval_status_can_be_omitted_by_callers():
+    schema = ActionApproval.model_json_schema()
+
+    assert "status" not in schema["required"]
+    assert (
+        ActionApproval(proposal_id="proposal-1", approved=True).model_dump(mode="json")["status"]
+        == "approved"
+    )
+    assert (
+        ActionApproval(proposal_id="proposal-1", approved=False).model_dump(mode="json")["status"]
+        == "rejected"
+    )
+
+
 def test_action_approval_rejects_mismatched_status():
     with pytest.raises(ValidationError, match="approval status must match approved flag"):
         ActionApproval(
@@ -120,6 +134,17 @@ def test_action_result_failure_shape():
 
     assert result.status is ActionStatus.failed
     assert result.model_dump(mode="json")["error"] == "Action was not executed."
+
+
+def test_action_result_status_can_be_omitted_by_callers():
+    schema = ActionResult.model_json_schema()
+
+    assert "status" not in schema["required"]
+    assert ActionResult(proposal_id="proposal-1").model_dump(mode="json")["status"] == "completed"
+    assert (
+        ActionResult(proposal_id="proposal-1", success=False).model_dump(mode="json")["status"]
+        == "failed"
+    )
 
 
 def test_action_proposal_allows_only_proposed_status():

--- a/tests/test_action_contracts.py
+++ b/tests/test_action_contracts.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.actions import ActionApproval, ActionProposal, ActionResult, ActionRisk, ActionStatus
+
+
+def test_action_proposal_construction_defaults():
+    proposal = ActionProposal(
+        proposal_id="proposal-1",
+        action_type="calendar.create_event",
+        title="Create planning hold",
+        description="Create a tentative calendar hold for planning.",
+    )
+
+    assert proposal.risk is ActionRisk.medium
+    assert proposal.status is ActionStatus.proposed
+    assert proposal.parameters == {}
+    assert proposal.metadata == {}
+    assert proposal.requires_approval is True
+
+
+def test_action_proposal_serializes_enums_and_payload():
+    proposal = ActionProposal(
+        proposal_id="proposal-2",
+        action_type="email.draft",
+        title="Draft reply",
+        description="Draft a reply without sending it.",
+        risk=ActionRisk.high,
+        parameters={"thread_id": "thread-123"},
+        metadata={"source": "unit-test"},
+    )
+
+    assert proposal.model_dump(mode="json") == {
+        "proposal_id": "proposal-2",
+        "action_type": "email.draft",
+        "title": "Draft reply",
+        "description": "Draft a reply without sending it.",
+        "risk": "high",
+        "status": "proposed",
+        "parameters": {"thread_id": "thread-123"},
+        "metadata": {"source": "unit-test"},
+        "requires_approval": True,
+    }
+
+
+def test_action_approval_and_rejection_shapes():
+    approval = ActionApproval.approve(
+        "proposal-1",
+        approved_by="user-1",
+        reason="Looks correct",
+    )
+    rejection = ActionApproval.reject(
+        "proposal-2",
+        approved_by="user-1",
+        reason="Too risky",
+        metadata={"ticket": "INC-42"},
+    )
+
+    assert approval.model_dump(mode="json") == {
+        "proposal_id": "proposal-1",
+        "approved": True,
+        "status": "approved",
+        "approved_by": "user-1",
+        "reason": "Looks correct",
+        "metadata": {},
+    }
+    assert rejection.model_dump(mode="json") == {
+        "proposal_id": "proposal-2",
+        "approved": False,
+        "status": "rejected",
+        "approved_by": "user-1",
+        "reason": "Too risky",
+        "metadata": {"ticket": "INC-42"},
+    }
+
+
+def test_action_approval_normalizes_default_status():
+    approval = ActionApproval(proposal_id="proposal-1", approved=True)
+    rejection = ActionApproval(proposal_id="proposal-1", approved=False)
+
+    assert approval.status is ActionStatus.approved
+    assert rejection.status is ActionStatus.rejected
+
+
+def test_action_approval_rejects_mismatched_status():
+    with pytest.raises(ValidationError, match="approval status must match approved flag"):
+        ActionApproval(
+            proposal_id="proposal-1",
+            approved=False,
+            status=ActionStatus.approved,
+        )
+
+
+def test_action_result_defaults_and_serialization():
+    result = ActionResult(
+        proposal_id="proposal-1",
+        output={"draft_id": "draft-123"},
+        metadata={"provider": "mock"},
+    )
+
+    assert result.status is ActionStatus.completed
+    assert result.model_dump(mode="json") == {
+        "proposal_id": "proposal-1",
+        "success": True,
+        "status": "completed",
+        "output": {"draft_id": "draft-123"},
+        "error": None,
+        "metadata": {"provider": "mock"},
+    }
+
+
+def test_action_result_failure_shape():
+    result = ActionResult(
+        proposal_id="proposal-1",
+        success=False,
+        error="Action was not executed.",
+    )
+
+    assert result.status is ActionStatus.failed
+    assert result.model_dump(mode="json")["error"] == "Action was not executed."
+
+
+def test_action_proposal_allows_only_proposed_status():
+    with pytest.raises(ValidationError, match="action proposals must use proposed status"):
+        ActionProposal(
+            proposal_id="proposal-1",
+            action_type="email.send",
+            title="Send message",
+            description="Send a message.",
+            status=ActionStatus.approved,
+        )


### PR DESCRIPTION
## Summary
- Adds proposal-only action contracts.
- Adds focused unit tests.
- Does not wire actions into /ask.
- Does not change DB schema.
- Does not execute real actions.

## Validation
- pytest -q passed.
- ruff check app/ tests/ passed.
- black --check app/ tests/ passed.

## Review
ChatGPT should review before merge.