### PR TITLE
Externalizer v1 checkpoint CLI

### DIFF
--- a/tests/skeleton_core/test_checkpoint.py
+++ b/tests/skeleton_core/test_checkpoint.py
@@ -1,0 +1,54 @@
+import json
+
+from tools.skeleton_core.checkpoint import render_checkpoint
+from tools.skeleton_core.trace import TracePacket
+
+
+def _trace_json_from_checkpoint(checkpoint: str) -> dict:
+    _, rest = checkpoint.split("trace_packet_json\n", 1)
+    trace_json, _ = rest.split("\nrunner_report\n", 1)
+    return json.loads(trace_json)
+
+
+def test_render_checkpoint_contains_trace_json_and_report() -> None:
+    packet = TracePacket(
+        task_id="manual-001",
+        project="skeleton",
+        risk_level="YELLOW",
+        route_target="RUNNER_YELLOW",
+        result="completed",
+        next_safe_step="review",
+        files_changed=["tools/skeleton_core/cli.py"],
+        commands_run=["python -m pytest -q"],
+    )
+
+    checkpoint = render_checkpoint(packet)
+    trace_payload = _trace_json_from_checkpoint(checkpoint)
+
+    assert checkpoint.startswith("trace_packet_json\n{")
+    assert "\nrunner_report\nchanged_files" in checkpoint
+    assert trace_payload["task_id"] == "manual-001"
+    assert trace_payload["files_changed"] == ["tools/skeleton_core/cli.py"]
+    assert "test_result\nreported in commands_run" in checkpoint
+    assert checkpoint.endswith("next_safe_step\nreview")
+
+
+def test_render_checkpoint_for_blocked_trace() -> None:
+    packet = TracePacket(
+        task_id="blocked-001",
+        risk_level="RED",
+        route_target="BLOCKED_RED",
+        result="blocked",
+        next_safe_step="wait for Oleksii",
+        blocked_reason="blocked by policy",
+        private_data_seen=True,
+    )
+
+    checkpoint = render_checkpoint(packet)
+    trace_payload = _trace_json_from_checkpoint(checkpoint)
+
+    assert trace_payload["route_target"] == "BLOCKED_RED"
+    assert trace_payload["blocked_reason"] == "blocked by policy"
+    assert "errors_or_blockers\nblocked by policy" in checkpoint
+    assert "private_data_seen: yes" in checkpoint
+    assert checkpoint.endswith("next_safe_step\nwait for Oleksii")

--- a/tools/skeleton_core/checkpoint.py
+++ b/tools/skeleton_core/checkpoint.py
@@ -1,0 +1,19 @@
+"""Public-safe checkpoint bundle rendering for Skeleton trace packets."""
+
+import json
+
+from tools.skeleton_core.report import render_runner_report_from_trace
+from tools.skeleton_core.trace import TracePacket
+
+
+def render_checkpoint(packet: TracePacket) -> str:
+    """Render TracePacket JSON and runner report in one public-safe bundle."""
+    trace_json = json.dumps(packet.model_dump(mode="json"), ensure_ascii=False, indent=2)
+    return "\n".join(
+        [
+            "trace_packet_json",
+            trace_json,
+            "runner_report",
+            render_runner_report_from_trace(packet),
+        ]
+    )

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from tools.skeleton_core.checkpoint import render_checkpoint
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.report import render_runner_report_from_trace
@@ -20,6 +21,7 @@ from tools.skeleton_core.trace import TracePacket
 from tools.skeleton_core.work_packet import render_work_packet
 
 SUBCOMMANDS = {
+    "checkpoint",
     "decide",
     "queue-summary",
     "runner-report-from-trace",
@@ -161,6 +163,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Skeleton Externalizer CLI.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    checkpoint_parser = subparsers.add_parser(
+        "checkpoint",
+        help="Build a Skeleton checkpoint bundle",
+    )
+    _add_trace_args(checkpoint_parser)
+
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
 
@@ -266,6 +274,24 @@ def _run_runner_report_from_trace(args: argparse.Namespace) -> int:
     return 0
 
 
+def _trace_packet_from_args(args: argparse.Namespace) -> TracePacket:
+    return TracePacket(
+        task_id=args.task_id,
+        project=args.project,
+        risk_level=args.risk_level,
+        route_target=args.route_target,
+        result=args.result,
+        next_safe_step=args.next_safe_step,
+        sources_read=_split_csv(args.sources_read),
+        files_changed=_split_csv(args.files_changed),
+        commands_run=_split_csv(args.commands_run),
+        blocked_reason=args.blocked_reason,
+        private_data_seen=args.private_data_seen,
+        runtime_code_touched=args.runtime_code_touched,
+        external_services_called=args.external_services_called,
+    )
+
+
 def _run_task_from_text(args: argparse.Namespace) -> int:
     try:
         packet = build_task_from_text_packet(
@@ -285,21 +311,7 @@ def _run_task_from_text(args: argparse.Namespace) -> int:
 
 def _run_trace_packet(args: argparse.Namespace) -> int:
     try:
-        packet = TracePacket(
-            task_id=args.task_id,
-            project=args.project,
-            risk_level=args.risk_level,
-            route_target=args.route_target,
-            result=args.result,
-            next_safe_step=args.next_safe_step,
-            sources_read=_split_csv(args.sources_read),
-            files_changed=_split_csv(args.files_changed),
-            commands_run=_split_csv(args.commands_run),
-            blocked_reason=args.blocked_reason,
-            private_data_seen=args.private_data_seen,
-            runtime_code_touched=args.runtime_code_touched,
-            external_services_called=args.external_services_called,
-        )
+        packet = _trace_packet_from_args(args)
     except ValidationError as exc:
         print(exc.json(), flush=True)
         return 2
@@ -308,6 +320,17 @@ def _run_trace_packet(args: argparse.Namespace) -> int:
         json.dumps(build_trace_packet_payload(packet), ensure_ascii=False, indent=2),
         flush=True,
     )
+    return 0
+
+
+def _run_checkpoint(args: argparse.Namespace) -> int:
+    try:
+        packet = _trace_packet_from_args(args)
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(render_checkpoint(packet), flush=True)
     return 0
 
 
@@ -336,6 +359,8 @@ def _run_work_packet(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.command == "checkpoint":
+        return _run_checkpoint(args)
     if args.command == "queue-summary":
         return _run_queue_summary(args)
     if args.command == "runner-report-from-trace":


### PR DESCRIPTION
## Summary

Adds a local offline `checkpoint` command that emits both TracePacket JSON and the public-safe runner report text in one output:

```bash
python -m tools.skeleton_core.cli checkpoint \
  --task-id manual-001 \
  --project skeleton \
  --risk-level YELLOW \
  --route-target RUNNER_YELLOW \
  --result completed \
  --next-safe-step review
```

## Changed files

```text
tools/skeleton_core/checkpoint.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_checkpoint.py
```

## Behavior

Output shape:

```text
trace_packet_json
{...}
runner_report
...
```

It reuses existing Skeleton pieces:

```text
TracePacket
render_runner_report_from_trace
```

## Validation result

Runner validation reported by Oleksii on 2026-05-05:

```text
python -m tools.skeleton_core.cli checkpoint ...
checkpoint output includes trace_packet_json and runner_report

python -m tools.skeleton_core.cli validate-state
ok: true
missing_files: []
missing_anchors: []

python -m pytest -q
111 passed in 0.26s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 22 files would be left unchanged.

git status --short
clean
```

## Safety note

Local read-only Skeleton CLI/test-only change. No runtime behavior changes. No file writes from checkpoint command. No GitHub/API/network calls from the CLI.

## Related issue

Implements #45.