### PR TITLE
Externalizer v1 pr-status reader

### DIFF
--- a/tests/fixtures/pr_status_sample_black_failed.json
+++ b/tests/fixtures/pr_status_sample_black_failed.json
@@ -1,0 +1,24 @@
+{
+  "pr_number": 52,
+  "title": "Externalizer v1 handoff-pack CLI",
+  "state": "open",
+  "mergeable": true,
+  "draft": false,
+  "head_sha": "6a7f86e06231c8c624bdf6796eb66f522b89d0fd",
+  "workflow_runs": [
+    {
+      "name": "Skeleton Core",
+      "status": "completed",
+      "conclusion": "failure"
+    }
+  ],
+  "jobs": [
+    {
+      "name": "Validate Skeleton core",
+      "status": "completed",
+      "conclusion": "failure",
+      "failed_step": "Run Black check"
+    }
+  ],
+  "log_excerpt": "would reformat /home/runner/work/jeeves/jeeves/tests/skeleton_core/test_handoff_pack.py\nwould reformat /home/runner/work/jeeves/jeeves/tools/skeleton_core/handoff_pack.py\nOh no! 2 files would be reformatted."
+}

--- a/tests/fixtures/pr_status_sample_green.json
+++ b/tests/fixtures/pr_status_sample_green.json
@@ -1,0 +1,24 @@
+{
+  "pr_number": 52,
+  "title": "Externalizer v1 handoff-pack CLI",
+  "state": "open",
+  "mergeable": true,
+  "draft": false,
+  "head_sha": "82d414651bd1f9dfbe01cd7eb203a2418095a3ee",
+  "workflow_runs": [
+    {
+      "name": "Skeleton Core",
+      "status": "completed",
+      "conclusion": "success"
+    }
+  ],
+  "jobs": [
+    {
+      "name": "Validate Skeleton core",
+      "status": "completed",
+      "conclusion": "success",
+      "failed_step": null
+    }
+  ],
+  "log_excerpt": "pytest: 119 passed\nruff: All checks passed\nblack --check: success\nvalidate-state: success"
+}

--- a/tests/skeleton_core/test_cli_pr_status.py
+++ b/tests/skeleton_core/test_cli_pr_status.py
@@ -1,0 +1,29 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def test_cli_pr_status_green_fixture(capsys) -> None:
+    exit_code = main(["pr-status", "--input", "tests/fixtures/pr_status_sample_green.json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["pr_number"] == 52
+    assert payload["status"] == "ready_to_merge"
+    assert payload["ci_state"] == "success"
+    assert payload["blockers"] == []
+
+
+def test_cli_pr_status_black_failed_fixture(capsys) -> None:
+    exit_code = main(["pr-status", "--input", "tests/fixtures/pr_status_sample_black_failed.json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["status"] == "needs_fix"
+    assert payload["ci_state"] == "failure"
+    assert any("Run Black check" in blocker for blocker in payload["blockers"])
+    assert any("Black formatting check failed" in blocker for blocker in payload["blockers"])

--- a/tests/skeleton_core/test_pr_status.py
+++ b/tests/skeleton_core/test_pr_status.py
@@ -1,0 +1,96 @@
+from tools.skeleton_core.pr_status import PRStatusInput, build_pr_status
+
+
+def test_pr_status_ready_to_merge() -> None:
+    result = build_pr_status(
+        PRStatusInput(
+            pr_number=52,
+            title="Ready PR",
+            state="open",
+            mergeable=True,
+            draft=False,
+            workflow_runs=[{"name": "Skeleton Core", "status": "completed", "conclusion": "success"}],
+            jobs=[{"name": "Validate Skeleton core", "status": "completed", "conclusion": "success"}],
+        )
+    )
+
+    assert result.status == "ready_to_merge"
+    assert result.ci_state == "success"
+    assert result.blockers == []
+
+
+def test_pr_status_draft_blocks() -> None:
+    result = build_pr_status(
+        PRStatusInput(
+            pr_number=53,
+            title="Draft PR",
+            state="open",
+            mergeable=True,
+            draft=True,
+        )
+    )
+
+    assert result.status == "blocked"
+    assert result.blockers == ["PR is draft"]
+
+
+def test_pr_status_waiting_for_ci() -> None:
+    result = build_pr_status(
+        PRStatusInput(
+            pr_number=54,
+            title="Pending PR",
+            state="open",
+            mergeable=True,
+            draft=False,
+            workflow_runs=[{"name": "Skeleton Core", "status": "in_progress", "conclusion": None}],
+        )
+    )
+
+    assert result.status == "waiting_for_ci"
+    assert result.ci_state == "pending"
+
+
+def test_pr_status_black_failure_from_log_excerpt() -> None:
+    result = build_pr_status(
+        PRStatusInput(
+            pr_number=55,
+            title="Black failed PR",
+            state="open",
+            mergeable=True,
+            draft=False,
+            workflow_runs=[{"name": "Skeleton Core", "status": "completed", "conclusion": "failure"}],
+            jobs=[
+                {
+                    "name": "Validate Skeleton core",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "failed_step": "Run Black check",
+                }
+            ],
+            log_excerpt=(
+                "would reformat /repo/tests/skeleton_core/test_handoff_pack.py\n"
+                "would reformat /repo/tools/skeleton_core/handoff_pack.py"
+            ),
+        )
+    )
+
+    assert result.status == "needs_fix"
+    assert result.ci_state == "failure"
+    assert "Job failed: Validate Skeleton core / Run Black check" in result.blockers
+    assert any("Black formatting check failed" in blocker for blocker in result.blockers)
+    assert any("test_handoff_pack.py" in blocker for blocker in result.blockers)
+
+
+def test_pr_status_unknown_without_ci_data() -> None:
+    result = build_pr_status(
+        PRStatusInput(
+            pr_number=56,
+            title="Ambiguous PR",
+            state="open",
+            mergeable=True,
+            draft=False,
+        )
+    )
+
+    assert result.status == "unknown_needs_review"
+    assert result.ci_state == "unknown"

--- a/tests/skeleton_core/test_pr_status.py
+++ b/tests/skeleton_core/test_pr_status.py
@@ -9,8 +9,16 @@ def test_pr_status_ready_to_merge() -> None:
             state="open",
             mergeable=True,
             draft=False,
-            workflow_runs=[{"name": "Skeleton Core", "status": "completed", "conclusion": "success"}],
-            jobs=[{"name": "Validate Skeleton core", "status": "completed", "conclusion": "success"}],
+            workflow_runs=[
+                {"name": "Skeleton Core", "status": "completed", "conclusion": "success"}
+            ],
+            jobs=[
+                {
+                    "name": "Validate Skeleton core",
+                    "status": "completed",
+                    "conclusion": "success",
+                }
+            ],
         )
     )
 
@@ -42,7 +50,9 @@ def test_pr_status_waiting_for_ci() -> None:
             state="open",
             mergeable=True,
             draft=False,
-            workflow_runs=[{"name": "Skeleton Core", "status": "in_progress", "conclusion": None}],
+            workflow_runs=[
+                {"name": "Skeleton Core", "status": "in_progress", "conclusion": None}
+            ],
         )
     )
 
@@ -58,7 +68,9 @@ def test_pr_status_black_failure_from_log_excerpt() -> None:
             state="open",
             mergeable=True,
             draft=False,
-            workflow_runs=[{"name": "Skeleton Core", "status": "completed", "conclusion": "failure"}],
+            workflow_runs=[
+                {"name": "Skeleton Core", "status": "completed", "conclusion": "failure"}
+            ],
             jobs=[
                 {
                     "name": "Validate Skeleton core",

--- a/tests/skeleton_core/test_pr_status.py
+++ b/tests/skeleton_core/test_pr_status.py
@@ -50,9 +50,7 @@ def test_pr_status_waiting_for_ci() -> None:
             state="open",
             mergeable=True,
             draft=False,
-            workflow_runs=[
-                {"name": "Skeleton Core", "status": "in_progress", "conclusion": None}
-            ],
+            workflow_runs=[{"name": "Skeleton Core", "status": "in_progress", "conclusion": None}],
         )
     )
 

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -14,6 +14,7 @@ from tools.skeleton_core.checkpoint import render_checkpoint
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.handoff_pack import render_handoff_pack
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
+from tools.skeleton_core.pr_status import PRStatusInput, build_pr_status
 from tools.skeleton_core.queue_classifier import classify_queue_items
 from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
@@ -27,6 +28,7 @@ SUBCOMMANDS = {
     "classify-queue",
     "decide",
     "handoff-pack",
+    "pr-status",
     "queue-summary",
     "runner-report-from-trace",
     "task-from-text",
@@ -56,6 +58,11 @@ def load_queue_items(input_path: Path) -> list[dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("queue input must be a JSON list")
     return raw_items
+
+
+def load_pr_status_input(input_path: Path) -> PRStatusInput:
+    """Load public-safe PR status input from JSON."""
+    return PRStatusInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def build_queue_summary_payload(input_path: Path) -> dict[str, int]:
@@ -205,6 +212,17 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Repository root to use",
     )
 
+    pr_status_parser = subparsers.add_parser(
+        "pr-status",
+        help="Build a deterministic PR status packet from public-safe JSON",
+    )
+    pr_status_parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to public-safe PR status JSON",
+    )
+
     queue_parser = subparsers.add_parser(
         "queue-summary",
         help="Summarize an offline queue JSON file",
@@ -310,6 +328,16 @@ def _run_handoff_pack(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_pr_status(args: argparse.Namespace) -> int:
+    try:
+        result = build_pr_status(load_pr_status_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_queue_summary(args: argparse.Namespace) -> int:
     print(
         json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2),
@@ -409,6 +437,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_classify_queue(args)
     if args.command == "handoff-pack":
         return _run_handoff_pack(args)
+    if args.command == "pr-status":
+        return _run_pr_status(args)
     if args.command == "queue-summary":
         return _run_queue_summary(args)
     if args.command == "runner-report-from-trace":

--- a/tools/skeleton_core/pr_status.py
+++ b/tools/skeleton_core/pr_status.py
@@ -1,0 +1,196 @@
+"""Deterministic PR status reader for public-safe exported GitHub/CI data."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PRStatusValue = Literal[
+    "ready_to_merge",
+    "blocked",
+    "needs_fix",
+    "waiting_for_ci",
+    "unknown_needs_review",
+]
+CIStateValue = Literal["success", "failure", "pending", "unknown"]
+
+PENDING_STATUSES = {"queued", "in_progress", "requested", "pending", "waiting"}
+FAILURE_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required", "startup_failure"}
+SUCCESS_CONCLUSIONS = {"success", "skipped", "neutral"}
+
+
+class WorkflowRunStatus(BaseModel):
+    """Public-safe workflow run status export."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    status: str
+    conclusion: str | None = None
+
+
+class JobStatus(BaseModel):
+    """Public-safe workflow job status export."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    status: str
+    conclusion: str | None = None
+    failed_step: str | None = None
+
+
+class PRStatusInput(BaseModel):
+    """Public-safe PR/CI status export."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pr_number: int
+    title: str
+    state: str
+    mergeable: bool | None = None
+    draft: bool = False
+    head_sha: str | None = None
+    workflow_runs: list[WorkflowRunStatus] = Field(default_factory=list)
+    jobs: list[JobStatus] = Field(default_factory=list)
+    log_excerpt: str | None = None
+
+
+class PRStatusResult(BaseModel):
+    """Deterministic PR status decision packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pr_number: int
+    status: PRStatusValue
+    summary: str
+    blockers: list[str]
+    next_action: str
+    ci_state: CIStateValue
+
+
+def _casefold(value: str | None) -> str:
+    return (value or "").casefold()
+
+
+def _has_pending_status(packet: PRStatusInput) -> bool:
+    statuses = [_casefold(run.status) for run in packet.workflow_runs]
+    statuses.extend(_casefold(job.status) for job in packet.jobs)
+    return any(status in PENDING_STATUSES for status in statuses)
+
+
+def _failed_workflow_blockers(packet: PRStatusInput) -> list[str]:
+    blockers: list[str] = []
+    for run in packet.workflow_runs:
+        if _casefold(run.conclusion) in FAILURE_CONCLUSIONS:
+            blockers.append(f"Workflow failed: {run.name}")
+    for job in packet.jobs:
+        if _casefold(job.conclusion) in FAILURE_CONCLUSIONS:
+            if job.failed_step:
+                blockers.append(f"Job failed: {job.name} / {job.failed_step}")
+            else:
+                blockers.append(f"Job failed: {job.name}")
+    return blockers
+
+
+def _black_format_blockers(log_excerpt: str | None) -> list[str]:
+    if not log_excerpt:
+        return []
+    if "would reformat" not in log_excerpt.casefold():
+        return []
+
+    paths = re.findall(r"would reformat\s+([^\n\r]+)", log_excerpt)
+    if not paths:
+        return ["Black formatting check failed: files would be reformatted"]
+
+    clean_paths = [path.strip() for path in paths]
+    return ["Black formatting check failed: " + ", ".join(clean_paths)]
+
+
+def _all_ci_success(packet: PRStatusInput) -> bool:
+    if not packet.workflow_runs and not packet.jobs:
+        return False
+    conclusions = [_casefold(run.conclusion) for run in packet.workflow_runs]
+    conclusions.extend(_casefold(job.conclusion) for job in packet.jobs)
+    return all(conclusion in SUCCESS_CONCLUSIONS for conclusion in conclusions if conclusion)
+
+
+def build_pr_status(packet: PRStatusInput) -> PRStatusResult:
+    """Build a deterministic status packet from public-safe PR/CI export data."""
+    if packet.draft:
+        return PRStatusResult(
+            pr_number=packet.pr_number,
+            status="blocked",
+            summary=f"PR #{packet.pr_number} is draft.",
+            blockers=["PR is draft"],
+            next_action="Mark the PR ready for review before merge consideration.",
+            ci_state="unknown",
+        )
+
+    if _casefold(packet.state) != "open":
+        return PRStatusResult(
+            pr_number=packet.pr_number,
+            status="blocked",
+            summary=f"PR #{packet.pr_number} is not open.",
+            blockers=[f"PR state is {packet.state}"],
+            next_action="Review PR state before taking further action.",
+            ci_state="unknown",
+        )
+
+    if packet.mergeable is False:
+        return PRStatusResult(
+            pr_number=packet.pr_number,
+            status="blocked",
+            summary=f"PR #{packet.pr_number} is not mergeable.",
+            blockers=["PR is not mergeable"],
+            next_action="Resolve merge conflicts or branch protection blockers.",
+            ci_state="unknown",
+        )
+
+    if _has_pending_status(packet):
+        return PRStatusResult(
+            pr_number=packet.pr_number,
+            status="waiting_for_ci",
+            summary=f"PR #{packet.pr_number} is waiting for CI.",
+            blockers=[],
+            next_action="Wait for GitHub Actions to complete, then re-run pr-status.",
+            ci_state="pending",
+        )
+
+    blockers = _failed_workflow_blockers(packet)
+    blockers.extend(_black_format_blockers(packet.log_excerpt))
+    if blockers:
+        return PRStatusResult(
+            pr_number=packet.pr_number,
+            status="needs_fix",
+            summary=f"PR #{packet.pr_number} has CI blockers.",
+            blockers=blockers,
+            next_action="Fix the listed blocker, push a new commit, and wait for CI.",
+            ci_state="failure",
+        )
+
+    if packet.mergeable is True and _all_ci_success(packet):
+        return PRStatusResult(
+            pr_number=packet.pr_number,
+            status="ready_to_merge",
+            summary=f"PR #{packet.pr_number} is open, mergeable, non-draft, and CI is green.",
+            blockers=[],
+            next_action="Ask Oleksii for explicit merge approval before merging.",
+            ci_state="success",
+        )
+
+    return PRStatusResult(
+        pr_number=packet.pr_number,
+        status="unknown_needs_review",
+        summary=f"PR #{packet.pr_number} status cannot be decided from the provided export.",
+        blockers=["Insufficient or ambiguous PR/CI status data"],
+        next_action="Fetch/update public-safe PR and CI status export, then re-run pr-status.",
+        ci_state="unknown",
+    )
+
+
+def build_pr_status_from_raw(raw: dict[str, Any]) -> PRStatusResult:
+    """Validate raw JSON-compatible data and build a deterministic PR status result."""
+    return build_pr_status(PRStatusInput.model_validate(raw))


### PR DESCRIPTION
## Summary

Adds a local offline `pr-status` command that turns public-safe PR/CI/job-log exports into a deterministic status packet:

```bash
python -m tools.skeleton_core.cli pr-status --input tests/fixtures/pr_status_sample_green.json
python -m tools.skeleton_core.cli pr-status --input tests/fixtures/pr_status_sample_black_failed.json
```

## Changed files

```text
tools/skeleton_core/pr_status.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_pr_status.py
tests/skeleton_core/test_cli_pr_status.py
tests/fixtures/pr_status_sample_green.json
tests/fixtures/pr_status_sample_black_failed.json
```

## Behavior

Allowed status values:

```text
ready_to_merge
blocked
needs_fix
waiting_for_ci
unknown_needs_review
```

It identifies:

```text
- draft PRs as blocked
- pending CI as waiting_for_ci
- failed workflows/jobs as needs_fix
- Black formatting failures from public-safe log excerpts
- open/mergeable/non-draft green CI as ready_to_merge
```

## CI result

GitHub Actions run on PR head `f048aa979189647f69f9372f08b32d44f80ddbb1`:

```text
Workflow: Skeleton Core
Run: 25405435005
Status: completed
Conclusion: success
Job: Validate Skeleton core -> success
```

Completed steps:

```text
Run tests: success
Run Ruff: success
Run Black check: success
Validate Skeleton state: success
```

Validation details from CI:

```text
pytest: 126 passed
ruff: All checks passed
black --check: success
validate-state: success
```

## Safety note

Local read-only Skeleton CLI/test-only change. No runtime behavior changes. No file writes. No GitHub/API/network calls from the CLI. No merge/deploy authority.

## Related issue

Implements #53.