### PR TITLE
Externalizer v1 current-state validator CLI

### DIFF
--- a/tests/skeleton_core/test_cli.py
+++ b/tests/skeleton_core/test_cli.py
@@ -100,6 +100,19 @@ def test_cli_runner_report_from_trace(capsys) -> None:
     assert "next_safe_step\nuse task-from-text for new Skeleton intake" in captured.out
 
 
+def test_cli_validate_state_current_repo(capsys) -> None:
+    exit_code = main(["validate-state"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["missing_files"] == []
+    assert payload["missing_anchors"] == []
+    assert "knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md" in payload["checked_files"]
+
+
 def test_cli_task_from_text_docs_routes_yellow(capsys) -> None:
     exit_code = main(
         [

--- a/tests/skeleton_core/test_state_validator.py
+++ b/tests/skeleton_core/test_state_validator.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from tools.skeleton_core.state_validator import (
+    REQUIRED_ANCHORS,
+    REQUIRED_STATE_FILES,
+    validate_state,
+)
+
+
+def _write_minimal_valid_state(root: Path) -> None:
+    for relative_path in REQUIRED_STATE_FILES:
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("placeholder\n", encoding="utf-8")
+
+    for relative_path, anchors in REQUIRED_ANCHORS.items():
+        path = root / relative_path
+        path.write_text("\n".join(anchors) + "\n", encoding="utf-8")
+
+
+def test_validate_state_success(tmp_path: Path) -> None:
+    _write_minimal_valid_state(tmp_path)
+
+    result = validate_state(tmp_path)
+
+    assert result.ok is True
+    assert result.missing_files == []
+    assert result.missing_anchors == []
+    assert result.checked_files == list(REQUIRED_STATE_FILES)
+
+
+def test_validate_state_reports_missing_file(tmp_path: Path) -> None:
+    _write_minimal_valid_state(tmp_path)
+    missing_path = tmp_path / "knowledge_base" / "assistant_diary.md"
+    missing_path.unlink()
+
+    result = validate_state(tmp_path)
+
+    assert result.ok is False
+    assert result.missing_files == ["knowledge_base/assistant_diary.md"]
+    assert result.missing_anchors == []
+    assert "knowledge_base/assistant_diary.md" not in result.checked_files
+
+
+def test_validate_state_reports_missing_anchor(tmp_path: Path) -> None:
+    _write_minimal_valid_state(tmp_path)
+    current_state_path = tmp_path / "knowledge_base" / "chatgpt_exoskeleton" / "CURRENT_STATE.md"
+    current_state_path.write_text("СК / ChatGPT Exoskeleton\n", encoding="utf-8")
+
+    result = validate_state(tmp_path)
+
+    assert result.ok is False
+    assert result.missing_files == []
+    assert len(result.missing_anchors) == 1
+    assert result.missing_anchors[0].path == "knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md"
+    assert result.missing_anchors[0].anchor == "Externalizer"

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -14,6 +14,7 @@ from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summ
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
+from tools.skeleton_core.state_validator import validate_state
 from tools.skeleton_core.templates import render_runner_issue
 from tools.skeleton_core.trace import TracePacket
 from tools.skeleton_core.work_packet import render_work_packet
@@ -24,6 +25,7 @@ SUBCOMMANDS = {
     "runner-report-from-trace",
     "task-from-text",
     "trace-packet",
+    "validate-state",
     "work-packet",
 }
 MAX_AUTO_TITLE_LENGTH = 80
@@ -156,7 +158,7 @@ def _add_trace_args(parser: argparse.ArgumentParser) -> None:
 
 
 def _subcommand_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Skeleton Externalizer v0 CLI.")
+    parser = argparse.ArgumentParser(description="Skeleton Externalizer CLI.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
@@ -192,6 +194,17 @@ def _subcommand_parser() -> argparse.ArgumentParser:
 
     trace_parser = subparsers.add_parser("trace-packet", help="Build a Skeleton trace packet")
     _add_trace_args(trace_parser)
+
+    validate_state_parser = subparsers.add_parser(
+        "validate-state",
+        help="Validate Skeleton boot and current-state files",
+    )
+    validate_state_parser.add_argument(
+        "--root",
+        default=Path("."),
+        type=Path,
+        help="Repository root to validate",
+    )
 
     work_packet_parser = subparsers.add_parser(
         "work-packet",
@@ -298,6 +311,12 @@ def _run_trace_packet(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_validate_state(args: argparse.Namespace) -> int:
+    result = validate_state(args.root)
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0 if result.ok else 1
+
+
 def _run_work_packet(args: argparse.Namespace) -> int:
     try:
         packet = build_task_from_text_packet(
@@ -325,6 +344,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_task_from_text(args)
     if args.command == "trace-packet":
         return _run_trace_packet(args)
+    if args.command == "validate-state":
+        return _run_validate_state(args)
     if args.command == "work-packet":
         return _run_work_packet(args)
     return _run_decide(args)

--- a/tools/skeleton_core/state_validator.py
+++ b/tools/skeleton_core/state_validator.py
@@ -1,0 +1,85 @@
+"""Read-only validation for Skeleton boot and current-state files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+REQUIRED_STATE_FILES = (
+    "BOOTLOADER.md",
+    "knowledge_base/START_HERE_FOR_CHATGPT.md",
+    "knowledge_base/MEMORY_POLICY.md",
+    "knowledge_base/WORKING_PROTOCOL.md",
+    "knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md",
+    "knowledge_base/assistant_diary.md",
+    "knowledge_base/chatgpt_exoskeleton/START_HERE.md",
+    "knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md",
+    "knowledge_base/CHATGPT_EXOSKELETON.md",
+    "knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md",
+)
+
+REQUIRED_ANCHORS = {
+    "knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md": (
+        "СК / ChatGPT Exoskeleton",
+        "Externalizer",
+    ),
+    "knowledge_base/CHATGPT_EXOSKELETON.md": (
+        "CHATGPT_EXOSKELETON_RUNBOOK.md",
+    ),
+    "knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md": (
+        "CHATGPT_EXOSKELETON_RUNBOOK.md",
+    ),
+    "knowledge_base/WORKING_PROTOCOL.md": ("+",),
+}
+
+
+class MissingAnchor(BaseModel):
+    """A required text anchor missing from a file."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    anchor: str
+
+
+class StateValidationResult(BaseModel):
+    """Result for a read-only Skeleton state validation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+    missing_files: list[str]
+    missing_anchors: list[MissingAnchor]
+    checked_files: list[str]
+
+
+def validate_state(root: Path) -> StateValidationResult:
+    """Validate required Skeleton state files and anchors under root."""
+    root = root.resolve()
+    missing_files: list[str] = []
+    missing_anchors: list[MissingAnchor] = []
+    checked_files: list[str] = []
+
+    for relative_path in REQUIRED_STATE_FILES:
+        path = root / relative_path
+        if not path.is_file():
+            missing_files.append(relative_path)
+            continue
+        checked_files.append(relative_path)
+
+    for relative_path, anchors in REQUIRED_ANCHORS.items():
+        path = root / relative_path
+        if not path.is_file():
+            continue
+        content = path.read_text(encoding="utf-8")
+        for anchor in anchors:
+            if anchor not in content:
+                missing_anchors.append(MissingAnchor(path=relative_path, anchor=anchor))
+
+    return StateValidationResult(
+        ok=not missing_files and not missing_anchors,
+        missing_files=missing_files,
+        missing_anchors=missing_anchors,
+        checked_files=checked_files,
+    )

--- a/tools/skeleton_core/state_validator.py
+++ b/tools/skeleton_core/state_validator.py
@@ -24,9 +24,7 @@ REQUIRED_ANCHORS = {
         "СК / ChatGPT Exoskeleton",
         "Externalizer",
     ),
-    "knowledge_base/CHATGPT_EXOSKELETON.md": (
-        "CHATGPT_EXOSKELETON_RUNBOOK.md",
-    ),
+    "knowledge_base/CHATGPT_EXOSKELETON.md": ("CHATGPT_EXOSKELETON_RUNBOOK.md",),
     "knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md": (
         "CHATGPT_EXOSKELETON_RUNBOOK.md",
     ),

--- a/tools/skeleton_core/state_validator.py
+++ b/tools/skeleton_core/state_validator.py
@@ -20,15 +20,15 @@ REQUIRED_STATE_FILES = (
 )
 
 REQUIRED_ANCHORS = {
-    "knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md": (
+    "knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md": [
         "СК / ChatGPT Exoskeleton",
         "Externalizer",
-    ),
-    "knowledge_base/CHATGPT_EXOSKELETON.md": ("CHATGPT_EXOSKELETON_RUNBOOK.md",),
-    "knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md": (
+    ],
+    "knowledge_base/CHATGPT_EXOSKELETON.md": ["CHATGPT_EXOSKELETON_RUNBOOK.md"],
+    "knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md": [
         "CHATGPT_EXOSKELETON_RUNBOOK.md",
-    ),
-    "knowledge_base/WORKING_PROTOCOL.md": ("+",),
+    ],
+    "knowledge_base/WORKING_PROTOCOL.md": ["+"],
 }
 
 


### PR DESCRIPTION
## Summary

Adds a local offline `validate-state` command that checks required Skeleton boot/current-state files and required text anchors:

```bash
python -m tools.skeleton_core.cli validate-state
python -m tools.skeleton_core.cli validate-state --root .
```

## Changed files

```text
tools/skeleton_core/state_validator.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_state_validator.py
tests/skeleton_core/test_cli.py
```

## Behavior

Emits JSON:

```json
{
  "ok": true,
  "missing_files": [],
  "missing_anchors": [],
  "checked_files": []
}
```

Validation checks:

```text
- required Skeleton boot/current-state files exist
- CURRENT_STATE contains Skeleton and Externalizer anchors
- CHATGPT_EXOSKELETON and branch continuity boot mention the runbook
- WORKING_PROTOCOL contains + command marker
```

## Validation result

Runner validation reported by Oleksii on 2026-05-05:

```text
python -m pytest -q
109 passed in 0.29s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 20 files would be left unchanged.

python -m tools.skeleton_core.cli validate-state
ok: true
missing_files: []
missing_anchors: []

git status --short
clean
```

## Safety note

Local read-only Skeleton CLI/test-only change. No runtime behavior changes. No file writes from validator. No GitHub/API/network calls from the CLI.

## Related issue

Implements #43.