### PR TITLE
Externalizer v0 Skeleton core CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["app*"]
+include = ["app*", "tools*"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/skeleton_core/test_classifier.py
+++ b/tests/skeleton_core/test_classifier.py
@@ -1,0 +1,32 @@
+from tools.skeleton_core.classifier import classify_task
+from tools.skeleton_core.models import RiskLevel, TaskPacket
+
+
+def test_docs_task_is_yellow() -> None:
+    packet = TaskPacket(title="Docs note", body="Write a markdown note")
+
+    assert classify_task(packet) == RiskLevel.YELLOW
+
+
+def test_code_task_is_orange() -> None:
+    packet = TaskPacket(title="Implement CLI", body="Add code and tests")
+
+    assert classify_task(packet) == RiskLevel.ORANGE
+
+
+def test_secret_task_is_red() -> None:
+    packet = TaskPacket(title="Use token", body="Read .env and SSH secret")
+
+    assert classify_task(packet) == RiskLevel.RED
+
+
+def test_red_beats_orange_and_yellow() -> None:
+    packet = TaskPacket(title="Deploy CLI docs", body="Use production token")
+
+    assert classify_task(packet) == RiskLevel.RED
+
+
+def test_green_task_has_no_trigger_terms() -> None:
+    packet = TaskPacket(title="Sort queue", body="Classify items by current status")
+
+    assert classify_task(packet) == RiskLevel.GREEN

--- a/tests/skeleton_core/test_cli.py
+++ b/tests/skeleton_core/test_cli.py
@@ -1,0 +1,60 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def test_cli_outputs_decision_json(capsys) -> None:
+    exit_code = main(["--title", "Write docs", "--body", "Add markdown note"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["task"]["title"] == "Write docs"
+    assert payload["risk_level"] == "YELLOW"
+    assert payload["route_target"] == "RUNNER_YELLOW"
+    assert payload["evidence_policy"] == "NONE"
+    assert payload["blocked_reason"] is None
+    assert "required runner report shape" in payload["runner_issue_body"].casefold()
+
+
+def test_cli_preserves_evidence_policy(capsys) -> None:
+    exit_code = main(
+        [
+            "--title",
+            "Review evidence",
+            "--body",
+            "Write docs note",
+            "--evidence-policy",
+            "GEMINI_EVIDENCE_ALLOWED",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["evidence_policy"] == "GEMINI_EVIDENCE_ALLOWED"
+    assert "GEMINI_EVIDENCE_ALLOWED" in payload["runner_issue_body"]
+
+
+def test_cli_blocks_red_task(capsys) -> None:
+    exit_code = main(["--title", "Use token", "--body", "Read production .env"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["risk_level"] == "RED"
+    assert payload["route_target"] == "BLOCKED_RED"
+    assert payload["blocked_reason"] is not None
+    assert "not executable" in payload["runner_issue_body"]
+
+
+def test_cli_returns_2_for_invalid_packet(capsys) -> None:
+    exit_code = main(["--title", "", "--body", "Body"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "string_too_short" in captured.out

--- a/tests/skeleton_core/test_models.py
+++ b/tests/skeleton_core/test_models.py
@@ -3,9 +3,9 @@ from pydantic import ValidationError
 
 from tools.skeleton_core.models import (
     EvidencePolicy,
+    RiskLevel,
     RouteDecision,
     RouteTarget,
-    RiskLevel,
     TaskPacket,
 )
 

--- a/tests/skeleton_core/test_models.py
+++ b/tests/skeleton_core/test_models.py
@@ -1,7 +1,13 @@
 import pytest
 from pydantic import ValidationError
 
-from tools.skeleton_core.models import EvidencePolicy, RouteDecision, RouteTarget, RiskLevel, TaskPacket
+from tools.skeleton_core.models import (
+    EvidencePolicy,
+    RouteDecision,
+    RouteTarget,
+    RiskLevel,
+    TaskPacket,
+)
 
 
 def test_task_packet_defaults() -> None:

--- a/tests/skeleton_core/test_models.py
+++ b/tests/skeleton_core/test_models.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import ValidationError
+
+from tools.skeleton_core.models import EvidencePolicy, RouteDecision, RouteTarget, RiskLevel, TaskPacket
+
+
+def test_task_packet_defaults() -> None:
+    packet = TaskPacket(title="Write docs", body="Write a markdown note")
+
+    assert packet.project == "skeleton"
+    assert packet.requested_by == "oleksii"
+    assert packet.evidence_policy == EvidencePolicy.NONE
+
+
+def test_task_packet_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        TaskPacket(title="Test", body="Body", unexpected="value")
+
+
+def test_task_packet_requires_non_empty_strings() -> None:
+    with pytest.raises(ValidationError):
+        TaskPacket(title="", body="Body")
+
+    with pytest.raises(ValidationError):
+        TaskPacket(title="Title", body="")
+
+
+def test_route_decision_includes_evidence_policy_and_blocked_reason() -> None:
+    decision = RouteDecision(
+        risk_level=RiskLevel.RED,
+        route_target=RouteTarget.BLOCKED_RED,
+        evidence_policy=EvidencePolicy.PRIVATE_EVIDENCE_REQUIRES_REVIEW,
+        blocked_reason="blocked",
+    )
+
+    assert decision.evidence_policy == EvidencePolicy.PRIVATE_EVIDENCE_REQUIRES_REVIEW
+    assert decision.blocked_reason == "blocked"

--- a/tests/skeleton_core/test_router.py
+++ b/tests/skeleton_core/test_router.py
@@ -1,0 +1,45 @@
+from tools.skeleton_core.models import EvidencePolicy, RouteTarget, RiskLevel, TaskPacket
+from tools.skeleton_core.router import route_task
+
+
+def test_green_routes_to_runner_green() -> None:
+    decision = route_task(TaskPacket(title="Sort queue", body="Classify items"))
+
+    assert decision.risk_level == RiskLevel.GREEN
+    assert decision.route_target == RouteTarget.RUNNER_GREEN
+    assert decision.blocked_reason is None
+
+
+def test_yellow_routes_to_runner_yellow() -> None:
+    decision = route_task(TaskPacket(title="Write docs", body="Add README note"))
+
+    assert decision.risk_level == RiskLevel.YELLOW
+    assert decision.route_target == RouteTarget.RUNNER_YELLOW
+
+
+def test_orange_routes_to_runner_orange() -> None:
+    decision = route_task(TaskPacket(title="Implement CLI", body="Add package tests"))
+
+    assert decision.risk_level == RiskLevel.ORANGE
+    assert decision.route_target == RouteTarget.RUNNER_ORANGE
+
+
+def test_red_routes_to_blocked_red_with_reason() -> None:
+    decision = route_task(TaskPacket(title="Deploy with token", body="Use production .env"))
+
+    assert decision.risk_level == RiskLevel.RED
+    assert decision.route_target == RouteTarget.BLOCKED_RED
+    assert decision.blocked_reason is not None
+    assert "non-executable" in decision.blocked_reason
+
+
+def test_evidence_policy_is_preserved() -> None:
+    packet = TaskPacket(
+        title="Review note",
+        body="Write docs",
+        evidence_policy=EvidencePolicy.GEMINI_EVIDENCE_ALLOWED,
+    )
+
+    decision = route_task(packet)
+
+    assert decision.evidence_policy == EvidencePolicy.GEMINI_EVIDENCE_ALLOWED

--- a/tests/skeleton_core/test_router.py
+++ b/tests/skeleton_core/test_router.py
@@ -1,4 +1,4 @@
-from tools.skeleton_core.models import EvidencePolicy, RouteTarget, RiskLevel, TaskPacket
+from tools.skeleton_core.models import EvidencePolicy, RiskLevel, RouteTarget, TaskPacket
 from tools.skeleton_core.router import route_task
 
 

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone tooling namespace for repository-local helpers."""

--- a/tools/skeleton_core/__init__.py
+++ b/tools/skeleton_core/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal ChatGPT Exoskeleton / Skeleton core helpers."""

--- a/tools/skeleton_core/classifier.py
+++ b/tools/skeleton_core/classifier.py
@@ -1,0 +1,56 @@
+"""Risk classification for Skeleton task packets."""
+
+from tools.skeleton_core.models import RiskLevel, TaskPacket
+
+RED_TERMS = (
+    "secret",
+    "token",
+    "password",
+    ".env",
+    "ssh",
+    "oauth",
+    "production",
+    "deploy",
+    "payment",
+    "bank",
+    "health",
+    "private document",
+)
+
+ORANGE_TERMS = (
+    "code",
+    "implement",
+    "test",
+    "cli",
+    "package",
+    "refactor",
+)
+
+YELLOW_TERMS = (
+    "docs",
+    "markdown",
+    "note",
+    "policy",
+    "readme",
+)
+
+
+def _task_text(packet: TaskPacket) -> str:
+    return f"{packet.title}\n{packet.body}".casefold()
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    return any(term.casefold() in text for term in terms)
+
+
+def classify_task(packet: TaskPacket) -> RiskLevel:
+    """Classify a task using conservative priority ordering."""
+    text = _task_text(packet)
+
+    if _contains_any(text, RED_TERMS):
+        return RiskLevel.RED
+    if _contains_any(text, ORANGE_TERMS):
+        return RiskLevel.ORANGE
+    if _contains_any(text, YELLOW_TERMS):
+        return RiskLevel.YELLOW
+    return RiskLevel.GREEN

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -1,0 +1,63 @@
+"""Command line entrypoint for the minimal Skeleton core decision gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from pydantic import ValidationError
+
+from tools.skeleton_core.models import EvidencePolicy, TaskPacket
+from tools.skeleton_core.router import route_task
+from tools.skeleton_core.templates import render_runner_issue
+
+
+def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
+    """Build the JSON-serializable decision payload for a task packet."""
+    decision = route_task(packet)
+    return {
+        "task": packet.model_dump(mode="json"),
+        "risk_level": decision.risk_level.value,
+        "route_target": decision.route_target.value,
+        "evidence_policy": decision.evidence_policy.value,
+        "blocked_reason": decision.blocked_reason,
+        "runner_issue_body": render_runner_issue(packet, decision),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build a Skeleton task decision packet.")
+    parser.add_argument("--title", required=True, help="Task title")
+    parser.add_argument("--body", required=True, help="Task body")
+    parser.add_argument("--project", default="skeleton", help="Project name")
+    parser.add_argument("--requested-by", default="oleksii", help="Requester name")
+    parser.add_argument(
+        "--evidence-policy",
+        choices=[policy.value for policy in EvidencePolicy],
+        default=EvidencePolicy.NONE.value,
+        help="Allowed evidence policy to record without calling external services",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        packet = TaskPacket(
+            title=args.title,
+            body=args.body,
+            project=args.project,
+            requested_by=args.requested_by,
+            evidence_policy=EvidencePolicy(args.evidence_policy),
+        )
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/skeleton_core/models.py
+++ b/tools/skeleton_core/models.py
@@ -1,0 +1,57 @@
+"""Decision models for the ChatGPT Exoskeleton core CLI."""
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RiskLevel(StrEnum):
+    """Skeleton task risk level."""
+
+    GREEN = "GREEN"
+    YELLOW = "YELLOW"
+    ORANGE = "ORANGE"
+    RED = "RED"
+
+
+class RouteTarget(StrEnum):
+    """Execution route selected by the Skeleton gate."""
+
+    CHATGPT_ONLY = "CHATGPT_ONLY"
+    RUNNER_GREEN = "RUNNER_GREEN"
+    RUNNER_YELLOW = "RUNNER_YELLOW"
+    RUNNER_ORANGE = "RUNNER_ORANGE"
+    BLOCKED_RED = "BLOCKED_RED"
+
+
+class EvidencePolicy(StrEnum):
+    """Evidence sources allowed for later review, without calling them in this CLI."""
+
+    NONE = "NONE"
+    MANUAL_EVIDENCE_ALLOWED = "MANUAL_EVIDENCE_ALLOWED"
+    GEMINI_EVIDENCE_ALLOWED = "GEMINI_EVIDENCE_ALLOWED"
+    ANTIGRAVITY_EVIDENCE_ALLOWED = "ANTIGRAVITY_EVIDENCE_ALLOWED"
+    PRIVATE_EVIDENCE_REQUIRES_REVIEW = "PRIVATE_EVIDENCE_REQUIRES_REVIEW"
+
+
+class TaskPacket(BaseModel):
+    """User task normalized into a Skeleton decision packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(..., min_length=1)
+    body: str = Field(..., min_length=1)
+    project: str = Field(default="skeleton", min_length=1)
+    requested_by: str = Field(default="oleksii", min_length=1)
+    evidence_policy: EvidencePolicy = EvidencePolicy.NONE
+
+
+class RouteDecision(BaseModel):
+    """Routing decision for a task packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    risk_level: RiskLevel
+    route_target: RouteTarget
+    evidence_policy: EvidencePolicy
+    blocked_reason: str | None = None

--- a/tools/skeleton_core/router.py
+++ b/tools/skeleton_core/router.py
@@ -1,7 +1,7 @@
 """Route Skeleton task packets to the safest available target."""
 
 from tools.skeleton_core.classifier import classify_task
-from tools.skeleton_core.models import RouteDecision, RouteTarget, RiskLevel, TaskPacket
+from tools.skeleton_core.models import RiskLevel, RouteDecision, RouteTarget, TaskPacket
 
 BLOCKED_RED_REASON = (
     "RED task detected by Skeleton tripwire. It is non-executable until Oleksii gives "

--- a/tools/skeleton_core/router.py
+++ b/tools/skeleton_core/router.py
@@ -1,0 +1,35 @@
+"""Route Skeleton task packets to the safest available target."""
+
+from tools.skeleton_core.classifier import classify_task
+from tools.skeleton_core.models import RouteDecision, RouteTarget, RiskLevel, TaskPacket
+
+BLOCKED_RED_REASON = (
+    "RED task detected by Skeleton tripwire. It is non-executable until Oleksii gives "
+    "explicit narrow approval in a later task."
+)
+
+
+def route_task(packet: TaskPacket) -> RouteDecision:
+    """Create a route decision for a Skeleton task packet."""
+    risk_level = classify_task(packet)
+
+    if risk_level == RiskLevel.RED:
+        return RouteDecision(
+            risk_level=risk_level,
+            route_target=RouteTarget.BLOCKED_RED,
+            evidence_policy=packet.evidence_policy,
+            blocked_reason=BLOCKED_RED_REASON,
+        )
+    if risk_level == RiskLevel.ORANGE:
+        target = RouteTarget.RUNNER_ORANGE
+    elif risk_level == RiskLevel.YELLOW:
+        target = RouteTarget.RUNNER_YELLOW
+    else:
+        target = RouteTarget.RUNNER_GREEN
+
+    return RouteDecision(
+        risk_level=risk_level,
+        route_target=target,
+        evidence_policy=packet.evidence_policy,
+        blocked_reason=None,
+    )

--- a/tools/skeleton_core/templates.py
+++ b/tools/skeleton_core/templates.py
@@ -76,7 +76,8 @@ def render_runner_issue(packet: TaskPacket, decision: RouteDecision) -> str:
         {decision.evidence_policy}
         ```
 
-        Evidence is never canon by default. This task packet records evidence policy only; it does not authorize external service calls.
+        Evidence is never canon by default. This task packet records evidence policy only; it
+        does not authorize external service calls.
 
         ## Original task body
 
@@ -94,7 +95,8 @@ def render_runner_issue(packet: TaskPacket, decision: RouteDecision) -> str:
 
         ## Expected output
 
-        Return a short public-safe runner report. Do not include secrets, private infrastructure details, or raw private material.
+        Return a short public-safe runner report. Do not include secrets, private infrastructure
+        details, or raw private material.
 
         ## Required runner report shape
 

--- a/tools/skeleton_core/templates.py
+++ b/tools/skeleton_core/templates.py
@@ -28,8 +28,7 @@ def render_runner_issue(packet: TaskPacket, decision: RouteDecision) -> str:
     """Render a bounded runner issue body for a Skeleton task."""
     blocked_section = ""
     if decision.route_target == RouteTarget.BLOCKED_RED:
-        blocked_section = dedent(
-            f"""
+        blocked_section = dedent(f"""
             ## Blocked
 
             This task is blocked and not executable.
@@ -39,11 +38,9 @@ def render_runner_issue(packet: TaskPacket, decision: RouteDecision) -> str:
             ```text
             {decision.blocked_reason}
             ```
-            """
-        ).strip()
+            """).strip()
 
-    body = dedent(
-        f"""
+    body = dedent(f"""
         # [skeleton-task] {packet.title}
 
         ## Active project
@@ -103,7 +100,6 @@ def render_runner_issue(packet: TaskPacket, decision: RouteDecision) -> str:
         ```text
         {REQUIRED_RUNNER_REPORT_SHAPE}
         ```
-        """
-    ).strip()
+        """).strip()
 
     return body + "\n"

--- a/tools/skeleton_core/templates.py
+++ b/tools/skeleton_core/templates.py
@@ -1,0 +1,107 @@
+"""Runner issue rendering for Skeleton task packets."""
+
+from textwrap import dedent
+
+from tools.skeleton_core.models import RouteDecision, RouteTarget, TaskPacket
+
+REQUIRED_RUNNER_REPORT_SHAPE = """changed_files
+commands_run
+test_result
+lint_result
+format_result
+diff_summary
+errors_or_blockers
+private_data_seen: yes/no
+runtime_code_touched: yes/no
+external_services_called: yes/no
+next_safe_step"""
+
+SAFETY_BOUNDARIES = """- new code must live outside the Jeeves runtime app package when applicable
+- do not modify Jeeves runtime behavior
+- no Gemini / NotebookLM / Antigravity calls
+- no GitHub / Drive / Gmail / external API calls from the implementation
+- no secrets, .env, OAuth, SSH, deploy, infra, DB migrations, or production access
+- no private infrastructure details in reports"""
+
+
+def render_runner_issue(packet: TaskPacket, decision: RouteDecision) -> str:
+    """Render a bounded runner issue body for a Skeleton task."""
+    blocked_section = ""
+    if decision.route_target == RouteTarget.BLOCKED_RED:
+        blocked_section = dedent(
+            f"""
+            ## Blocked
+
+            This task is blocked and not executable.
+
+            Reason:
+
+            ```text
+            {decision.blocked_reason}
+            ```
+            """
+        ).strip()
+
+    body = dedent(
+        f"""
+        # [skeleton-task] {packet.title}
+
+        ## Active project
+
+        ```text
+        СК / ChatGPT Exoskeleton
+        ```
+
+        ## Project
+
+        ```text
+        {packet.project}
+        ```
+
+        ## Risk level
+
+        ```text
+        {decision.risk_level}
+        ```
+
+        ## Route target
+
+        ```text
+        {decision.route_target}
+        ```
+
+        ## Evidence policy
+
+        ```text
+        {decision.evidence_policy}
+        ```
+
+        Evidence is never canon by default. This task packet records evidence policy only; it does not authorize external service calls.
+
+        ## Original task body
+
+        ```text
+        {packet.body}
+        ```
+
+        {blocked_section}
+
+        ## Safety boundaries
+
+        ```text
+        {SAFETY_BOUNDARIES}
+        ```
+
+        ## Expected output
+
+        Return a short public-safe runner report. Do not include secrets, private infrastructure details, or raw private material.
+
+        ## Required runner report shape
+
+        ```text
+        {REQUIRED_RUNNER_REPORT_SHAPE}
+        ```
+        """
+    ).strip()
+
+    return body + "\n"


### PR DESCRIPTION
## Summary

Implements the first Externalizer v0 slice for the ChatGPT Exoskeleton / Skeleton:

```text
TaskPacket -> RiskLevel -> RouteDecision -> runner_issue_body
```

This is a standalone Skeleton tool package outside the Jeeves runtime app package.

## Validation result

Runner / Hetzner validation reported by Oleksii on 2026-05-05:

```text
python -m pytest -q
74 passed in 0.21s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 10 files would be left unchanged.

git status --short
clean
```

## Safety confirmations

```text
No Gemini API calls.
No NotebookLM API calls.
No Antigravity operation.
No GitHub / Drive / Gmail / external API calls from the implementation.
No secrets, .env, OAuth, SSH, deploy, infra, DB migrations, or production access.
No intended Jeeves runtime behavior changes.
New code lives under tools/skeleton_core, not app/.
```

## Notes

Supersedes draft PR #28 because the GitHub connector failed to mark the draft PR as ready for review.

Implements #26 first slice.