### PR TITLE
Add Skeleton core CI workflow

### DIFF
--- a/.github/workflows/skeleton-core.yml
+++ b/.github/workflows/skeleton-core.yml
@@ -1,0 +1,55 @@
+name: Skeleton Core
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/skeleton-core.yml"
+      - "Makefile"
+      - "pyproject.toml"
+      - "tools/skeleton_core/**"
+      - "tests/skeleton_core/**"
+      - "tests/fixtures/**"
+      - "knowledge_base/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/skeleton-core.yml"
+      - "Makefile"
+      - "pyproject.toml"
+      - "tools/skeleton_core/**"
+      - "tests/skeleton_core/**"
+      - "tests/fixtures/**"
+      - "knowledge_base/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Skeleton core
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Run tests
+        run: python -m pytest -q
+
+      - name: Run Ruff
+        run: python -m ruff check tools/skeleton_core tests/skeleton_core
+
+      - name: Run Black check
+        run: python -m black --check tools/skeleton_core tests/skeleton_core
+
+      - name: Validate Skeleton state
+        run: python -m tools.skeleton_core.cli validate-state


### PR DESCRIPTION
## Summary

Adds GitHub Actions validation for Skeleton core:

```text
.github/workflows/skeleton-core.yml
```

The workflow runs on pull requests and pushes to `main` that touch Skeleton-relevant paths.

## Validation commands

```bash
make install
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

## CI result

GitHub Actions run on PR head `b3a8b5249c55a2ae620331875029db78f6b66c28`:

```text
Workflow: Skeleton Core
Run: 25397481083
Status: completed
Conclusion: success
Job: Validate Skeleton core -> success
```

Completed steps:

```text
Check out repository
Set up Python
Install dependencies
Run tests
Run Ruff
Run Black check
Validate Skeleton state
```

## Safety note

Validation-only CI. No secrets. No deploy. No runtime/app changes. No external credentials.

## Goal

Reduce Hetzner screenshot validation friction. Future Skeleton PRs should expose validation status directly in GitHub, which ChatGPT can read.

## Related issue

Implements #49.