### PR TITLE
test(jeeves): harden action contracts documentation

### DIFF
--- a/knowledge-base/05_ACTION_LAYER.md
+++ b/knowledge-base/05_ACTION_LAYER.md
@@ -2,13 +2,15 @@
 
 ## Current state
 
-The project has accepted a future action direction and already added foundational contracts, but the action layer is **not live**.
+The project has accepted a future action direction and added proposal-only
+contracts, but the action layer is **not live**.
 
 Current live truth:
 - no real side effects
 - no action runner
 - no live proposal generation
 - no approval flow exposed in runtime behavior
+- no action execution result produced by runtime behavior
 - no `/ask` or DB schema changes for action handling
 
 ## Why this layer exists
@@ -22,45 +24,38 @@ The project must eventually distinguish between:
 
 This separation is required to avoid silent or ambiguous side effects.
 
-## Canonical action-layer foundation already added
+## Canonical proposal-only action contracts already added
 
 ### Enums
-- `ApprovalState`
-  - `not_required`
-  - `required`
-  - `approved`
-  - `denied`
-  - `expired`
+- `ActionRisk`
+  - `low`
+  - `medium`
+  - `high`
+  - `critical`
 
-- `ActionExecutionStatus`
-  - `not_started`
-  - `running`
-  - `succeeded`
+- `ActionStatus`
+  - `proposed`
+  - `approved`
+  - `rejected`
+  - `completed`
   - `failed`
-  - `blocked`
-  - `skipped`
 
 ### Models
 - `ActionProposal`
 - `ActionApproval`
-- `ActionExecutionRecord`
+- `ActionResult`
 
-### ExecutionResult extensions
-Additive default-empty fields exist for:
-- `proposed_actions`
-- `action_approvals`
-- `action_executions`
+These are typed data contracts only. They are not wired into `/ask`,
+orchestration, persistence, policy authorization, or tool execution.
 
-## Policy scaffolding already added
-
-The policy engine now has future-facing scaffolding for:
-- `assess_action_proposal(proposal)`
-- `authorize_action_execution(proposal, approval=None)`
-
-Accepted conservative defaults:
-- side-effectful actions require approval by default
-- no implicit authorization exists
-- no live execution path is enabled by these methods yet
+Current contract constraints:
+- action contracts reject unknown fields
+- proposal IDs and required proposal text fields must be non-empty strings
+- proposals must remain in `proposed` status
+- approvals normalize omitted status from the `approved` flag
+- approval status must match the `approved` flag
+- results normalize omitted status from the `success` flag
+- result status must match the `success` flag
 
 ## Accepted future action architecture
 
@@ -85,6 +80,6 @@ That future slice would allow the system to produce typed proposed action intent
 Do not prematurely introduce:
 - direct executor-to-tool execution
 - hidden approval logic in prompts
-- claims of successful action without a real `ActionExecutionRecord`
+- claims of successful action without a real execution path and `ActionResult`
 - API schema expansion before action semantics stabilize
 - DB schema changes before the runtime action model is proven

--- a/tests/test_action_contracts.py
+++ b/tests/test_action_contracts.py
@@ -21,6 +21,63 @@ def test_action_proposal_construction_defaults():
     assert proposal.requires_approval is True
 
 
+@pytest.mark.parametrize(
+    ("model_cls", "payload"),
+    [
+        (
+            ActionProposal,
+            {
+                "proposal_id": "proposal-1",
+                "action_type": "calendar.create_event",
+                "title": "Create planning hold",
+                "description": "Create a tentative calendar hold for planning.",
+                "unexpected": "nope",
+            },
+        ),
+        (
+            ActionApproval,
+            {
+                "proposal_id": "proposal-1",
+                "approved": True,
+                "unexpected": "nope",
+            },
+        ),
+        (
+            ActionResult,
+            {
+                "proposal_id": "proposal-1",
+                "unexpected": "nope",
+            },
+        ),
+    ],
+)
+def test_action_contracts_reject_extra_fields(model_cls, payload):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        model_cls(**payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("proposal_id", ""),
+        ("action_type", ""),
+        ("title", ""),
+        ("description", ""),
+    ],
+)
+def test_action_proposal_rejects_empty_required_strings(field, value):
+    payload = {
+        "proposal_id": "proposal-1",
+        "action_type": "calendar.create_event",
+        "title": "Create planning hold",
+        "description": "Create a tentative calendar hold for planning.",
+        field: value,
+    }
+
+    with pytest.raises(ValidationError, match="String should have at least 1 character"):
+        ActionProposal(**payload)
+
+
 def test_action_proposal_serializes_enums_and_payload():
     proposal = ActionProposal(
         proposal_id="proposal-2",
@@ -84,6 +141,24 @@ def test_action_approval_normalizes_default_status():
     assert rejection.status is ActionStatus.rejected
 
 
+@pytest.mark.parametrize(
+    ("approved", "status"),
+    [
+        (True, ActionStatus.approved),
+        (False, ActionStatus.rejected),
+    ],
+)
+def test_action_approval_accepts_explicit_matching_status(approved, status):
+    approval = ActionApproval(
+        proposal_id="proposal-1",
+        approved=approved,
+        status=status,
+    )
+
+    assert approval.approved is approved
+    assert approval.status is status
+
+
 def test_action_approval_status_can_be_omitted_by_callers():
     schema = ActionApproval.model_json_schema()
 
@@ -105,6 +180,11 @@ def test_action_approval_rejects_mismatched_status():
             approved=False,
             status=ActionStatus.approved,
         )
+
+
+def test_action_approval_rejects_empty_proposal_id():
+    with pytest.raises(ValidationError, match="String should have at least 1 character"):
+        ActionApproval(proposal_id="", approved=True)
 
 
 def test_action_result_defaults_and_serialization():
@@ -147,6 +227,27 @@ def test_action_result_status_can_be_omitted_by_callers():
     )
 
 
+@pytest.mark.parametrize(
+    ("success", "status"),
+    [
+        (True, ActionStatus.failed),
+        (False, ActionStatus.completed),
+    ],
+)
+def test_action_result_rejects_mismatched_status(success, status):
+    with pytest.raises(ValidationError, match="result status must match success flag"):
+        ActionResult(
+            proposal_id="proposal-1",
+            success=success,
+            status=status,
+        )
+
+
+def test_action_result_rejects_empty_proposal_id():
+    with pytest.raises(ValidationError, match="String should have at least 1 character"):
+        ActionResult(proposal_id="")
+
+
 def test_action_proposal_allows_only_proposed_status():
     with pytest.raises(ValidationError, match="action proposals must use proposed status"):
         ActionProposal(
@@ -156,3 +257,13 @@ def test_action_proposal_allows_only_proposed_status():
             description="Send a message.",
             status=ActionStatus.approved,
         )
+
+
+def test_ask_response_schema_does_not_expose_action_fields():
+    from app.schemas.ask import AskResponse
+
+    schema = AskResponse.model_json_schema()
+
+    assert "proposed_actions" not in schema["properties"]
+    assert "action_approvals" not in schema["properties"]
+    assert "action_executions" not in schema["properties"]


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #12

## Scope

[agent-task-yellow] Jeeves docs-and-tests action contracts hardening

## Validation

```text
Collecting pytest-asyncio>=0.23.0 (from jeeves==0.1.0)
  Using cached pytest_asyncio-1.3.0-py3-none-any.whl.metadata (4.1 kB)
Collecting aiosqlite>=0.20.0 (from jeeves==0.1.0)
  Using cached aiosqlite-0.22.1-py3-none-any.whl.metadata (4.3 kB)
Collecting ruff>=0.4.0 (from jeeves==0.1.0)
  Using cached ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (26 kB)
Collecting black>=24.4.0 (from jeeves==0.1.0)
  Using cached black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (91 kB)
Collecting annotated-types>=0.6.0 (from pydantic<2.10,>=2.7.0->jeeves==0.1.0)
  Using cached annotated_types-0.7.0-py3-none-any.whl.metadata (15 kB)
Collecting pydantic-core==2.23.4 (from pydantic<2.10,>=2.7.0->jeeves==0.1.0)
  Using cached pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)
Collecting typing-extensions>=4.6.1 (from pydantic<2.10,>=2.7.0->jeeves==0.1.0)
  Using cached typing_extensions-4.15.0-py3-none-any.whl.metadata (3.3 kB)
Collecting typing-inspection>=0.4.0 (from pydantic-settings<2.10,>=2.3.0->jeeves==0.1.0)
  Using cached typing_inspection-0.4.2-py3-none-any.whl.metadata (2.6 kB)
Collecting Mako (from alembic>=1.13.0->jeeves==0.1.0)
  Using cached mako-1.3.12-py3-none-any.whl.metadata (2.9 kB)
Collecting click>=8.0.0 (from black>=24.4.0->jeeves==0.1.0)
  Using cached click-8.3.3-py3-none-any.whl.metadata (2.6 kB)
Collecting mypy-extensions>=0.4.3 (from black>=24.4.0->jeeves==0.1.0)
  Using cached mypy_extensions-1.1.0-py3-none-any.whl.metadata (1.1 kB)
Collecting packaging>=22.0 (from black>=24.4.0->jeeves==0.1.0)
  Using cached packaging-26.2-py3-none-any.whl.metadata (3.5 kB)
Collecting pathspec>=1.0.0 (from black>=24.4.0->jeeves==0.1.0)
  Using cached pathspec-1.1.1-py3-none-any.whl.metadata (14 kB)
Collecting platformdirs>=2 (from black>=24.4.0->jeeves==0.1.0)
  Using cached platformdirs-4.9.6-py3-none-any.whl.metadata (4.7 kB)
Collecting pytokens~=0.4.0 (from black>=24.4.0->jeeves==0.1.0)
  Using cached pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (3.8 kB)
Collecting starlette>=0.46.0 (from fastapi>=0.115.0->jeeves==0.1.0)
  Using cached starlette-1.0.0-py3-none-any.whl.metadata (6.3 kB)
Collecting annotated-doc>=0.0.2 (from fastapi>=0.115.0->jeeves==0.1.0)
  Using cached annotated_doc-0.0.4-py3-none-any.whl.metadata (6.6 kB)
Collecting anyio (from httpx>=0.27.0->jeeves==0.1.0)
  Using cached anyio-4.13.0-py3-none-any.whl.metadata (4.5 kB)
Collecting certifi (from httpx>=0.27.0->jeeves==0.1.0)
  Using cached certifi-2026.4.22-py3-none-any.whl.metadata (2.5 kB)
Collecting httpcore==1.* (from httpx>=0.27.0->jeeves==0.1.0)
  Using cached httpcore-1.0.9-py3-none-any.whl.metadata (21 kB)
Collecting idna (from httpx>=0.27.0->jeeves==0.1.0)
  Using cached idna-3.13-py3-none-any.whl.metadata (8.0 kB)
Collecting h11>=0.16 (from httpcore==1.*->httpx>=0.27.0->jeeves==0.1.0)
  Using cached h11-0.16.0-py3-none-any.whl.metadata (8.3 kB)
Collecting iniconfig>=1.0.1 (from pytest>=8.2.0->jeeves==0.1.0)
  Using cached iniconfig-2.3.0-py3-none-any.whl.metadata (2.5 kB)
Collecting pluggy<2,>=1.5 (from pytest>=8.2.0->jeeves==0.1.0)
  Using cached pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
Collecting pygments>=2.7.2 (from pytest>=8.2.0->jeeves==0.1.0)
  Using cached pygments-2.20.0-py3-none-any.whl.metadata (2.5 kB)
Collecting httptools>=0.6.3 (from uvicorn[standard]>=0.30.0->jeeves==0.1.0)
  Using cached httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (3.5 kB)
Collecting pyyaml>=5.1 (from uvicorn[standard]>=0.30.0->jeeves==0.1.0)
  Using cached pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (2.4 kB)
Collecting uvloop>=0.15.1 (from uvicorn[standard]>=0.30.0->jeeves==0.1.0)
  Using cached uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (4.9 kB)
Collecting watchfiles>=0.20 (from uvicorn[standard]>=0.30.0->jeeves==0.1.0)
  Using cached watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.9 kB)
Collecting websockets>=10.4 (from uvicorn[standard]>=0.30.0->jeeves==0.1.0)
  Using cached websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (6.8 kB)
Collecting MarkupSafe>=0.9.2 (from Mako->alembic>=1.13.0->jeeves==0.1.0)
  Using cached markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (2.7 kB)
Using cached pydantic-2.9.2-py3-none-any.whl (434 kB)
Using cached pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.1 MB)
Using cached pydantic_settings-2.9.1-py3-none-any.whl (44 kB)
Using cached aiosqlite-0.22.1-py3-none-any.whl (17 kB)
Using cached alembic-1.18.4-py3-none-any.whl (263 kB)
Using cached annotated_types-0.7.0-py3-none-any.whl (13 kB)
Using cached asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl (3.5 MB)
Using cached black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (1.8 MB)
Using cached pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (269 kB)
Using cached click-8.3.3-py3-none-any.whl (110 kB)
Using cached fastapi-0.136.1-py3-none-any.whl (117 kB)
Using cached annotated_doc-0.0.4-py3-none-any.whl (5.3 kB)
Using cached greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (611 kB)
Using cached httpx-0.28.1-py3-none-any.whl (73 kB)
Using cached httpcore-1.0.9-py3-none-any.whl (78 kB)
Using cached h11-0.16.0-py3-none-any.whl (37 kB)
Using cached mypy_extensions-1.1.0-py3-none-any.whl (5.0 kB)
Using cached packaging-26.2-py3-none-any.whl (100 kB)
Using cached pathspec-1.1.1-py3-none-any.whl (57 kB)
Using cached platformdirs-4.9.6-py3-none-any.whl (21 kB)
Using cached pytest-9.0.3-py3-none-any.whl (375 kB)
Using cached pluggy-1.6.0-py3-none-any.whl (20 kB)
Using cached iniconfig-2.3.0-py3-none-any.whl (7.5 kB)
Using cached pygments-2.20.0-py3-none-any.whl (1.2 MB)
Using cached pytest_asyncio-1.3.0-py3-none-any.whl (15 kB)
Using cached python_dotenv-1.2.2-py3-none-any.whl (22 kB)
Using cached ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.3 MB)
Using cached sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (3.4 MB)
Using cached starlette-1.0.0-py3-none-any.whl (72 kB)
Using cached anyio-4.13.0-py3-none-any.whl (114 kB)
Using cached idna-3.13-py3-none-any.whl (68 kB)
Using cached structlog-25.5.0-py3-none-any.whl (72 kB)
Using cached tenacity-9.1.4-py3-none-any.whl (28 kB)
Using cached typing_extensions-4.15.0-py3-none-any.whl (44 kB)
Using cached typing_inspection-0.4.2-py3-none-any.whl (14 kB)
Using cached uvicorn-0.46.0-py3-none-any.whl (70 kB)
Using cached httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (517 kB)
Using cached pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (807 kB)
Using cached uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (4.4 MB)
Using cached watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (456 kB)
Using cached websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (184 kB)
Using cached certifi-2026.4.22-py3-none-any.whl (135 kB)
Using cached mako-1.3.12-py3-none-any.whl (78 kB)
Using cached markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (22 kB)
Building wheels for collected packages: jeeves
  Building editable for jeeves (pyproject.toml): started
  Building editable for jeeves (pyproject.toml): finished with status 'done'
  Created wheel for jeeves: filename=jeeves-0.1.0-0.editable-py3-none-any.whl size=2892 sha256=4412b1acf7560111bbaf61851b4688f895bb6f9f28e128b331d7f5f1643c23ca
  Stored in directory: /tmp/pip-ephem-wheel-cache-2259k8a9/wheels/8a/25/cf/912a4e3b157b481f23d7bbc6229d680bf53e33c80a4b3b69fb
Successfully built jeeves
Installing collected packages: websockets, uvloop, typing-extensions, tenacity, structlog, ruff, pyyaml, pytokens, python-dotenv, pygments, pluggy, platformdirs, pathspec, packaging, mypy-extensions, MarkupSafe, iniconfig, idna, httptools, h11, greenlet, click, certifi, asyncpg, annotated-types, annotated-doc, aiosqlite, uvicorn, typing-inspection, sqlalchemy, pytest, pydantic-core, Mako, httpcore, black, anyio, watchfiles, starlette, pytest-asyncio, pydantic, httpx, alembic, pydantic-settings, fastapi, jeeves

Successfully installed Mako-1.3.12 MarkupSafe-3.0.3 aiosqlite-0.22.1 alembic-1.18.4 annotated-doc-0.0.4 annotated-types-0.7.0 anyio-4.13.0 asyncpg-0.31.0 black-26.3.1 certifi-2026.4.22 click-8.3.3 fastapi-0.136.1 greenlet-3.5.0 h11-0.16.0 httpcore-1.0.9 httptools-0.7.1 httpx-0.28.1 idna-3.13 iniconfig-2.3.0 jeeves-0.1.0 mypy-extensions-1.1.0 packaging-26.2 pathspec-1.1.1 platformdirs-4.9.6 pluggy-1.6.0 pydantic-2.9.2 pydantic-core-2.23.4 pydantic-settings-2.9.1 pygments-2.20.0 pytest-9.0.3 pytest-asyncio-1.3.0 python-dotenv-1.2.2 pytokens-0.4.1 pyyaml-6.0.3 ruff-0.15.12 sqlalchemy-2.0.49 starlette-1.0.0 structlog-25.5.0 tenacity-9.1.4 typing-extensions-4.15.0 typing-inspection-0.4.2 uvicorn-0.46.0 uvloop-0.22.1 watchfiles-1.1.1 websockets-16.0
........................................................                 [100%]
56 passed in 0.21s
All checks passed!
All done! ✨ 🍰 ✨
50 files would be left unchanged.
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
