### PR TITLE
Externalizer v1 handoff-pack CLI

### DIFF
--- a/tests/skeleton_core/test_cli_handoff_pack.py
+++ b/tests/skeleton_core/test_cli_handoff_pack.py
@@ -1,0 +1,14 @@
+from tools.skeleton_core.cli import main
+
+
+def test_cli_handoff_pack_current_repo(capsys) -> None:
+    exit_code = main(["handoff-pack"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.startswith("skeleton_handoff_pack\nstate_validation")
+    assert "ok: true" in captured.out
+    assert "current_state_excerpt" in captured.out
+    assert "available_commands\n- validate-state" in captured.out
+    assert "next_recommended_step" in captured.out

--- a/tests/skeleton_core/test_handoff_pack.py
+++ b/tests/skeleton_core/test_handoff_pack.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+from tools.skeleton_core.handoff_pack import current_state_excerpt, render_handoff_pack
+from tools.skeleton_core.state_validator import REQUIRED_ANCHORS, REQUIRED_STATE_FILES
+
+
+def _write_minimal_valid_state(root: Path) -> None:
+    for relative_path in REQUIRED_STATE_FILES:
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("placeholder\n", encoding="utf-8")
+
+    for relative_path, anchors in REQUIRED_ANCHORS.items():
+        path = root / relative_path
+        path.write_text("\n".join(anchors) + "\n", encoding="utf-8")
+
+
+def test_current_state_excerpt_uses_selected_sections_only() -> None:
+    content = """# State
+
+## Current state
+
+Current content.
+
+## Externalizer usage
+
+Should not be included.
+
+## Active GitHub queue
+
+Queue content.
+
+## Next practical step
+
+Next content.
+"""
+
+    excerpt = current_state_excerpt(content)
+
+    assert "## Current state" in excerpt
+    assert "Current content." in excerpt
+    assert "## Active GitHub queue" in excerpt
+    assert "Queue content." in excerpt
+    assert "## Next practical step" in excerpt
+    assert "Next content." in excerpt
+    assert "Should not be included." not in excerpt
+
+
+def test_current_state_excerpt_is_capped() -> None:
+    content = "## Current state\n\n" + ("x" * 3000)
+
+    excerpt = current_state_excerpt(content, max_chars=100)
+
+    assert len(excerpt) == 100
+    assert excerpt.endswith("…")
+
+
+def test_render_handoff_pack_success(tmp_path: Path) -> None:
+    _write_minimal_valid_state(tmp_path)
+    current_state_path = tmp_path / "knowledge_base" / "chatgpt_exoskeleton" / "CURRENT_STATE.md"
+    current_state_path.write_text(
+        """# State
+
+## Current state
+
+СК / ChatGPT Exoskeleton
+Externalizer ready.
+
+## Active GitHub queue
+
+#40
+
+## Next practical step
+
+Use current tools.
+""",
+        encoding="utf-8",
+    )
+
+    handoff = render_handoff_pack(tmp_path)
+
+    assert handoff.startswith("skeleton_handoff_pack\nstate_validation")
+    assert "ok: true" in handoff
+    assert "missing_files\n- none" in handoff
+    assert "missing_anchors\n- none" in handoff
+    assert "current_state_excerpt\n## Current state" in handoff
+    assert "available_commands\n- validate-state" in handoff
+    assert "- handoff-pack" not in handoff
+    assert "next_recommended_step" in handoff
+
+
+def test_render_handoff_pack_reports_missing_state(tmp_path: Path) -> None:
+    handoff = render_handoff_pack(tmp_path)
+
+    assert "ok: false" in handoff
+    assert "missing_files\n- BOOTLOADER.md" in handoff
+    assert "CURRENT_STATE excerpt unavailable" in handoff

--- a/tests/skeleton_core/test_handoff_pack.py
+++ b/tests/skeleton_core/test_handoff_pack.py
@@ -57,9 +57,7 @@ def test_current_state_excerpt_is_capped() -> None:
 
 def test_render_handoff_pack_success(tmp_path: Path) -> None:
     _write_minimal_valid_state(tmp_path)
-    current_state_path = (
-        tmp_path / "knowledge_base" / "chatgpt_exoskeleton" / "CURRENT_STATE.md"
-    )
+    current_state_path = tmp_path / "knowledge_base" / "chatgpt_exoskeleton" / "CURRENT_STATE.md"
     current_state_path.write_text(
         """# State
 

--- a/tests/skeleton_core/test_handoff_pack.py
+++ b/tests/skeleton_core/test_handoff_pack.py
@@ -57,7 +57,9 @@ def test_current_state_excerpt_is_capped() -> None:
 
 def test_render_handoff_pack_success(tmp_path: Path) -> None:
     _write_minimal_valid_state(tmp_path)
-    current_state_path = tmp_path / "knowledge_base" / "chatgpt_exoskeleton" / "CURRENT_STATE.md"
+    current_state_path = (
+        tmp_path / "knowledge_base" / "chatgpt_exoskeleton" / "CURRENT_STATE.md"
+    )
     current_state_path.write_text(
         """# State
 

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -202,7 +202,8 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
 
     decide_parser = subparsers.add_parser(
-        "decide", help="Build a Skeleton task decision packet"
+        "decide",
+        help="Build a Skeleton task decision packet",
     )
     _add_decide_args(decide_parser)
 
@@ -246,7 +247,8 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     _add_task_from_text_args(task_from_text_parser)
 
     trace_parser = subparsers.add_parser(
-        "trace-packet", help="Build a Skeleton trace packet"
+        "trace-packet",
+        help="Build a Skeleton trace packet",
     )
     _add_trace_args(trace_parser)
 

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -11,11 +11,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from tools.skeleton_core.checkpoint import render_checkpoint
-from tools.skeleton_core.github_queue import (
-    normalize_issue,
-    normalize_pr,
-    summarize_queue,
-)
+from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.handoff_pack import render_handoff_pack
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.queue_classifier import classify_queue_items
@@ -195,10 +191,7 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Path to public-safe queue JSON",
     )
 
-    decide_parser = subparsers.add_parser(
-        "decide",
-        help="Build a Skeleton task decision packet",
-    )
+    decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
 
     handoff_pack_parser = subparsers.add_parser(
@@ -240,10 +233,7 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
     _add_task_from_text_args(task_from_text_parser)
 
-    trace_parser = subparsers.add_parser(
-        "trace-packet",
-        help="Build a Skeleton trace packet",
-    )
+    trace_parser = subparsers.add_parser("trace-packet", help="Build a Skeleton trace packet")
     _add_trace_args(trace_parser)
 
     validate_state_parser = subparsers.add_parser(
@@ -294,10 +284,7 @@ def _run_decide(args: argparse.Namespace) -> int:
         print(exc.json(), flush=True)
         return 2
 
-    print(
-        json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2),
-        flush=True,
-    )
+    print(json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2), flush=True)
     return 0
 
 
@@ -314,10 +301,7 @@ def _run_checkpoint(args: argparse.Namespace) -> int:
 
 def _run_classify_queue(args: argparse.Namespace) -> int:
     result = classify_queue_items(load_queue_items(args.input))
-    print(
-        json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2),
-        flush=True,
-    )
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
     return 0
 
 
@@ -376,10 +360,7 @@ def _run_task_from_text(args: argparse.Namespace) -> int:
         print(exc.json(), flush=True)
         return 2
 
-    print(
-        json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2),
-        flush=True,
-    )
+    print(json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2), flush=True)
     return 0
 
 
@@ -399,10 +380,7 @@ def _run_trace_packet(args: argparse.Namespace) -> int:
 
 def _run_validate_state(args: argparse.Namespace) -> int:
     result = validate_state(args.root)
-    print(
-        json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2),
-        flush=True,
-    )
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
     return 0 if result.ok else 1
 
 

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -154,15 +154,9 @@ def _add_trace_args(parser: argparse.ArgumentParser) -> None:
         default="",
         help="Comma-separated public-safe sources read",
     )
-    parser.add_argument(
-        "--files-changed", default="", help="Comma-separated files changed"
-    )
-    parser.add_argument(
-        "--commands-run", default="", help="Comma-separated commands run"
-    )
-    parser.add_argument(
-        "--blocked-reason", default=None, help="Optional blocked reason"
-    )
+    parser.add_argument("--files-changed", default="", help="Comma-separated files changed")
+    parser.add_argument("--commands-run", default="", help="Comma-separated commands run")
+    parser.add_argument("--blocked-reason", default=None, help="Optional blocked reason")
     parser.add_argument(
         "--private-data-seen",
         action="store_true",
@@ -272,9 +266,7 @@ def _subcommand_parser() -> argparse.ArgumentParser:
 
 
 def _legacy_decide_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Build a Skeleton task decision packet."
-    )
+    parser = argparse.ArgumentParser(description="Build a Skeleton task decision packet.")
     _add_decide_args(parser)
     return parser
 
@@ -336,9 +328,7 @@ def _run_handoff_pack(args: argparse.Namespace) -> int:
 
 def _run_queue_summary(args: argparse.Namespace) -> int:
     print(
-        json.dumps(
-            build_queue_summary_payload(args.input), ensure_ascii=False, indent=2
-        ),
+        json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2),
         flush=True,
     )
     return 0

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 from tools.skeleton_core.checkpoint import render_checkpoint
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
+from tools.skeleton_core.handoff_pack import render_handoff_pack
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.queue_classifier import classify_queue_items
 from tools.skeleton_core.report import render_runner_report_from_trace
@@ -25,6 +26,7 @@ SUBCOMMANDS = {
     "checkpoint",
     "classify-queue",
     "decide",
+    "handoff-pack",
     "queue-summary",
     "runner-report-from-trace",
     "task-from-text",
@@ -192,6 +194,17 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
 
+    handoff_pack_parser = subparsers.add_parser(
+        "handoff-pack",
+        help="Render a compact Skeleton handoff packet",
+    )
+    handoff_pack_parser.add_argument(
+        "--root",
+        default=Path("."),
+        type=Path,
+        help="Repository root to use",
+    )
+
     queue_parser = subparsers.add_parser(
         "queue-summary",
         help="Summarize an offline queue JSON file",
@@ -292,6 +305,11 @@ def _run_classify_queue(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_handoff_pack(args: argparse.Namespace) -> int:
+    print(render_handoff_pack(args.root), flush=True)
+    return 0
+
+
 def _run_queue_summary(args: argparse.Namespace) -> int:
     print(
         json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2),
@@ -389,6 +407,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_checkpoint(args)
     if args.command == "classify-queue":
         return _run_classify_queue(args)
+    if args.command == "handoff-pack":
+        return _run_handoff_pack(args)
     if args.command == "queue-summary":
         return _run_queue_summary(args)
     if args.command == "runner-report-from-trace":

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -11,7 +11,11 @@ from typing import Any
 from pydantic import ValidationError
 
 from tools.skeleton_core.checkpoint import render_checkpoint
-from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
+from tools.skeleton_core.github_queue import (
+    normalize_issue,
+    normalize_pr,
+    summarize_queue,
+)
 from tools.skeleton_core.handoff_pack import render_handoff_pack
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.queue_classifier import classify_queue_items
@@ -150,9 +154,15 @@ def _add_trace_args(parser: argparse.ArgumentParser) -> None:
         default="",
         help="Comma-separated public-safe sources read",
     )
-    parser.add_argument("--files-changed", default="", help="Comma-separated files changed")
-    parser.add_argument("--commands-run", default="", help="Comma-separated commands run")
-    parser.add_argument("--blocked-reason", default=None, help="Optional blocked reason")
+    parser.add_argument(
+        "--files-changed", default="", help="Comma-separated files changed"
+    )
+    parser.add_argument(
+        "--commands-run", default="", help="Comma-separated commands run"
+    )
+    parser.add_argument(
+        "--blocked-reason", default=None, help="Optional blocked reason"
+    )
     parser.add_argument(
         "--private-data-seen",
         action="store_true",
@@ -191,7 +201,9 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Path to public-safe queue JSON",
     )
 
-    decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
+    decide_parser = subparsers.add_parser(
+        "decide", help="Build a Skeleton task decision packet"
+    )
     _add_decide_args(decide_parser)
 
     handoff_pack_parser = subparsers.add_parser(
@@ -233,7 +245,9 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
     _add_task_from_text_args(task_from_text_parser)
 
-    trace_parser = subparsers.add_parser("trace-packet", help="Build a Skeleton trace packet")
+    trace_parser = subparsers.add_parser(
+        "trace-packet", help="Build a Skeleton trace packet"
+    )
     _add_trace_args(trace_parser)
 
     validate_state_parser = subparsers.add_parser(
@@ -256,7 +270,9 @@ def _subcommand_parser() -> argparse.ArgumentParser:
 
 
 def _legacy_decide_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Build a Skeleton task decision packet.")
+    parser = argparse.ArgumentParser(
+        description="Build a Skeleton task decision packet."
+    )
     _add_decide_args(parser)
     return parser
 
@@ -284,7 +300,10 @@ def _run_decide(args: argparse.Namespace) -> int:
         print(exc.json(), flush=True)
         return 2
 
-    print(json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2), flush=True)
+    print(
+        json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2),
+        flush=True,
+    )
     return 0
 
 
@@ -301,7 +320,10 @@ def _run_checkpoint(args: argparse.Namespace) -> int:
 
 def _run_classify_queue(args: argparse.Namespace) -> int:
     result = classify_queue_items(load_queue_items(args.input))
-    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    print(
+        json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2),
+        flush=True,
+    )
     return 0
 
 
@@ -312,7 +334,9 @@ def _run_handoff_pack(args: argparse.Namespace) -> int:
 
 def _run_queue_summary(args: argparse.Namespace) -> int:
     print(
-        json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2),
+        json.dumps(
+            build_queue_summary_payload(args.input), ensure_ascii=False, indent=2
+        ),
         flush=True,
     )
     return 0
@@ -360,7 +384,10 @@ def _run_task_from_text(args: argparse.Namespace) -> int:
         print(exc.json(), flush=True)
         return 2
 
-    print(json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2), flush=True)
+    print(
+        json.dumps(build_decision_payload(packet), ensure_ascii=False, indent=2),
+        flush=True,
+    )
     return 0
 
 
@@ -380,7 +407,10 @@ def _run_trace_packet(args: argparse.Namespace) -> int:
 
 def _run_validate_state(args: argparse.Namespace) -> int:
     result = validate_state(args.root)
-    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    print(
+        json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2),
+        flush=True,
+    )
     return 0 if result.ok else 1
 
 

--- a/tools/skeleton_core/handoff_pack.py
+++ b/tools/skeleton_core/handoff_pack.py
@@ -1,0 +1,101 @@
+"""Compact public-safe handoff pack rendering for Skeleton branches."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.skeleton_core.state_validator import StateValidationResult, validate_state
+
+AVAILABLE_COMMANDS = (
+    "validate-state",
+    "task-from-text",
+    "decide",
+    "work-packet",
+    "checkpoint",
+    "classify-queue",
+    "queue-summary",
+    "trace-packet",
+    "runner-report-from-trace",
+)
+
+CURRENT_STATE_PATH = Path("knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md")
+EXCERPT_HEADINGS = (
+    "## Current state",
+    "## Active GitHub queue",
+    "## Next practical step",
+)
+
+
+def _format_list(values: list[str]) -> str:
+    if not values:
+        return "- none"
+    return "\n".join(f"- {value}" for value in values)
+
+
+def _format_missing_anchors(result: StateValidationResult) -> str:
+    if not result.missing_anchors:
+        return "- none"
+    return "\n".join(
+        f"- {missing.path}: {missing.anchor}" for missing in result.missing_anchors
+    )
+
+
+def _extract_heading_section(content: str, heading: str) -> str:
+    marker = f"\n{heading}\n"
+    start = content.find(marker)
+    if start == -1:
+        if content.startswith(f"{heading}\n"):
+            start = 0
+        else:
+            return ""
+    else:
+        start += 1
+
+    next_heading = content.find("\n## ", start + len(heading))
+    if next_heading == -1:
+        return content[start:].strip()
+    return content[start:next_heading].strip()
+
+
+def current_state_excerpt(content: str, max_chars: int = 2400) -> str:
+    """Extract a compact excerpt from CURRENT_STATE content."""
+    sections = [
+        section
+        for heading in EXCERPT_HEADINGS
+        if (section := _extract_heading_section(content, heading))
+    ]
+    excerpt = "\n\n".join(sections).strip()
+    if not excerpt:
+        excerpt = "CURRENT_STATE excerpt unavailable"
+    if len(excerpt) > max_chars:
+        return excerpt[: max_chars - 1].rstrip() + "…"
+    return excerpt
+
+
+def render_handoff_pack(root: Path) -> str:
+    """Render a compact public-safe handoff pack for the next branch."""
+    root = root.resolve()
+    validation = validate_state(root)
+    current_state_path = root / CURRENT_STATE_PATH
+    if current_state_path.is_file():
+        excerpt = current_state_excerpt(current_state_path.read_text(encoding="utf-8"))
+    else:
+        excerpt = "CURRENT_STATE excerpt unavailable"
+
+    return "\n".join(
+        [
+            "skeleton_handoff_pack",
+            "state_validation",
+            f"ok: {str(validation.ok).lower()}",
+            "missing_files",
+            _format_list(validation.missing_files),
+            "missing_anchors",
+            _format_missing_anchors(validation),
+            "current_state_excerpt",
+            excerpt,
+            "available_commands",
+            _format_list(list(AVAILABLE_COMMANDS)),
+            "next_recommended_step",
+            "Run validate-state, create a work-packet for the real task, then checkpoint durable results. Use classify-queue when queue hygiene is needed and CI as the default validation source.",
+        ]
+    )

--- a/tools/skeleton_core/handoff_pack.py
+++ b/tools/skeleton_core/handoff_pack.py
@@ -96,6 +96,10 @@ def render_handoff_pack(root: Path) -> str:
             "available_commands",
             _format_list(list(AVAILABLE_COMMANDS)),
             "next_recommended_step",
-            "Run validate-state, create a work-packet for the real task, then checkpoint durable results. Use classify-queue when queue hygiene is needed and CI as the default validation source.",
+            (
+                "Run validate-state, create a work-packet for the real task, "
+                "then checkpoint durable results. Use classify-queue when queue hygiene "
+                "is needed and CI as the default validation source."
+            ),
         ]
     )

--- a/tools/skeleton_core/handoff_pack.py
+++ b/tools/skeleton_core/handoff_pack.py
@@ -35,9 +35,7 @@ def _format_list(values: list[str]) -> str:
 def _format_missing_anchors(result: StateValidationResult) -> str:
     if not result.missing_anchors:
         return "- none"
-    return "\n".join(
-        f"- {missing.path}: {missing.anchor}" for missing in result.missing_anchors
-    )
+    return "\n".join(f"- {missing.path}: {missing.anchor}" for missing in result.missing_anchors)
 
 
 def _extract_heading_section(content: str, heading: str) -> str:


### PR DESCRIPTION
## Summary

Adds a local offline `handoff-pack` command that emits a compact public-safe handoff packet for the next ChatGPT branch:

```bash
python -m tools.skeleton_core.cli handoff-pack
python -m tools.skeleton_core.cli handoff-pack --root .
```

## Changed files

```text
tools/skeleton_core/handoff_pack.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_handoff_pack.py
tests/skeleton_core/test_cli_handoff_pack.py
```

## Behavior

Output sections:

```text
skeleton_handoff_pack
state_validation
current_state_excerpt
available_commands
next_recommended_step
```

It reuses existing Skeleton state validation and reads a compact excerpt from:

```text
knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
```

## CI result

GitHub Actions run on PR head `82d414651bd1f9dfbe01cd7eb203a2418095a3ee`:

```text
Workflow: Skeleton Core
Run: 25403326633
Status: completed
Conclusion: success
Job: Validate Skeleton core -> success
```

Completed steps:

```text
Check out repository
Set up Python
Install dependencies
Run tests
Run Ruff
Run Black check
Validate Skeleton state
```

Validation details from CI:

```text
pytest: 119 passed
ruff: All checks passed
black --check: success
validate-state: success
```

## Safety note

Local read-only Skeleton CLI/test-only change. No runtime behavior changes. No file writes from handoff-pack. No GitHub/API/network calls from the CLI.

## Related issue

Implements #51.