### PR TITLE
Externalizer v0 queue-summary CLI

### DIFF
--- a/tests/skeleton_core/test_cli.py
+++ b/tests/skeleton_core/test_cli.py
@@ -18,6 +18,18 @@ def test_cli_outputs_decision_json(capsys) -> None:
     assert "required runner report shape" in payload["runner_issue_body"].casefold()
 
 
+def test_cli_outputs_decision_json_with_subcommand(capsys) -> None:
+    exit_code = main(["decide", "--title", "Write docs", "--body", "Add markdown note"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["task"]["title"] == "Write docs"
+    assert payload["risk_level"] == "YELLOW"
+    assert payload["route_target"] == "RUNNER_YELLOW"
+
+
 def test_cli_preserves_evidence_policy(capsys) -> None:
     exit_code = main(
         [
@@ -49,6 +61,20 @@ def test_cli_blocks_red_task(capsys) -> None:
     assert payload["route_target"] == "BLOCKED_RED"
     assert payload["blocked_reason"] is not None
     assert "not executable" in payload["runner_issue_body"]
+
+
+def test_cli_queue_summary(capsys) -> None:
+    exit_code = main(["queue-summary", "--input", "tests/fixtures/github_queue_sample.json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["ACTIVE_SKELETON"] == 1
+    assert payload["JEEVES_RUNTIME_NOISE_FOR_NOW"] == 1
+    assert payload["EVIDENCE_ONLY"] == 1
+    assert payload["BLOCKED_WAITING_FOR_OLEKSII"] == 1
+    assert payload["UNKNOWN_NEEDS_REVIEW"] == 0
 
 
 def test_cli_returns_2_for_invalid_packet(capsys) -> None:

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,8 @@ from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summ
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.templates import render_runner_issue
+
+SUBCOMMANDS = {"decide", "queue-summary"}
 
 
 def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
@@ -54,18 +57,32 @@ def _add_decide_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def _subcommand_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Skeleton Externalizer v0 CLI.")
-    subparsers = parser.add_subparsers(dest="command")
+    subparsers = parser.add_subparsers(dest="command", required=True)
 
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
 
     queue_parser = subparsers.add_parser("queue-summary", help="Summarize an offline queue JSON file")
     queue_parser.add_argument("--input", required=True, type=Path, help="Path to public-safe queue JSON")
+    return parser
 
+
+def _legacy_decide_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a Skeleton task decision packet.")
     _add_decide_args(parser)
-    return parser.parse_args(argv)
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    effective_argv = sys.argv[1:] if argv is None else argv
+    if effective_argv and effective_argv[0] in SUBCOMMANDS:
+        return _subcommand_parser().parse_args(effective_argv)
+
+    args = _legacy_decide_parser().parse_args(effective_argv)
+    args.command = "decide"
+    return args
 
 
 def _run_decide(args: argparse.Namespace) -> int:

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -64,8 +64,16 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
 
-    queue_parser = subparsers.add_parser("queue-summary", help="Summarize an offline queue JSON file")
-    queue_parser.add_argument("--input", required=True, type=Path, help="Path to public-safe queue JSON")
+    queue_parser = subparsers.add_parser(
+        "queue-summary",
+        help="Summarize an offline queue JSON file",
+    )
+    queue_parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to public-safe queue JSON",
+    )
     return parser
 
 

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -111,7 +111,10 @@ def _run_decide(args: argparse.Namespace) -> int:
 
 
 def _run_queue_summary(args: argparse.Namespace) -> int:
-    print(json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2), flush=True)
+    print(
+        json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2),
+        flush=True,
+    )
     return 0
 
 

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationError
 
+from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.templates import render_runner_issue
@@ -26,8 +28,20 @@ def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
     }
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Build a Skeleton task decision packet.")
+def build_queue_summary_payload(input_path: Path) -> dict[str, int]:
+    """Build summary counts from an offline public-safe queue fixture."""
+    raw_items = json.loads(input_path.read_text(encoding="utf-8"))
+    items = []
+    for raw in raw_items:
+        kind = str(raw.get("kind", "issue")).casefold()
+        if kind == "pr":
+            items.append(normalize_pr(raw))
+        else:
+            items.append(normalize_issue(raw))
+    return summarize_queue(items)
+
+
+def _add_decide_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--title", required=True, help="Task title")
     parser.add_argument("--body", required=True, help="Task body")
     parser.add_argument("--project", default="skeleton", help="Project name")
@@ -38,11 +52,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=EvidencePolicy.NONE.value,
         help="Allowed evidence policy to record without calling external services",
     )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Skeleton Externalizer v0 CLI.")
+    subparsers = parser.add_subparsers(dest="command")
+
+    decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
+    _add_decide_args(decide_parser)
+
+    queue_parser = subparsers.add_parser("queue-summary", help="Summarize an offline queue JSON file")
+    queue_parser.add_argument("--input", required=True, type=Path, help="Path to public-safe queue JSON")
+
+    _add_decide_args(parser)
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
+def _run_decide(args: argparse.Namespace) -> int:
     try:
         packet = TaskPacket(
             title=args.title,
@@ -57,6 +83,18 @@ def main(argv: list[str] | None = None) -> int:
 
     print(json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2), flush=True)
     return 0
+
+
+def _run_queue_summary(args: argparse.Namespace) -> int:
+    print(json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command == "queue-summary":
+        return _run_queue_summary(args)
+    return _run_decide(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a direct CLI command for the already-merged offline queue adapter:

```bash
python -m tools.skeleton_core.cli queue-summary --input tests/fixtures/github_queue_sample.json
```

This removes the need for Python heredoc usage during daily Skeleton checks.

## Changed files

```text
tools/skeleton_core/cli.py
tests/skeleton_core/test_cli.py
```

## Behavior

Existing decision-gate usage remains compatible:

```bash
python -m tools.skeleton_core.cli --title "Write docs" --body "Add markdown note"
python -m tools.skeleton_core.cli decide --title "Write docs" --body "Add markdown note"
```

New queue summary usage:

```bash
python -m tools.skeleton_core.cli queue-summary --input tests/fixtures/github_queue_sample.json
```

## Validation result

Runner validation reported by Oleksii on 2026-05-05:

```text
python -m pytest -q
84 passed in 0.23s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 12 files would be left unchanged.

queue-summary output matched the expected classification counts.

git status --short
clean
```

## Safety note

Local Skeleton CLI/test-only change. No runtime behavior changes.