### PR TITLE
Externalizer v0 trace packet CLI

### DIFF
--- a/tests/skeleton_core/test_cli.py
+++ b/tests/skeleton_core/test_cli.py
@@ -77,6 +77,49 @@ def test_cli_queue_summary(capsys) -> None:
     assert payload["UNKNOWN_NEEDS_REVIEW"] == 0
 
 
+def test_cli_trace_packet(capsys) -> None:
+    exit_code = main(
+        [
+            "trace-packet",
+            "--task-id",
+            "manual-001",
+            "--project",
+            "skeleton",
+            "--risk-level",
+            "YELLOW",
+            "--route-target",
+            "RUNNER_YELLOW",
+            "--result",
+            "completed",
+            "--next-safe-step",
+            "review",
+            "--sources-read",
+            "issue #33,CURRENT_STATE.md",
+            "--files-changed",
+            "tools/skeleton_core/trace.py",
+            "--commands-run",
+            "python -m pytest -q",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["task_id"] == "manual-001"
+    assert payload["project"] == "skeleton"
+    assert payload["risk_level"] == "YELLOW"
+    assert payload["route_target"] == "RUNNER_YELLOW"
+    assert payload["result"] == "completed"
+    assert payload["next_safe_step"] == "review"
+    assert payload["sources_read"] == ["issue #33", "CURRENT_STATE.md"]
+    assert payload["files_changed"] == ["tools/skeleton_core/trace.py"]
+    assert payload["commands_run"] == ["python -m pytest -q"]
+    assert payload["private_data_seen"] is False
+    assert payload["runtime_code_touched"] is False
+    assert payload["external_services_called"] is False
+
+
 def test_cli_returns_2_for_invalid_packet(capsys) -> None:
     exit_code = main(["--title", "", "--body", "Body"])
 

--- a/tests/skeleton_core/test_trace.py
+++ b/tests/skeleton_core/test_trace.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import ValidationError
+
+from tools.skeleton_core.trace import TracePacket
+
+
+def test_trace_packet_defaults_are_public_safe() -> None:
+    packet = TracePacket(
+        task_id="manual-001",
+        risk_level="YELLOW",
+        route_target="RUNNER_YELLOW",
+        result="completed",
+        next_safe_step="review",
+    )
+
+    assert packet.project == "skeleton"
+    assert packet.sources_read == []
+    assert packet.files_changed == []
+    assert packet.commands_run == []
+    assert packet.blocked_reason is None
+    assert packet.private_data_seen is False
+    assert packet.runtime_code_touched is False
+    assert packet.external_services_called is False
+
+
+def test_trace_packet_accepts_public_safe_lists() -> None:
+    packet = TracePacket(
+        task_id="manual-002",
+        project="skeleton",
+        risk_level="ORANGE",
+        route_target="RUNNER_ORANGE",
+        result="completed",
+        next_safe_step="merge",
+        sources_read=["issue #33"],
+        files_changed=["tools/skeleton_core/trace.py"],
+        commands_run=["python -m pytest -q"],
+    )
+
+    assert packet.sources_read == ["issue #33"]
+    assert packet.files_changed == ["tools/skeleton_core/trace.py"]
+    assert packet.commands_run == ["python -m pytest -q"]
+
+
+def test_trace_packet_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        TracePacket(
+            task_id="manual-003",
+            risk_level="YELLOW",
+            route_target="RUNNER_YELLOW",
+            result="completed",
+            next_safe_step="review",
+            unexpected="value",
+        )
+
+
+def test_trace_packet_rejects_empty_required_fields() -> None:
+    required_kwargs = {
+        "task_id": "manual-004",
+        "risk_level": "YELLOW",
+        "route_target": "RUNNER_YELLOW",
+        "result": "completed",
+        "next_safe_step": "review",
+    }
+
+    for field_name in required_kwargs:
+        kwargs = required_kwargs.copy()
+        kwargs[field_name] = ""
+        with pytest.raises(ValidationError):
+            TracePacket(**kwargs)

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -76,11 +76,19 @@ def _add_trace_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--route-target", required=True, help="Route target")
     parser.add_argument("--result", required=True, help="Result status")
     parser.add_argument("--next-safe-step", required=True, help="Next safe step")
-    parser.add_argument("--sources-read", default="", help="Comma-separated public-safe sources read")
+    parser.add_argument(
+        "--sources-read",
+        default="",
+        help="Comma-separated public-safe sources read",
+    )
     parser.add_argument("--files-changed", default="", help="Comma-separated files changed")
     parser.add_argument("--commands-run", default="", help="Comma-separated commands run")
     parser.add_argument("--blocked-reason", default=None, help="Optional blocked reason")
-    parser.add_argument("--private-data-seen", action="store_true", help="Mark private data as seen")
+    parser.add_argument(
+        "--private-data-seen",
+        action="store_true",
+        help="Mark private data as seen",
+    )
     parser.add_argument(
         "--runtime-code-touched",
         action="store_true",

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -14,8 +14,9 @@ from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summ
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.templates import render_runner_issue
+from tools.skeleton_core.trace import TracePacket
 
-SUBCOMMANDS = {"decide", "queue-summary"}
+SUBCOMMANDS = {"decide", "queue-summary", "trace-packet"}
 
 
 def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
@@ -44,6 +45,17 @@ def build_queue_summary_payload(input_path: Path) -> dict[str, int]:
     return summarize_queue(items)
 
 
+def build_trace_packet_payload(packet: TracePacket) -> dict[str, Any]:
+    """Build the JSON-serializable trace packet payload."""
+    return packet.model_dump(mode="json")
+
+
+def _split_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
 def _add_decide_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--title", required=True, help="Task title")
     parser.add_argument("--body", required=True, help="Task body")
@@ -54,6 +66,26 @@ def _add_decide_args(parser: argparse.ArgumentParser) -> None:
         choices=[policy.value for policy in EvidencePolicy],
         default=EvidencePolicy.NONE.value,
         help="Allowed evidence policy to record without calling external services",
+    )
+
+
+def _add_trace_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--task-id", required=True, help="Trace task id")
+    parser.add_argument("--project", default="skeleton", help="Project name")
+    parser.add_argument("--risk-level", required=True, help="Risk level")
+    parser.add_argument("--route-target", required=True, help="Route target")
+    parser.add_argument("--result", required=True, help="Result status")
+    parser.add_argument("--next-safe-step", required=True, help="Next safe step")
+    parser.add_argument("--sources-read", default="", help="Comma-separated public-safe sources read")
+    parser.add_argument("--files-changed", default="", help="Comma-separated files changed")
+    parser.add_argument("--commands-run", default="", help="Comma-separated commands run")
+    parser.add_argument("--blocked-reason", default=None, help="Optional blocked reason")
+    parser.add_argument("--private-data-seen", action="store_true", help="Mark private data as seen")
+    parser.add_argument("--runtime-code-touched", action="store_true", help="Mark runtime code as touched")
+    parser.add_argument(
+        "--external-services-called",
+        action="store_true",
+        help="Mark external services as called",
     )
 
 
@@ -74,6 +106,9 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Path to public-safe queue JSON",
     )
+
+    trace_parser = subparsers.add_parser("trace-packet", help="Build a Skeleton trace packet")
+    _add_trace_args(trace_parser)
     return parser
 
 
@@ -118,10 +153,37 @@ def _run_queue_summary(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_trace_packet(args: argparse.Namespace) -> int:
+    try:
+        packet = TracePacket(
+            task_id=args.task_id,
+            project=args.project,
+            risk_level=args.risk_level,
+            route_target=args.route_target,
+            result=args.result,
+            next_safe_step=args.next_safe_step,
+            sources_read=_split_csv(args.sources_read),
+            files_changed=_split_csv(args.files_changed),
+            commands_run=_split_csv(args.commands_run),
+            blocked_reason=args.blocked_reason,
+            private_data_seen=args.private_data_seen,
+            runtime_code_touched=args.runtime_code_touched,
+            external_services_called=args.external_services_called,
+        )
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(json.dumps(build_trace_packet_payload(packet), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.command == "queue-summary":
         return _run_queue_summary(args)
+    if args.command == "trace-packet":
+        return _run_trace_packet(args)
     return _run_decide(args)
 
 

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -81,7 +81,11 @@ def _add_trace_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--commands-run", default="", help="Comma-separated commands run")
     parser.add_argument("--blocked-reason", default=None, help="Optional blocked reason")
     parser.add_argument("--private-data-seen", action="store_true", help="Mark private data as seen")
-    parser.add_argument("--runtime-code-touched", action="store_true", help="Mark runtime code as touched")
+    parser.add_argument(
+        "--runtime-code-touched",
+        action="store_true",
+        help="Mark runtime code as touched",
+    )
     parser.add_argument(
         "--external-services-called",
         action="store_true",
@@ -174,7 +178,10 @@ def _run_trace_packet(args: argparse.Namespace) -> int:
         print(exc.json(), flush=True)
         return 2
 
-    print(json.dumps(build_trace_packet_payload(packet), ensure_ascii=False, indent=2), flush=True)
+    print(
+        json.dumps(build_trace_packet_payload(packet), ensure_ascii=False, indent=2),
+        flush=True,
+    )
     return 0
 
 

--- a/tools/skeleton_core/trace.py
+++ b/tools/skeleton_core/trace.py
@@ -1,0 +1,23 @@
+"""Public-safe trace packet model for Skeleton actions."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TracePacket(BaseModel):
+    """Small machine-readable trace/checkpoint packet for Skeleton work."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str = Field(..., min_length=1)
+    risk_level: str = Field(..., min_length=1)
+    route_target: str = Field(..., min_length=1)
+    result: str = Field(..., min_length=1)
+    next_safe_step: str = Field(..., min_length=1)
+    project: str = Field(default="skeleton", min_length=1)
+    sources_read: list[str] = Field(default_factory=list)
+    files_changed: list[str] = Field(default_factory=list)
+    commands_run: list[str] = Field(default_factory=list)
+    blocked_reason: str | None = None
+    private_data_seen: bool = False
+    runtime_code_touched: bool = False
+    external_services_called: bool = False


### PR DESCRIPTION
## Summary

Adds a minimal local trace/checkpoint packet command for Skeleton actions:

```bash
python -m tools.skeleton_core.cli trace-packet --task-id "manual-001" --project skeleton --risk-level YELLOW --route-target RUNNER_YELLOW --result completed --next-safe-step review
```

## Changed files

```text
tools/skeleton_core/trace.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_trace.py
tests/skeleton_core/test_cli.py
```

## Behavior

Creates a public-safe JSON packet with:

```text
task_id
project
risk_level
route_target
result
next_safe_step
sources_read
files_changed
commands_run
blocked_reason
private_data_seen
runtime_code_touched
external_services_called
```

## Validation result

Runner validation reported by Oleksii on 2026-05-05:

```text
python -m pytest -q
89 passed in 0.23s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 14 files would be left unchanged.

trace-packet CLI emitted the expected public-safe JSON.

git status --short
clean
```

## Safety note

Local Skeleton CLI/model/test-only change. No runtime behavior changes.

## Related issue

Implements #33.