### PR TITLE
Externalizer v0 offline GitHub queue adapter

### DIFF
--- a/tests/fixtures/github_queue_sample.json
+++ b/tests/fixtures/github_queue_sample.json
@@ -1,0 +1,48 @@
+[
+  {
+    "kind": "issue",
+    "number": 101,
+    "title": "Implement Skeleton runner contour task packet",
+    "body": "Add TaskPacket and RouteDecision support for ChatGPT Exoskeleton.",
+    "labels": ["skeleton", "agent:task"],
+    "state": "open",
+    "risk_level": "ORANGE",
+    "route_target": "RUNNER_ORANGE",
+    "evidence_policy": "NONE",
+    "source_repo": "alanua/jeeves",
+    "url": "https://example.invalid/issue/101"
+  },
+  {
+    "kind": "issue",
+    "number": 102,
+    "title": "Refactor FastAPI /ask orchestrator",
+    "body": "Change app/api and app/orchestration runtime behavior.",
+    "labels": ["runtime"],
+    "state": "open",
+    "source_repo": "alanua/jeeves",
+    "url": "https://example.invalid/issue/102"
+  },
+  {
+    "kind": "issue",
+    "number": 103,
+    "title": "Gemini audit notes",
+    "body": "Manual external auditor evidence only from Gemini and Antigravity sandbox workbench.",
+    "labels": ["evidence"],
+    "state": "open",
+    "source_repo": "alanua/jeeves",
+    "url": "https://example.invalid/issue/103"
+  },
+  {
+    "kind": "issue",
+    "number": 104,
+    "title": "Production token deployment task",
+    "body": "Blocked waiting for Oleksii approval.",
+    "labels": ["risk:red"],
+    "state": "open",
+    "risk_level": "RED",
+    "route_target": "BLOCKED_RED",
+    "blocked_reason": "RED task detected by Skeleton tripwire.",
+    "source_repo": "alanua/jeeves",
+    "url": "https://example.invalid/issue/104"
+  }
+]

--- a/tests/skeleton_core/test_github_queue.py
+++ b/tests/skeleton_core/test_github_queue.py
@@ -1,0 +1,135 @@
+import json
+from pathlib import Path
+
+from tools.skeleton_core.github_queue import (
+    QueueClassification,
+    QueueItemKind,
+    QueueItemState,
+    classify_queue_item,
+    normalize_issue,
+    normalize_pr,
+    summarize_queue,
+)
+
+FIXTURE_PATH = Path("tests/fixtures/github_queue_sample.json")
+
+
+def test_normalize_issue_preserves_public_safe_metadata() -> None:
+    raw = {
+        "number": 27,
+        "title": "Implement Skeleton github_queue offline adapter",
+        "body": "Preserve EvidencePolicy and blocked_reason.",
+        "labels": [{"name": "skeleton"}],
+        "state": "open",
+        "risk_level": "ORANGE",
+        "route_target": "RUNNER_ORANGE",
+        "evidence_policy": "NONE",
+        "source_repo": "alanua/jeeves",
+        "url": "https://example.invalid/issue/27",
+    }
+
+    item = normalize_issue(raw)
+
+    assert item.number_or_id == "27"
+    assert item.title == "Implement Skeleton github_queue offline adapter"
+    assert item.labels == ["skeleton"]
+    assert item.state == QueueItemState.OPEN
+    assert item.kind == QueueItemKind.ISSUE
+    assert item.evidence_policy == "NONE"
+
+
+def test_normalize_pr_detects_draft_state() -> None:
+    item = normalize_pr(
+        {
+            "number": 28,
+            "title": "Draft Skeleton PR",
+            "body": "Draft PR body",
+            "draft": True,
+            "state": "open",
+        }
+    )
+
+    assert item.kind == QueueItemKind.PR
+    assert item.state == QueueItemState.DRAFT
+
+
+def test_active_skeleton_item_classifies_active() -> None:
+    item = normalize_issue(
+        {
+            "title": "Implement Skeleton runner contour",
+            "body": "Add TaskPacket and RouteDecision support.",
+            "labels": ["skeleton"],
+            "state": "open",
+        }
+    )
+
+    assert classify_queue_item(item) == QueueClassification.ACTIVE_SKELETON
+
+
+def test_runtime_item_classifies_noise() -> None:
+    item = normalize_issue(
+        {
+            "title": "Refactor FastAPI /ask orchestrator",
+            "body": "Change app/api and app/orchestration runtime behavior.",
+            "labels": ["runtime"],
+            "state": "open",
+        }
+    )
+
+    assert classify_queue_item(item) == QueueClassification.JEEVES_RUNTIME_NOISE_FOR_NOW
+
+
+def test_evidence_item_classifies_evidence_only() -> None:
+    item = normalize_issue(
+        {
+            "title": "Gemini audit notes",
+            "body": "Manual external auditor evidence only from Antigravity sandbox workbench.",
+            "labels": ["evidence"],
+            "state": "open",
+        }
+    )
+
+    assert classify_queue_item(item) == QueueClassification.EVIDENCE_ONLY
+
+
+def test_blocked_item_classifies_waiting_for_oleksii() -> None:
+    item = normalize_issue(
+        {
+            "title": "Production token task",
+            "body": "Blocked waiting for Oleksii approval.",
+            "labels": ["risk:red"],
+            "state": "open",
+            "risk_level": "RED",
+            "route_target": "BLOCKED_RED",
+            "blocked_reason": "RED tripwire",
+        }
+    )
+
+    assert classify_queue_item(item) == QueueClassification.BLOCKED_WAITING_FOR_OLEKSII
+
+
+def test_superseded_item_classifies_duplicate_or_superseded() -> None:
+    item = normalize_issue(
+        {
+            "title": "Draft PR superseded",
+            "body": "Superseded by non-draft PR.",
+            "labels": ["skeleton"],
+            "state": "closed",
+        }
+    )
+
+    assert classify_queue_item(item) == QueueClassification.DUPLICATE_OR_SUPERSEDED
+
+
+def test_fixture_summary_counts() -> None:
+    raw_items = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    items = [normalize_issue(raw) for raw in raw_items]
+
+    summary = summarize_queue(items)
+
+    assert summary[QueueClassification.ACTIVE_SKELETON] == 1
+    assert summary[QueueClassification.JEEVES_RUNTIME_NOISE_FOR_NOW] == 1
+    assert summary[QueueClassification.EVIDENCE_ONLY] == 1
+    assert summary[QueueClassification.BLOCKED_WAITING_FOR_OLEKSII] == 1
+    assert summary[QueueClassification.DUPLICATE_OR_SUPERSEDED] == 0
+    assert summary[QueueClassification.UNKNOWN_NEEDS_REVIEW] == 0

--- a/tools/skeleton_core/github_queue.py
+++ b/tools/skeleton_core/github_queue.py
@@ -1,0 +1,221 @@
+"""Offline GitHub queue normalization and classification for Skeleton work."""
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class QueueItemKind(StrEnum):
+    """Supported queue item kinds."""
+
+    ISSUE = "ISSUE"
+    PR = "PR"
+    REPORT = "REPORT"
+
+
+class QueueItemState(StrEnum):
+    """Normalized queue item state."""
+
+    OPEN = "OPEN"
+    CLOSED = "CLOSED"
+    MERGED = "MERGED"
+    DRAFT = "DRAFT"
+    UNKNOWN = "UNKNOWN"
+
+
+class QueueClassification(StrEnum):
+    """Skeleton queue classification labels."""
+
+    ACTIVE_SKELETON = "ACTIVE_SKELETON"
+    JEEVES_RUNTIME_NOISE_FOR_NOW = "JEEVES_RUNTIME_NOISE_FOR_NOW"
+    EVIDENCE_ONLY = "EVIDENCE_ONLY"
+    DUPLICATE_OR_SUPERSEDED = "DUPLICATE_OR_SUPERSEDED"
+    BLOCKED_WAITING_FOR_OLEKSII = "BLOCKED_WAITING_FOR_OLEKSII"
+    UNKNOWN_NEEDS_REVIEW = "UNKNOWN_NEEDS_REVIEW"
+
+
+class QueueItem(BaseModel):
+    """Public-safe normalized GitHub queue item."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    number_or_id: str | None = None
+    title: str = ""
+    body_or_summary: str = ""
+    labels: list[str] = Field(default_factory=list)
+    state: QueueItemState = QueueItemState.UNKNOWN
+    kind: QueueItemKind
+    risk_level: str | None = None
+    route_target: str | None = None
+    evidence_policy: str | None = None
+    blocked_reason: str | None = None
+    source_repo: str | None = None
+    url: str | None = None
+
+
+SKELETON_TERMS = (
+    "skeleton",
+    "exoskeleton",
+    "ск",
+    "chatgpt exoskeleton",
+    "runner contour",
+    "handoff",
+    "memory layer",
+    "skeleton_core",
+    "evidencepolicy",
+    "routedecision",
+    "taskpacket",
+)
+
+EVIDENCE_TERMS = (
+    "gemini",
+    "gemini audit",
+    "notebooklm",
+    "gemini notebooks",
+    "antigravity",
+    "manual external auditor",
+    "evidence only",
+    "sandbox workbench",
+)
+
+RUNTIME_TERMS = (
+    "fastapi",
+    "/ask",
+    "orchestrator",
+    "llm router",
+    "database migration",
+    "app/api",
+    "app/orchestration",
+    "runtime",
+    "jeeves runtime",
+)
+
+BLOCKED_TERMS = (
+    "waiting for oleksii approval",
+    "blocked waiting for oleksii",
+    "blocked_red",
+    "blocked red",
+)
+
+SUPERSEDED_TERMS = (
+    "superseded",
+    "duplicate",
+    "replaced by",
+)
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _labels(raw: dict[str, Any]) -> list[str]:
+    labels = raw.get("labels") or []
+    normalized: list[str] = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = label.get("name")
+        else:
+            name = label
+        if name:
+            normalized.append(str(name))
+    return normalized
+
+
+def _state(raw: dict[str, Any], *, is_pr: bool = False) -> QueueItemState:
+    if raw.get("merged") is True or raw.get("merged_at"):
+        return QueueItemState.MERGED
+    if is_pr and raw.get("draft") is True:
+        return QueueItemState.DRAFT
+
+    state = _as_text(raw.get("state")).casefold()
+    if state == "open":
+        return QueueItemState.OPEN
+    if state == "closed":
+        return QueueItemState.CLOSED
+    return QueueItemState.UNKNOWN
+
+
+def _joined(item: QueueItem) -> str:
+    return "\n".join(
+        [
+            item.title,
+            item.body_or_summary,
+            " ".join(item.labels),
+            _as_text(item.risk_level),
+            _as_text(item.route_target),
+            _as_text(item.evidence_policy),
+            _as_text(item.blocked_reason),
+        ]
+    ).casefold()
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    return any(term in text for term in terms)
+
+
+def normalize_issue(raw: dict[str, Any]) -> QueueItem:
+    """Normalize public-safe issue metadata from a dict or fixture."""
+    return QueueItem(
+        number_or_id=_as_text(raw.get("number") or raw.get("id")) or None,
+        title=_as_text(raw.get("title")),
+        body_or_summary=_as_text(raw.get("body") or raw.get("summary")),
+        labels=_labels(raw),
+        state=_state(raw),
+        kind=QueueItemKind.ISSUE,
+        risk_level=raw.get("risk_level"),
+        route_target=raw.get("route_target"),
+        evidence_policy=raw.get("evidence_policy"),
+        blocked_reason=raw.get("blocked_reason"),
+        source_repo=raw.get("source_repo") or raw.get("repo"),
+        url=raw.get("url") or raw.get("html_url"),
+    )
+
+
+def normalize_pr(raw: dict[str, Any]) -> QueueItem:
+    """Normalize public-safe pull request metadata from a dict or fixture."""
+    return QueueItem(
+        number_or_id=_as_text(raw.get("number") or raw.get("id")) or None,
+        title=_as_text(raw.get("title")),
+        body_or_summary=_as_text(raw.get("body") or raw.get("summary")),
+        labels=_labels(raw),
+        state=_state(raw, is_pr=True),
+        kind=QueueItemKind.PR,
+        risk_level=raw.get("risk_level"),
+        route_target=raw.get("route_target"),
+        evidence_policy=raw.get("evidence_policy"),
+        blocked_reason=raw.get("blocked_reason"),
+        source_repo=raw.get("source_repo") or raw.get("repo"),
+        url=raw.get("url") or raw.get("html_url"),
+    )
+
+
+def classify_queue_item(item: QueueItem) -> QueueClassification:
+    """Classify one queue item without network or live GitHub access."""
+    text = _joined(item)
+
+    if _contains_any(text, SUPERSEDED_TERMS):
+        return QueueClassification.DUPLICATE_OR_SUPERSEDED
+    if item.route_target == "BLOCKED_RED" or item.risk_level == "RED" or item.blocked_reason:
+        return QueueClassification.BLOCKED_WAITING_FOR_OLEKSII
+    if _contains_any(text, BLOCKED_TERMS):
+        return QueueClassification.BLOCKED_WAITING_FOR_OLEKSII
+    if _contains_any(text, RUNTIME_TERMS):
+        return QueueClassification.JEEVES_RUNTIME_NOISE_FOR_NOW
+    if _contains_any(text, EVIDENCE_TERMS) and not _contains_any(text, SKELETON_TERMS):
+        return QueueClassification.EVIDENCE_ONLY
+    if _contains_any(text, SKELETON_TERMS):
+        return QueueClassification.ACTIVE_SKELETON
+    if _contains_any(text, EVIDENCE_TERMS):
+        return QueueClassification.EVIDENCE_ONLY
+    return QueueClassification.UNKNOWN_NEEDS_REVIEW
+
+
+def summarize_queue(items: list[QueueItem]) -> dict[str, int]:
+    """Count queue items by Skeleton classification."""
+    counts = {classification.value: 0 for classification in QueueClassification}
+    for item in items:
+        counts[classify_queue_item(item).value] += 1
+    return counts

--- a/tools/skeleton_core/github_queue.py
+++ b/tools/skeleton_core/github_queue.py
@@ -115,10 +115,7 @@ def _labels(raw: dict[str, Any]) -> list[str]:
     labels = raw.get("labels") or []
     normalized: list[str] = []
     for label in labels:
-        if isinstance(label, dict):
-            name = label.get("name")
-        else:
-            name = label
+        name = label.get("name") if isinstance(label, dict) else label
         if name:
             normalized.append(str(name))
     return normalized


### PR DESCRIPTION
## Summary

Implements the next Externalizer v0 slice for the ChatGPT Exoskeleton / Skeleton:

```text
offline GitHub queue metadata -> QueueItem -> QueueClassification -> summary counts
```

This is local/offline only. It does not call GitHub API or any external service.

## Validation result

Runner / Hetzner validation reported by Oleksii on 2026-05-05:

```text
python -m pytest -q
82 passed in 0.27s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 12 files would be left unchanged.

python -m pytest tests/skeleton_core/test_github_queue.py -q
8 passed in 0.01s

git status --short
clean
```

## Safety confirmations

```text
No live GitHub API calls.
No network calls.
No Gemini API calls.
No NotebookLM API calls.
No Antigravity operation.
No Drive/Gmail access.
No secrets, .env, OAuth, SSH, deploy, infra, DB migrations, or production access.
No intended Jeeves runtime behavior changes.
New code lives under tools/skeleton_core, not app/.
Gemini/NotebookLM/Antigravity references remain EVIDENCE_ONLY unless explicitly converted into a reviewed Skeleton task.
```

## Notes

Supersedes draft PR #30 because the GitHub connector cannot reliably mark draft PRs as ready for review.

Implements #27 first slice.