### PR TITLE
Externalizer v1 classify-queue CLI

### DIFF
--- a/tests/skeleton_core/test_cli_classify_queue.py
+++ b/tests/skeleton_core/test_cli_classify_queue.py
@@ -1,0 +1,22 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def test_cli_classify_queue_outputs_items_and_summary(capsys) -> None:
+    exit_code = main(["classify-queue", "--input", "tests/fixtures/github_queue_sample.json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert "items" in payload
+    assert "summary" in payload
+    assert len(payload["items"]) == 4
+    assert payload["items"][0]["classification"] == "ACTIVE_SKELETON"
+    assert payload["items"][0]["kind"] == "issue"
+    assert "reason" in payload["items"][0]
+    assert payload["summary"]["ACTIVE_SKELETON"] == 1
+    assert payload["summary"]["JEEVES_RUNTIME_NOISE_FOR_NOW"] == 1
+    assert payload["summary"]["EVIDENCE_ONLY"] == 1
+    assert payload["summary"]["BLOCKED_WAITING_FOR_OLEKSII"] == 1

--- a/tests/skeleton_core/test_queue_classifier.py
+++ b/tests/skeleton_core/test_queue_classifier.py
@@ -1,0 +1,65 @@
+from tools.skeleton_core.queue_classifier import classify_queue_items
+
+
+def test_classify_queue_items_returns_items_and_summary() -> None:
+    result = classify_queue_items(
+        [
+            {
+                "kind": "issue",
+                "number": 40,
+                "title": "[skeleton] Stage 2 practical exoskeleton growth",
+                "labels": ["skeleton"],
+            },
+            {
+                "kind": "pr",
+                "number": 15,
+                "title": "test(jeeves): harden runtime action contracts",
+                "labels": [],
+            },
+            {
+                "kind": "issue",
+                "number": 280,
+                "title": "Gemini external-secret readiness note",
+                "labels": ["evidence"],
+            },
+            {
+                "kind": "issue",
+                "number": 99,
+                "title": "Blocked RED task",
+                "labels": ["risk:red"],
+            },
+        ]
+    )
+
+    assert [item.classification for item in result.items] == [
+        "ACTIVE_SKELETON",
+        "JEEVES_RUNTIME_NOISE_FOR_NOW",
+        "EVIDENCE_ONLY",
+        "BLOCKED_WAITING_FOR_OLEKSII",
+    ]
+    assert result.items[0].kind == "issue"
+    assert result.items[0].number == 40
+    assert result.items[0].title == "[skeleton] Stage 2 practical exoskeleton growth"
+    assert "Skeleton-active" in result.items[0].reason
+    assert result.summary["ACTIVE_SKELETON"] == 1
+    assert result.summary["JEEVES_RUNTIME_NOISE_FOR_NOW"] == 1
+    assert result.summary["EVIDENCE_ONLY"] == 1
+    assert result.summary["BLOCKED_WAITING_FOR_OLEKSII"] == 1
+    assert result.summary["UNKNOWN_NEEDS_REVIEW"] == 0
+
+
+def test_classify_queue_items_handles_unknown() -> None:
+    result = classify_queue_items(
+        [
+            {
+                "kind": "issue",
+                "number": 1,
+                "title": "Unclear follow-up",
+                "labels": [],
+            }
+        ]
+    )
+
+    assert result.items[0].classification == "UNKNOWN_NEEDS_REVIEW"
+    assert "No known Skeleton queue pattern" in result.items[0].reason
+    assert result.summary["UNKNOWN_NEEDS_REVIEW"] == 1

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from tools.skeleton_core.checkpoint import render_checkpoint
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
+from tools.skeleton_core.queue_classifier import classify_queue_items
 from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.state_validator import validate_state
@@ -22,6 +23,7 @@ from tools.skeleton_core.work_packet import render_work_packet
 
 SUBCOMMANDS = {
     "checkpoint",
+    "classify-queue",
     "decide",
     "queue-summary",
     "runner-report-from-trace",
@@ -46,11 +48,18 @@ def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
     }
 
 
+def load_queue_items(input_path: Path) -> list[dict[str, Any]]:
+    """Load raw offline public-safe queue items from JSON."""
+    raw_items = json.loads(input_path.read_text(encoding="utf-8"))
+    if not isinstance(raw_items, list):
+        raise ValueError("queue input must be a JSON list")
+    return raw_items
+
+
 def build_queue_summary_payload(input_path: Path) -> dict[str, int]:
     """Build summary counts from an offline public-safe queue fixture."""
-    raw_items = json.loads(input_path.read_text(encoding="utf-8"))
     items = []
-    for raw in raw_items:
+    for raw in load_queue_items(input_path):
         kind = str(raw.get("kind", "issue")).casefold()
         if kind == "pr":
             items.append(normalize_pr(raw))
@@ -169,6 +178,17 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
     _add_trace_args(checkpoint_parser)
 
+    classify_queue_parser = subparsers.add_parser(
+        "classify-queue",
+        help="Classify offline queue JSON items",
+    )
+    classify_queue_parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to public-safe queue JSON",
+    )
+
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
 
@@ -255,6 +275,23 @@ def _run_decide(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_checkpoint(args: argparse.Namespace) -> int:
+    try:
+        packet = _trace_packet_from_args(args)
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(render_checkpoint(packet), flush=True)
+    return 0
+
+
+def _run_classify_queue(args: argparse.Namespace) -> int:
+    result = classify_queue_items(load_queue_items(args.input))
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_queue_summary(args: argparse.Namespace) -> int:
     print(
         json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2),
@@ -323,17 +360,6 @@ def _run_trace_packet(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_checkpoint(args: argparse.Namespace) -> int:
-    try:
-        packet = _trace_packet_from_args(args)
-    except ValidationError as exc:
-        print(exc.json(), flush=True)
-        return 2
-
-    print(render_checkpoint(packet), flush=True)
-    return 0
-
-
 def _run_validate_state(args: argparse.Namespace) -> int:
     result = validate_state(args.root)
     print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
@@ -361,6 +387,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.command == "checkpoint":
         return _run_checkpoint(args)
+    if args.command == "classify-queue":
+        return _run_classify_queue(args)
     if args.command == "queue-summary":
         return _run_queue_summary(args)
     if args.command == "runner-report-from-trace":

--- a/tools/skeleton_core/queue_classifier.py
+++ b/tools/skeleton_core/queue_classifier.py
@@ -56,6 +56,14 @@ def _normalized_item(raw: dict[str, Any]) -> Any:
     return normalize_issue(raw)
 
 
+def _classification_for_item(normalized: Any) -> str:
+    summary = summarize_queue([normalized])
+    for classification in QUEUE_CLASSIFICATIONS:
+        if summary.get(classification, 0) > 0:
+            return classification
+    return "UNKNOWN_NEEDS_REVIEW"
+
+
 def _classification_reason(classification: str, title: str, labels: list[str]) -> str:
     label_text = ", ".join(labels) if labels else "no labels"
     if classification == "ACTIVE_SKELETON":
@@ -77,7 +85,7 @@ def classify_queue_items(raw_items: list[dict[str, Any]]) -> QueueClassification
 
     for raw, normalized in zip(raw_items, normalized_items, strict=True):
         labels = _raw_labels(raw)
-        classification = normalized.classification.value
+        classification = _classification_for_item(normalized)
         classified_items.append(
             ClassifiedQueueItem(
                 kind=str(raw.get("kind", "issue")).casefold(),

--- a/tools/skeleton_core/queue_classifier.py
+++ b/tools/skeleton_core/queue_classifier.py
@@ -1,0 +1,94 @@
+"""Per-item queue classification for offline public-safe GitHub queue exports."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
+
+QUEUE_CLASSIFICATIONS = (
+    "ACTIVE_SKELETON",
+    "JEEVES_RUNTIME_NOISE_FOR_NOW",
+    "EVIDENCE_ONLY",
+    "BLOCKED_WAITING_FOR_OLEKSII",
+    "UNKNOWN_NEEDS_REVIEW",
+)
+
+
+class ClassifiedQueueItem(BaseModel):
+    """A normalized queue item with an actionable classification."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    number: int | None
+    title: str
+    classification: str
+    reason: str
+
+
+class QueueClassificationResult(BaseModel):
+    """Per-item queue classification result with summary counts."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ClassifiedQueueItem]
+    summary: dict[str, int]
+
+
+def _raw_labels(raw: dict[str, Any]) -> list[str]:
+    labels = raw.get("labels", [])
+    result: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            result.append(label)
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            result.append(label["name"])
+    return result
+
+
+def _normalized_item(raw: dict[str, Any]) -> Any:
+    kind = str(raw.get("kind", "issue")).casefold()
+    if kind == "pr":
+        return normalize_pr(raw)
+    return normalize_issue(raw)
+
+
+def _classification_reason(classification: str, title: str, labels: list[str]) -> str:
+    label_text = ", ".join(labels) if labels else "no labels"
+    if classification == "ACTIVE_SKELETON":
+        return f"Skeleton-active title or labels detected: {label_text}"
+    if classification == "JEEVES_RUNTIME_NOISE_FOR_NOW":
+        return f"Jeeves/runtime or historical runner noise detected: {label_text}"
+    if classification == "EVIDENCE_ONLY":
+        return f"Evidence lane item detected: {label_text}"
+    if classification == "BLOCKED_WAITING_FOR_OLEKSII":
+        return f"Blocked/RED item requires Oleksii decision: {label_text}"
+    return f"No known Skeleton queue pattern matched: {title}"
+
+
+def classify_queue_items(raw_items: list[dict[str, Any]]) -> QueueClassificationResult:
+    """Classify raw offline queue items and return item list plus summary counts."""
+    normalized_items = [_normalized_item(raw) for raw in raw_items]
+    summary = summarize_queue(normalized_items)
+    classified_items: list[ClassifiedQueueItem] = []
+
+    for raw, normalized in zip(raw_items, normalized_items, strict=True):
+        labels = _raw_labels(raw)
+        classification = normalized.classification.value
+        classified_items.append(
+            ClassifiedQueueItem(
+                kind=str(raw.get("kind", "issue")).casefold(),
+                number=raw.get("number"),
+                title=normalized.title,
+                classification=classification,
+                reason=_classification_reason(classification, normalized.title, labels),
+            )
+        )
+
+    for classification in QUEUE_CLASSIFICATIONS:
+        summary.setdefault(classification, 0)
+
+    return QueueClassificationResult(items=classified_items, summary=summary)


### PR DESCRIPTION
## Summary

Adds a local offline `classify-queue` command that reads the same public-safe queue JSON as `queue-summary`, but returns per-item classifications plus summary counts:

```bash
python -m tools.skeleton_core.cli classify-queue --input tests/fixtures/github_queue_sample.json
```

## Changed files

```text
tools/skeleton_core/queue_classifier.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_queue_classifier.py
tests/skeleton_core/test_cli_classify_queue.py
```

## Behavior

Output shape:

```json
{
  "items": [
    {
      "kind": "issue",
      "number": 40,
      "title": "...",
      "classification": "ACTIVE_SKELETON",
      "reason": "..."
    }
  ],
  "summary": {
    "ACTIVE_SKELETON": 1
  }
}
```

It reuses existing Skeleton queue behavior:

```text
normalize_issue
normalize_pr
summarize_queue
existing QueueClassification category names
```

## Validation result

Runner validation reported by Oleksii on 2026-05-05:

```text
python -m tools.skeleton_core.cli classify-queue --input tests/fixtures/github_queue_sample.json
per-item classifications emitted with summary counts

python -m pytest -q
114 passed in 0.27s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed!

python -m black --check tools/skeleton_core tests/skeleton_core
All done! 25 files would be left unchanged.

python -m tools.skeleton_core.cli validate-state
ok: true
missing_files: []
missing_anchors: []

git status --short
clean
```

## Safety note

Local read-only Skeleton CLI/test-only change. No runtime behavior changes. No file writes from classify-queue command. No GitHub/API/network calls from the CLI.

## Related issue

Implements #47.