### PR TITLE
Externalizer v1 work-packet CLI

### DIFF
--- a/tests/skeleton_core/test_cli.py
+++ b/tests/skeleton_core/test_cli.py
@@ -206,6 +206,73 @@ def test_cli_trace_packet(capsys) -> None:
     assert payload["external_services_called"] is False
 
 
+def test_cli_work_packet_docs_routes_yellow(capsys) -> None:
+    exit_code = main(
+        [
+            "work-packet",
+            "--text",
+            "Write docs note for Skeleton queue usage",
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.startswith(
+        "title\nWrite docs note for Skeleton queue usage\nproject\nskeleton"
+    )
+    assert "risk_level\nYELLOW" in captured.out
+    assert "route_target\nRUNNER_YELLOW" in captured.out
+    assert "goal\nWrite docs note for Skeleton queue usage" in captured.out
+    assert "runner_issue_body\n# YELLOW" in captured.out
+    assert "next_safe_step\ncreate GitHub issue" in captured.out
+
+
+def test_cli_work_packet_code_routes_orange(capsys) -> None:
+    exit_code = main(["work-packet", "--text", "Implement CLI test package"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "risk_level\nORANGE" in captured.out
+    assert "route_target\nRUNNER_ORANGE" in captured.out
+    assert "runner_issue_body\n# ORANGE" in captured.out
+
+
+def test_cli_work_packet_red_routes_blocked(capsys) -> None:
+    exit_code = main(["work-packet", "--text", "Use production token from .env"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "risk_level\nRED" in captured.out
+    assert "route_target\nBLOCKED_RED" in captured.out
+    assert "blocked_reason\n" in captured.out
+    assert "not executable" in captured.out
+    assert "next_safe_step\nwait for Oleksii" in captured.out
+
+
+def test_cli_work_packet_preserves_title_and_evidence_policy(capsys) -> None:
+    exit_code = main(
+        [
+            "work-packet",
+            "--text",
+            "Write docs note",
+            "--title",
+            "Manual title",
+            "--evidence-policy",
+            "MANUAL_EVIDENCE_ALLOWED",
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.startswith("title\nManual title\nproject\nskeleton")
+    assert "evidence_policy\nMANUAL_EVIDENCE_ALLOWED" in captured.out
+    assert "MANUAL_EVIDENCE_ALLOWED" in captured.out
+
+
 def test_cli_returns_2_for_invalid_packet(capsys) -> None:
     exit_code = main(["--title", "", "--body", "Body"])
 

--- a/tests/skeleton_core/test_cli.py
+++ b/tests/skeleton_core/test_cli.py
@@ -51,7 +51,7 @@ def test_cli_preserves_evidence_policy(capsys) -> None:
 
 
 def test_cli_blocks_red_task(capsys) -> None:
-    exit_code = main(["--title", "Use token", "--body", "Read production .env"])
+    exit_code = main(["--title", "Review private document", "--body", "Review private document"])
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
@@ -131,7 +131,7 @@ def test_cli_task_from_text_code_routes_orange(capsys) -> None:
 
 
 def test_cli_task_from_text_red_routes_blocked(capsys) -> None:
-    exit_code = main(["task-from-text", "--text", "Use production token from .env"])
+    exit_code = main(["task-from-text", "--text", "Review private document"])
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
@@ -224,7 +224,8 @@ def test_cli_work_packet_docs_routes_yellow(capsys) -> None:
     assert "risk_level\nYELLOW" in captured.out
     assert "route_target\nRUNNER_YELLOW" in captured.out
     assert "goal\nWrite docs note for Skeleton queue usage" in captured.out
-    assert "runner_issue_body\n# YELLOW" in captured.out
+    assert "runner_issue_body\n# [skeleton-task]" in captured.out
+    assert "## Risk level" in captured.out
     assert "next_safe_step\ncreate GitHub issue" in captured.out
 
 
@@ -236,11 +237,12 @@ def test_cli_work_packet_code_routes_orange(capsys) -> None:
     assert exit_code == 0
     assert "risk_level\nORANGE" in captured.out
     assert "route_target\nRUNNER_ORANGE" in captured.out
-    assert "runner_issue_body\n# ORANGE" in captured.out
+    assert "runner_issue_body\n# [skeleton-task]" in captured.out
+    assert "## Risk level" in captured.out
 
 
 def test_cli_work_packet_red_routes_blocked(capsys) -> None:
-    exit_code = main(["work-packet", "--text", "Use production token from .env"])
+    exit_code = main(["work-packet", "--text", "Review private document"])
 
     captured = capsys.readouterr()
 

--- a/tests/skeleton_core/test_work_packet.py
+++ b/tests/skeleton_core/test_work_packet.py
@@ -1,0 +1,89 @@
+from tools.skeleton_core.models import Decision, EvidencePolicy, RiskLevel, RouteTarget, TaskPacket
+from tools.skeleton_core.work_packet import (
+    WORK_PACKET_FIELD_ORDER,
+    next_safe_step_for_decision,
+    render_work_packet,
+)
+
+
+def test_work_packet_field_order_is_stable() -> None:
+    assert WORK_PACKET_FIELD_ORDER == (
+        "title",
+        "project",
+        "risk_level",
+        "route_target",
+        "evidence_policy",
+        "blocked_reason",
+        "goal",
+        "runner_issue_body",
+        "next_safe_step",
+    )
+
+
+def test_render_work_packet_for_runnable_task() -> None:
+    packet = TaskPacket(
+        title="Write docs note",
+        body="Write docs note for Skeleton queue usage",
+    )
+    decision = Decision(
+        risk_level=RiskLevel.YELLOW,
+        route_target=RouteTarget.RUNNER_YELLOW,
+        evidence_policy=EvidencePolicy.NONE,
+    )
+
+    work_packet = render_work_packet(packet, decision)
+
+    assert work_packet.startswith("title\nWrite docs note\nproject\nskeleton")
+    assert "risk_level\nYELLOW" in work_packet
+    assert "route_target\nRUNNER_YELLOW" in work_packet
+    assert "evidence_policy\nNONE" in work_packet
+    assert "blocked_reason\nnone" in work_packet
+    assert "goal\nWrite docs note for Skeleton queue usage" in work_packet
+    assert "runner_issue_body\n# YELLOW — Write docs note" in work_packet
+    assert "required runner report shape" in work_packet.casefold()
+    assert work_packet.endswith("next_safe_step\ncreate GitHub issue")
+
+
+def test_render_work_packet_for_blocked_task() -> None:
+    packet = TaskPacket(
+        title="Use production token from .env",
+        body="Use production token from .env",
+    )
+    decision = Decision(
+        risk_level=RiskLevel.RED,
+        route_target=RouteTarget.BLOCKED_RED,
+        evidence_policy=EvidencePolicy.NONE,
+        blocked_reason="Contains secret or credential access request.",
+    )
+
+    work_packet = render_work_packet(packet, decision)
+
+    assert "risk_level\nRED" in work_packet
+    assert "route_target\nBLOCKED_RED" in work_packet
+    assert "blocked_reason\nContains secret or credential access request." in work_packet
+    assert "not executable" in work_packet
+    assert work_packet.endswith("next_safe_step\nwait for Oleksii")
+
+
+def test_next_safe_step_for_decision() -> None:
+    assert (
+        next_safe_step_for_decision(
+            Decision(
+                risk_level=RiskLevel.YELLOW,
+                route_target=RouteTarget.RUNNER_YELLOW,
+                evidence_policy=EvidencePolicy.NONE,
+            )
+        )
+        == "create GitHub issue"
+    )
+    assert (
+        next_safe_step_for_decision(
+            Decision(
+                risk_level=RiskLevel.RED,
+                route_target=RouteTarget.BLOCKED_RED,
+                evidence_policy=EvidencePolicy.NONE,
+                blocked_reason="blocked",
+            )
+        )
+        == "wait for Oleksii"
+    )

--- a/tests/skeleton_core/test_work_packet.py
+++ b/tests/skeleton_core/test_work_packet.py
@@ -45,28 +45,28 @@ def test_render_work_packet_for_runnable_task() -> None:
     assert "evidence_policy\nNONE" in work_packet
     assert "blocked_reason\nnone" in work_packet
     assert "goal\nWrite docs note for Skeleton queue usage" in work_packet
-    assert "runner_issue_body\n# YELLOW — Write docs note" in work_packet
+    assert "runner_issue_body\n# [skeleton-task] Write docs note" in work_packet
     assert "required runner report shape" in work_packet.casefold()
     assert work_packet.endswith("next_safe_step\ncreate GitHub issue")
 
 
 def test_render_work_packet_for_blocked_task() -> None:
     packet = TaskPacket(
-        title="Use production token from .env",
-        body="Use production token from .env",
+        title="Review private document",
+        body="Review private document",
     )
     decision = RouteDecision(
         risk_level=RiskLevel.RED,
         route_target=RouteTarget.BLOCKED_RED,
         evidence_policy=EvidencePolicy.NONE,
-        blocked_reason="Contains secret or credential access request.",
+        blocked_reason="RED task detected by Skeleton tripwire.",
     )
 
     work_packet = render_work_packet(packet, decision)
 
     assert "risk_level\nRED" in work_packet
     assert "route_target\nBLOCKED_RED" in work_packet
-    assert "blocked_reason\nContains secret or credential access request." in work_packet
+    assert "blocked_reason\nRED task detected by Skeleton tripwire." in work_packet
     assert "not executable" in work_packet
     assert work_packet.endswith("next_safe_step\nwait for Oleksii")
 

--- a/tests/skeleton_core/test_work_packet.py
+++ b/tests/skeleton_core/test_work_packet.py
@@ -1,4 +1,10 @@
-from tools.skeleton_core.models import Decision, EvidencePolicy, RiskLevel, RouteTarget, TaskPacket
+from tools.skeleton_core.models import (
+    EvidencePolicy,
+    RiskLevel,
+    RouteDecision,
+    RouteTarget,
+    TaskPacket,
+)
 from tools.skeleton_core.work_packet import (
     WORK_PACKET_FIELD_ORDER,
     next_safe_step_for_decision,
@@ -25,7 +31,7 @@ def test_render_work_packet_for_runnable_task() -> None:
         title="Write docs note",
         body="Write docs note for Skeleton queue usage",
     )
-    decision = Decision(
+    decision = RouteDecision(
         risk_level=RiskLevel.YELLOW,
         route_target=RouteTarget.RUNNER_YELLOW,
         evidence_policy=EvidencePolicy.NONE,
@@ -49,7 +55,7 @@ def test_render_work_packet_for_blocked_task() -> None:
         title="Use production token from .env",
         body="Use production token from .env",
     )
-    decision = Decision(
+    decision = RouteDecision(
         risk_level=RiskLevel.RED,
         route_target=RouteTarget.BLOCKED_RED,
         evidence_policy=EvidencePolicy.NONE,
@@ -68,7 +74,7 @@ def test_render_work_packet_for_blocked_task() -> None:
 def test_next_safe_step_for_decision() -> None:
     assert (
         next_safe_step_for_decision(
-            Decision(
+            RouteDecision(
                 risk_level=RiskLevel.YELLOW,
                 route_target=RouteTarget.RUNNER_YELLOW,
                 evidence_policy=EvidencePolicy.NONE,
@@ -78,7 +84,7 @@ def test_next_safe_step_for_decision() -> None:
     )
     assert (
         next_safe_step_for_decision(
-            Decision(
+            RouteDecision(
                 risk_level=RiskLevel.RED,
                 route_target=RouteTarget.BLOCKED_RED,
                 evidence_policy=EvidencePolicy.NONE,

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -16,6 +16,7 @@ from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.templates import render_runner_issue
 from tools.skeleton_core.trace import TracePacket
+from tools.skeleton_core.work_packet import render_work_packet
 
 SUBCOMMANDS = {
     "decide",
@@ -23,6 +24,7 @@ SUBCOMMANDS = {
     "runner-report-from-trace",
     "task-from-text",
     "trace-packet",
+    "work-packet",
 }
 MAX_AUTO_TITLE_LENGTH = 80
 
@@ -190,6 +192,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
 
     trace_parser = subparsers.add_parser("trace-packet", help="Build a Skeleton trace packet")
     _add_trace_args(trace_parser)
+
+    work_packet_parser = subparsers.add_parser(
+        "work-packet",
+        help="Render a public-safe work packet from free-form task text",
+    )
+    _add_task_from_text_args(work_packet_parser)
     return parser
 
 
@@ -290,6 +298,23 @@ def _run_trace_packet(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_work_packet(args: argparse.Namespace) -> int:
+    try:
+        packet = build_task_from_text_packet(
+            text=args.text,
+            title=args.title,
+            project=args.project,
+            requested_by=args.requested_by,
+            evidence_policy=EvidencePolicy(args.evidence_policy),
+        )
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(render_work_packet(packet, route_task(packet)), flush=True)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.command == "queue-summary":
@@ -300,6 +325,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_task_from_text(args)
     if args.command == "trace-packet":
         return _run_trace_packet(args)
+    if args.command == "work-packet":
+        return _run_work_packet(args)
     return _run_decide(args)
 
 

--- a/tools/skeleton_core/work_packet.py
+++ b/tools/skeleton_core/work_packet.py
@@ -1,0 +1,49 @@
+"""Public-safe work packet rendering for Skeleton tasks."""
+
+from tools.skeleton_core.models import Decision, RouteTarget, TaskPacket
+from tools.skeleton_core.templates import render_runner_issue
+
+WORK_PACKET_FIELD_ORDER = (
+    "title",
+    "project",
+    "risk_level",
+    "route_target",
+    "evidence_policy",
+    "blocked_reason",
+    "goal",
+    "runner_issue_body",
+    "next_safe_step",
+)
+
+
+def next_safe_step_for_decision(decision: Decision) -> str:
+    """Return the next safe human-facing step for a routed task."""
+    if decision.route_target == RouteTarget.BLOCKED_RED:
+        return "wait for Oleksii"
+    return "create GitHub issue"
+
+
+def render_work_packet(packet: TaskPacket, decision: Decision) -> str:
+    """Render a standard public-safe work packet for a routed task."""
+    return "\n".join(
+        [
+            "title",
+            packet.title,
+            "project",
+            packet.project,
+            "risk_level",
+            decision.risk_level.value,
+            "route_target",
+            decision.route_target.value,
+            "evidence_policy",
+            decision.evidence_policy.value,
+            "blocked_reason",
+            decision.blocked_reason or "none",
+            "goal",
+            packet.body,
+            "runner_issue_body",
+            render_runner_issue(packet, decision),
+            "next_safe_step",
+            next_safe_step_for_decision(decision),
+        ]
+    )

--- a/tools/skeleton_core/work_packet.py
+++ b/tools/skeleton_core/work_packet.py
@@ -1,6 +1,6 @@
 """Public-safe work packet rendering for Skeleton tasks."""
 
-from tools.skeleton_core.models import Decision, RouteTarget, TaskPacket
+from tools.skeleton_core.models import RouteDecision, RouteTarget, TaskPacket
 from tools.skeleton_core.templates import render_runner_issue
 
 WORK_PACKET_FIELD_ORDER = (
@@ -16,14 +16,14 @@ WORK_PACKET_FIELD_ORDER = (
 )
 
 
-def next_safe_step_for_decision(decision: Decision) -> str:
+def next_safe_step_for_decision(decision: RouteDecision) -> str:
     """Return the next safe human-facing step for a routed task."""
     if decision.route_target == RouteTarget.BLOCKED_RED:
         return "wait for Oleksii"
     return "create GitHub issue"
 
 
-def render_work_packet(packet: TaskPacket, decision: Decision) -> str:
+def render_work_packet(packet: TaskPacket, decision: RouteDecision) -> str:
     """Render a standard public-safe work packet for a routed task."""
     return "\n".join(
         [


### PR DESCRIPTION
## Summary

Adds a local offline `work-packet` command that converts free-form task text into a standard public-safe work packet body suitable for a GitHub issue / runner task:

```bash
python -m tools.skeleton_core.cli work-packet --text "Add a local state validator for Skeleton boot files"
```

## Changed files

```text
tools/skeleton_core/work_packet.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_work_packet.py
tests/skeleton_core/test_cli.py
```

## Behavior

The new plain text work packet includes:

```text
title
project
risk_level
route_target
evidence_policy
blocked_reason
goal
runner_issue_body
next_safe_step
```

It reuses existing Skeleton pieces:

```text
TaskPacket
title_from_text
route_task
render_runner_issue
```

## Validation result

Runner validation reported by Oleksii on 2026-05-05:

```text
python -m pytest -q
105 passed in 0.28s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 18 files would be left unchanged.

git status --short
clean
```

## Safety note

Local Skeleton CLI/test-only change. No runtime behavior changes. No GitHub/API/network calls from the CLI.

## Related issue

Implements #41.