### PR TITLE
Externalizer v0 runner-report-from-trace CLI

### DIFF
--- a/tests/fixtures/trace_packet_sample.json
+++ b/tests/fixtures/trace_packet_sample.json
@@ -1,0 +1,19 @@
+{
+  "task_id": "issue-35",
+  "project": "skeleton",
+  "risk_level": "ORANGE",
+  "route_target": "RUNNER_ORANGE",
+  "result": "merged",
+  "next_safe_step": "use task-from-text for new Skeleton intake",
+  "sources_read": ["issue #35", "PR #36"],
+  "files_changed": ["tools/skeleton_core/cli.py", "tests/skeleton_core/test_cli.py"],
+  "commands_run": [
+    "python -m pytest -q",
+    "python -m ruff check tools/skeleton_core tests/skeleton_core",
+    "python -m black --check tools/skeleton_core tests/skeleton_core"
+  ],
+  "blocked_reason": null,
+  "private_data_seen": false,
+  "runtime_code_touched": false,
+  "external_services_called": false
+}

--- a/tests/skeleton_core/test_cli.py
+++ b/tests/skeleton_core/test_cli.py
@@ -77,6 +77,29 @@ def test_cli_queue_summary(capsys) -> None:
     assert payload["UNKNOWN_NEEDS_REVIEW"] == 0
 
 
+def test_cli_runner_report_from_trace(capsys) -> None:
+    exit_code = main(
+        [
+            "runner-report-from-trace",
+            "--input",
+            "tests/fixtures/trace_packet_sample.json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "changed_files\n- tools/skeleton_core/cli.py" in captured.out
+    assert "commands_run\n- python -m pytest -q" in captured.out
+    assert "test_result\nreported in commands_run" in captured.out
+    assert "lint_result\nreported in commands_run" in captured.out
+    assert "format_result\nreported in commands_run" in captured.out
+    assert "private_data_seen: no" in captured.out
+    assert "runtime_code_touched: no" in captured.out
+    assert "external_services_called: no" in captured.out
+    assert "next_safe_step\nuse task-from-text for new Skeleton intake" in captured.out
+
+
 def test_cli_task_from_text_docs_routes_yellow(capsys) -> None:
     exit_code = main(
         [

--- a/tests/skeleton_core/test_report.py
+++ b/tests/skeleton_core/test_report.py
@@ -1,0 +1,75 @@
+from tools.skeleton_core.report import REPORT_FIELD_ORDER, render_runner_report_from_trace
+from tools.skeleton_core.trace import TracePacket
+
+
+def test_report_field_order_is_stable() -> None:
+    assert REPORT_FIELD_ORDER == (
+        "changed_files",
+        "commands_run",
+        "test_result",
+        "lint_result",
+        "format_result",
+        "diff_summary",
+        "errors_or_blockers",
+        "private_data_seen",
+        "runtime_code_touched",
+        "external_services_called",
+        "next_safe_step",
+    )
+
+
+def test_render_runner_report_from_trace() -> None:
+    packet = TracePacket(
+        task_id="issue-35",
+        project="skeleton",
+        risk_level="ORANGE",
+        route_target="RUNNER_ORANGE",
+        result="merged",
+        next_safe_step="use task-from-text for new Skeleton intake",
+        files_changed=["tools/skeleton_core/cli.py", "tests/skeleton_core/test_cli.py"],
+        commands_run=[
+            "python -m pytest -q",
+            "python -m ruff check tools/skeleton_core tests/skeleton_core",
+            "python -m black --check tools/skeleton_core tests/skeleton_core",
+        ],
+    )
+
+    report = render_runner_report_from_trace(packet)
+
+    assert "changed_files\n- tools/skeleton_core/cli.py" in report
+    assert "commands_run\n- python -m pytest -q" in report
+    assert "test_result\nreported in commands_run" in report
+    assert "lint_result\nreported in commands_run" in report
+    assert "format_result\nreported in commands_run" in report
+    assert "diff_summary\nnot reported" in report
+    assert "errors_or_blockers\nnone" in report
+    assert "private_data_seen: no" in report
+    assert "runtime_code_touched: no" in report
+    assert "external_services_called: no" in report
+    assert "next_safe_step\nuse task-from-text for new Skeleton intake" in report
+
+
+def test_render_runner_report_from_blocked_trace() -> None:
+    packet = TracePacket(
+        task_id="manual-blocked",
+        risk_level="RED",
+        route_target="BLOCKED_RED",
+        result="blocked",
+        next_safe_step="wait for Oleksii",
+        blocked_reason="RED task detected",
+        private_data_seen=True,
+        runtime_code_touched=True,
+        external_services_called=True,
+    )
+
+    report = render_runner_report_from_trace(packet)
+
+    assert "changed_files\nnone" in report
+    assert "commands_run\nnone" in report
+    assert "test_result\nnot reported" in report
+    assert "lint_result\nnot reported" in report
+    assert "format_result\nnot reported" in report
+    assert "errors_or_blockers\nRED task detected" in report
+    assert "private_data_seen: yes" in report
+    assert "runtime_code_touched: yes" in report
+    assert "external_services_called: yes" in report

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -12,11 +12,18 @@ from pydantic import ValidationError
 
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
+from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.templates import render_runner_issue
 from tools.skeleton_core.trace import TracePacket
 
-SUBCOMMANDS = {"decide", "queue-summary", "task-from-text", "trace-packet"}
+SUBCOMMANDS = {
+    "decide",
+    "queue-summary",
+    "runner-report-from-trace",
+    "task-from-text",
+    "trace-packet",
+}
 MAX_AUTO_TITLE_LENGTH = 80
 
 
@@ -49,6 +56,11 @@ def build_queue_summary_payload(input_path: Path) -> dict[str, int]:
 def build_trace_packet_payload(packet: TracePacket) -> dict[str, Any]:
     """Build the JSON-serializable trace packet payload."""
     return packet.model_dump(mode="json")
+
+
+def load_trace_packet(input_path: Path) -> TracePacket:
+    """Load and validate a TracePacket from a JSON file."""
+    return TracePacket.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def title_from_text(text: str, max_length: int = MAX_AUTO_TITLE_LENGTH) -> str:
@@ -159,6 +171,17 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Path to public-safe queue JSON",
     )
 
+    report_parser = subparsers.add_parser(
+        "runner-report-from-trace",
+        help="Render a short runner report from a TracePacket JSON file",
+    )
+    report_parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to public-safe TracePacket JSON",
+    )
+
     task_from_text_parser = subparsers.add_parser(
         "task-from-text",
         help="Build a Skeleton decision packet from free-form text",
@@ -211,6 +234,17 @@ def _run_queue_summary(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_runner_report_from_trace(args: argparse.Namespace) -> int:
+    try:
+        packet = load_trace_packet(args.input)
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(render_runner_report_from_trace(packet), flush=True)
+    return 0
+
+
 def _run_task_from_text(args: argparse.Namespace) -> int:
     try:
         packet = build_task_from_text_packet(
@@ -260,6 +294,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.command == "queue-summary":
         return _run_queue_summary(args)
+    if args.command == "runner-report-from-trace":
+        return _run_runner_report_from_trace(args)
     if args.command == "task-from-text":
         return _run_task_from_text(args)
     if args.command == "trace-packet":

--- a/tools/skeleton_core/report.py
+++ b/tools/skeleton_core/report.py
@@ -1,0 +1,64 @@
+"""Public-safe runner report rendering for Skeleton trace packets."""
+
+from tools.skeleton_core.trace import TracePacket
+
+REPORT_FIELD_ORDER = (
+    "changed_files",
+    "commands_run",
+    "test_result",
+    "lint_result",
+    "format_result",
+    "diff_summary",
+    "errors_or_blockers",
+    "private_data_seen",
+    "runtime_code_touched",
+    "external_services_called",
+    "next_safe_step",
+)
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _list_block(values: list[str]) -> str:
+    if not values:
+        return "none"
+    return "\n".join(f"- {value}" for value in values)
+
+
+def _has_command(commands: list[str], needle: str) -> bool:
+    return any(needle in command for command in commands)
+
+
+def _reported_if_command(commands: list[str], needle: str) -> str:
+    if _has_command(commands, needle):
+        return "reported in commands_run"
+    return "not reported"
+
+
+def render_runner_report_from_trace(packet: TracePacket) -> str:
+    """Render the standard short public-safe runner report shape."""
+    return "\n".join(
+        [
+            "changed_files",
+            _list_block(packet.files_changed),
+            "commands_run",
+            _list_block(packet.commands_run),
+            "test_result",
+            _reported_if_command(packet.commands_run, "pytest"),
+            "lint_result",
+            _reported_if_command(packet.commands_run, "ruff"),
+            "format_result",
+            _reported_if_command(packet.commands_run, "black"),
+            "diff_summary",
+            "not reported",
+            "errors_or_blockers",
+            packet.blocked_reason or "none",
+            f"private_data_seen: {_yes_no(packet.private_data_seen)}",
+            f"runtime_code_touched: {_yes_no(packet.runtime_code_touched)}",
+            f"external_services_called: {_yes_no(packet.external_services_called)}",
+            "next_safe_step",
+            packet.next_safe_step,
+        ]
+    )


### PR DESCRIPTION
## Summary

Adds a local command that renders a short public-safe runner report from a TracePacket JSON file:

```bash
python -m tools.skeleton_core.cli runner-report-from-trace --input tests/fixtures/trace_packet_sample.json
```

## Changed files

```text
tools/skeleton_core/report.py
tools/skeleton_core/cli.py
tests/fixtures/trace_packet_sample.json
tests/skeleton_core/test_report.py
tests/skeleton_core/test_cli.py
```

## Behavior

Renders the standard runner report field order:

```text
changed_files
commands_run
test_result
lint_result
format_result
diff_summary
errors_or_blockers
private_data_seen: yes/no
runtime_code_touched: yes/no
external_services_called: yes/no
next_safe_step
```

## Validation result

Runner validation reported by Oleksii on 2026-05-05:

```text
python -m pytest -q
97 passed in 0.27s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 16 files would be left unchanged.

runner-report-from-trace emitted expected report from tests/fixtures/trace_packet_sample.json

git status --short
clean
```

## Safety note

Local Skeleton CLI/model/test-only change. No runtime behavior changes.

## Related issue

Implements #37.