### PR TITLE
Externalizer v1 job-log summarizer

### DIFF
--- a/tests/fixtures/job_log_black_failed.txt
+++ b/tests/fixtures/job_log_black_failed.txt
@@ -1,0 +1,5 @@
+Run Black check
+python -m black --check tools/skeleton_core tests/skeleton_core
+would reformat /home/runner/work/jeeves/jeeves/tests/skeleton_core/test_pr_status.py
+Oh no! 1 file would be reformatted, 30 files would be left unchanged.
+##[error]Process completed with exit code 1.

--- a/tests/fixtures/job_log_success.txt
+++ b/tests/fixtures/job_log_success.txt
@@ -1,0 +1,10 @@
+Run tests
+python -m pytest -q
+126 passed in 0.71s
+Run Ruff
+All checks passed!
+Run Black check
+All done! ✨ 🍰 ✨
+30 files would be left unchanged.
+Validate Skeleton state
+"ok": true

--- a/tests/fixtures/job_log_tests_failed.txt
+++ b/tests/fixtures/job_log_tests_failed.txt
@@ -1,0 +1,8 @@
+Run tests
+python -m pytest -q
+=================================== FAILURES ===================================
+FAILED tests/skeleton_core/test_job_log_summary.py::test_detects_pytest_failure - AssertionError
+assert 'actual' == 'expected'
+=========================== short test summary info ===========================
+FAILED tests/skeleton_core/test_job_log_summary.py::test_detects_pytest_failure
+##[error]Process completed with exit code 1.

--- a/tests/skeleton_core/test_cli_pr_status.py
+++ b/tests/skeleton_core/test_cli_pr_status.py
@@ -27,3 +27,26 @@ def test_cli_pr_status_black_failed_fixture(capsys) -> None:
     assert payload["ci_state"] == "failure"
     assert any("Run Black check" in blocker for blocker in payload["blockers"])
     assert any("Black formatting check failed" in blocker for blocker in payload["blockers"])
+
+
+def test_cli_job_log_summary_black_fixture(capsys) -> None:
+    exit_code = main(["job-log-summary", "--input", "tests/fixtures/job_log_black_failed.txt"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["status"] == "needs_fix"
+    assert payload["detected_failure_type"] == "black_formatting"
+    assert payload["failed_step"] == "Run Black check"
+
+
+def test_cli_job_log_summary_success_fixture(capsys) -> None:
+    exit_code = main(["job-log-summary", "--input", "tests/fixtures/job_log_success.txt"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["status"] == "no_failure_detected"
+    assert payload["evidence_lines"] == []

--- a/tests/skeleton_core/test_job_log_summary.py
+++ b/tests/skeleton_core/test_job_log_summary.py
@@ -2,14 +2,12 @@ from tools.skeleton_core.job_log_summary import summarize_job_log
 
 
 def test_detects_black_formatting_failure() -> None:
-    summary = summarize_job_log(
-        """
+    summary = summarize_job_log("""
         Run Black check
         would reformat /repo/tests/skeleton_core/test_pr_status.py
         Oh no! 1 file would be reformatted, 30 files would be left unchanged.
         ##[error]Process completed with exit code 1.
-        """
-    )
+        """)
 
     assert summary.status == "needs_fix"
     assert summary.detected_failure_type == "black_formatting"
@@ -19,15 +17,13 @@ def test_detects_black_formatting_failure() -> None:
 
 
 def test_detects_pytest_failure() -> None:
-    summary = summarize_job_log(
-        """
+    summary = summarize_job_log("""
         Run tests
         =================================== FAILURES ===================================
         FAILED tests/skeleton_core/test_job_log_summary.py::test_detects_pytest_failure
         assert 'actual' == 'expected'
         =========================== short test summary info ===========================
-        """
-    )
+        """)
 
     assert summary.status == "needs_fix"
     assert summary.detected_failure_type == "tests_failed"
@@ -36,16 +32,14 @@ def test_detects_pytest_failure() -> None:
 
 
 def test_no_failure_detected_for_clean_log() -> None:
-    summary = summarize_job_log(
-        """
+    summary = summarize_job_log("""
         Run tests
         126 passed in 0.71s
         Run Ruff
         All checks passed!
         Run Black check
         All done!
-        """
-    )
+        """)
 
     assert summary.status == "no_failure_detected"
     assert summary.detected_failure_type == "unknown"
@@ -53,13 +47,11 @@ def test_no_failure_detected_for_clean_log() -> None:
 
 
 def test_unknown_failure_when_pattern_is_not_known() -> None:
-    summary = summarize_job_log(
-        """
+    summary = summarize_job_log("""
         Run custom step
         something unexpected happened
         ##[error]Process completed with exit code 1.
-        """
-    )
+        """)
 
     assert summary.status == "unknown_needs_review"
     assert summary.detected_failure_type == "unknown"

--- a/tests/skeleton_core/test_job_log_summary.py
+++ b/tests/skeleton_core/test_job_log_summary.py
@@ -1,0 +1,66 @@
+from tools.skeleton_core.job_log_summary import summarize_job_log
+
+
+def test_detects_black_formatting_failure() -> None:
+    summary = summarize_job_log(
+        """
+        Run Black check
+        would reformat /repo/tests/skeleton_core/test_pr_status.py
+        Oh no! 1 file would be reformatted, 30 files would be left unchanged.
+        ##[error]Process completed with exit code 1.
+        """
+    )
+
+    assert summary.status == "needs_fix"
+    assert summary.detected_failure_type == "black_formatting"
+    assert summary.failed_step == "Run Black check"
+    assert summary.affected_files == ["/repo/tests/skeleton_core/test_pr_status.py"]
+    assert any("would reformat" in line for line in summary.evidence_lines)
+
+
+def test_detects_pytest_failure() -> None:
+    summary = summarize_job_log(
+        """
+        Run tests
+        =================================== FAILURES ===================================
+        FAILED tests/skeleton_core/test_job_log_summary.py::test_detects_pytest_failure
+        assert 'actual' == 'expected'
+        =========================== short test summary info ===========================
+        """
+    )
+
+    assert summary.status == "needs_fix"
+    assert summary.detected_failure_type == "tests_failed"
+    assert summary.failed_step == "Run tests"
+    assert "tests/skeleton_core/test_job_log_summary.py" in summary.affected_files
+
+
+def test_no_failure_detected_for_clean_log() -> None:
+    summary = summarize_job_log(
+        """
+        Run tests
+        126 passed in 0.71s
+        Run Ruff
+        All checks passed!
+        Run Black check
+        All done!
+        """
+    )
+
+    assert summary.status == "no_failure_detected"
+    assert summary.detected_failure_type == "unknown"
+    assert summary.evidence_lines == []
+
+
+def test_unknown_failure_when_pattern_is_not_known() -> None:
+    summary = summarize_job_log(
+        """
+        Run custom step
+        something unexpected happened
+        ##[error]Process completed with exit code 1.
+        """
+    )
+
+    assert summary.status == "unknown_needs_review"
+    assert summary.detected_failure_type == "unknown"
+    assert summary.evidence_lines == ["##[error]Process completed with exit code 1."]

--- a/tests/skeleton_core/test_pr_status.py
+++ b/tests/skeleton_core/test_pr_status.py
@@ -108,14 +108,12 @@ def test_pr_status_unknown_without_ci_data() -> None:
 
 
 def test_job_log_summary_detects_black_formatting_failure() -> None:
-    summary = summarize_job_log(
-        """
+    summary = summarize_job_log("""
         Run Black check
         would reformat /repo/tests/skeleton_core/test_pr_status.py
         Oh no! 1 file would be reformatted, 30 files would be left unchanged.
         ##[error]Process completed with exit code 1.
-        """
-    )
+        """)
 
     assert summary.status == "needs_fix"
     assert summary.detected_failure_type == "black_formatting"
@@ -125,15 +123,13 @@ def test_job_log_summary_detects_black_formatting_failure() -> None:
 
 
 def test_job_log_summary_detects_pytest_failure() -> None:
-    summary = summarize_job_log(
-        """
+    summary = summarize_job_log("""
         Run tests
         =================================== FAILURES ===================================
         FAILED tests/skeleton_core/test_job_log_summary.py::test_detects_pytest_failure
         assert 'actual' == 'expected'
         =========================== short test summary info ===========================
-        """
-    )
+        """)
 
     assert summary.status == "needs_fix"
     assert summary.detected_failure_type == "tests_failed"
@@ -142,16 +138,14 @@ def test_job_log_summary_detects_pytest_failure() -> None:
 
 
 def test_job_log_summary_no_failure_detected_for_clean_log() -> None:
-    summary = summarize_job_log(
-        """
+    summary = summarize_job_log("""
         Run tests
         126 passed in 0.71s
         Run Ruff
         All checks passed!
         Run Black check
         All done!
-        """
-    )
+        """)
 
     assert summary.status == "no_failure_detected"
     assert summary.detected_failure_type == "unknown"
@@ -159,13 +153,11 @@ def test_job_log_summary_no_failure_detected_for_clean_log() -> None:
 
 
 def test_job_log_summary_unknown_failure_when_pattern_is_not_known() -> None:
-    summary = summarize_job_log(
-        """
+    summary = summarize_job_log("""
         Run custom step
         something unexpected happened
         ##[error]Process completed with exit code 1.
-        """
-    )
+        """)
 
     assert summary.status == "unknown_needs_review"
     assert summary.detected_failure_type == "unknown"

--- a/tests/skeleton_core/test_pr_status.py
+++ b/tests/skeleton_core/test_pr_status.py
@@ -1,3 +1,4 @@
+from tools.skeleton_core.job_log_summary import summarize_job_log
 from tools.skeleton_core.pr_status import PRStatusInput, build_pr_status
 
 
@@ -104,3 +105,68 @@ def test_pr_status_unknown_without_ci_data() -> None:
 
     assert result.status == "unknown_needs_review"
     assert result.ci_state == "unknown"
+
+
+def test_job_log_summary_detects_black_formatting_failure() -> None:
+    summary = summarize_job_log(
+        """
+        Run Black check
+        would reformat /repo/tests/skeleton_core/test_pr_status.py
+        Oh no! 1 file would be reformatted, 30 files would be left unchanged.
+        ##[error]Process completed with exit code 1.
+        """
+    )
+
+    assert summary.status == "needs_fix"
+    assert summary.detected_failure_type == "black_formatting"
+    assert summary.failed_step == "Run Black check"
+    assert summary.affected_files == ["/repo/tests/skeleton_core/test_pr_status.py"]
+    assert any("would reformat" in line for line in summary.evidence_lines)
+
+
+def test_job_log_summary_detects_pytest_failure() -> None:
+    summary = summarize_job_log(
+        """
+        Run tests
+        =================================== FAILURES ===================================
+        FAILED tests/skeleton_core/test_job_log_summary.py::test_detects_pytest_failure
+        assert 'actual' == 'expected'
+        =========================== short test summary info ===========================
+        """
+    )
+
+    assert summary.status == "needs_fix"
+    assert summary.detected_failure_type == "tests_failed"
+    assert summary.failed_step == "Run tests"
+    assert "tests/skeleton_core/test_job_log_summary.py" in summary.affected_files
+
+
+def test_job_log_summary_no_failure_detected_for_clean_log() -> None:
+    summary = summarize_job_log(
+        """
+        Run tests
+        126 passed in 0.71s
+        Run Ruff
+        All checks passed!
+        Run Black check
+        All done!
+        """
+    )
+
+    assert summary.status == "no_failure_detected"
+    assert summary.detected_failure_type == "unknown"
+    assert summary.evidence_lines == []
+
+
+def test_job_log_summary_unknown_failure_when_pattern_is_not_known() -> None:
+    summary = summarize_job_log(
+        """
+        Run custom step
+        something unexpected happened
+        ##[error]Process completed with exit code 1.
+        """
+    )
+
+    assert summary.status == "unknown_needs_review"
+    assert summary.detected_failure_type == "unknown"
+    assert summary.evidence_lines == ["##[error]Process completed with exit code 1."]

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from tools.skeleton_core.checkpoint import render_checkpoint
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.handoff_pack import render_handoff_pack
+from tools.skeleton_core.job_log_summary import summarize_job_log
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.pr_status import PRStatusInput, build_pr_status
 from tools.skeleton_core.queue_classifier import classify_queue_items
@@ -28,6 +29,7 @@ SUBCOMMANDS = {
     "classify-queue",
     "decide",
     "handoff-pack",
+    "job-log-summary",
     "pr-status",
     "queue-summary",
     "runner-report-from-trace",
@@ -212,6 +214,17 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Repository root to use",
     )
 
+    job_log_parser = subparsers.add_parser(
+        "job-log-summary",
+        help="Summarize a public-safe GitHub Actions job log excerpt",
+    )
+    job_log_parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to public-safe job log text",
+    )
+
     pr_status_parser = subparsers.add_parser(
         "pr-status",
         help="Build a deterministic PR status packet from public-safe JSON",
@@ -328,6 +341,12 @@ def _run_handoff_pack(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_job_log_summary(args: argparse.Namespace) -> int:
+    result = summarize_job_log(args.input.read_text(encoding="utf-8"))
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_pr_status(args: argparse.Namespace) -> int:
     try:
         result = build_pr_status(load_pr_status_input(args.input))
@@ -437,6 +456,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_classify_queue(args)
     if args.command == "handoff-pack":
         return _run_handoff_pack(args)
+    if args.command == "job-log-summary":
+        return _run_job_log_summary(args)
     if args.command == "pr-status":
         return _run_pr_status(args)
     if args.command == "queue-summary":

--- a/tools/skeleton_core/job_log_summary.py
+++ b/tools/skeleton_core/job_log_summary.py
@@ -72,7 +72,10 @@ def _black_summary(lines: list[str]) -> JobLogSummary | None:
         if "would reformat" in line.casefold():
             evidence.append(line)
             affected_files.append(line.split("would reformat", 1)[1].strip())
-        elif "files would be reformatted" in line.casefold() or "file would be reformatted" in line.casefold():
+        elif (
+            "files would be reformatted" in line.casefold()
+            or "file would be reformatted" in line.casefold()
+        ):
             evidence.append(line)
 
     if not evidence:
@@ -96,7 +99,8 @@ def _ruff_summary(lines: list[str]) -> JobLogSummary | None:
         for line in lines
         if re.match(r"^[A-Z][0-9]{3}\b", line)
         or "ruff failed" in line.casefold()
-        or "Found " in line and "error" in line.casefold()
+        or "Found " in line
+        and "error" in line.casefold()
     ]
     if not evidence:
         return None
@@ -148,7 +152,9 @@ def _pytest_summary(lines: list[str]) -> JobLogSummary | None:
 
 
 def _validate_state_summary(lines: list[str]) -> JobLogSummary | None:
-    has_validate_context = any("validate-state" in line or "Validate Skeleton state" in line for line in lines)
+    has_validate_context = any(
+        "validate-state" in line or "Validate Skeleton state" in line for line in lines
+    )
     evidence = [
         line
         for line in lines
@@ -210,7 +216,9 @@ def summarize_job_log(log_text: str) -> JobLogSummary:
     failure_lines = [
         line
         for line in lines
-        if "##[error]" in line or "Process completed with exit code" in line or "error" in line.casefold()
+        if "##[error]" in line
+        or "Process completed with exit code" in line
+        or "error" in line.casefold()
     ]
     if failure_lines:
         return JobLogSummary(

--- a/tools/skeleton_core/job_log_summary.py
+++ b/tools/skeleton_core/job_log_summary.py
@@ -1,0 +1,234 @@
+"""Deterministic summarizer for public-safe GitHub Actions job log excerpts."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+JobLogStatus = Literal["needs_fix", "no_failure_detected", "unknown_needs_review"]
+FailureType = Literal[
+    "black_formatting",
+    "ruff_lint",
+    "tests_failed",
+    "validate_state_failed",
+    "dependency_install_failed",
+    "unknown",
+]
+
+MAX_EVIDENCE_LINES = 8
+
+
+class JobLogSummary(BaseModel):
+    """Deterministic diagnosis packet for a public-safe CI job log excerpt."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: JobLogStatus
+    detected_failure_type: FailureType
+    failed_step: str | None = None
+    summary: str
+    evidence_lines: list[str] = Field(default_factory=list)
+    affected_files: list[str] = Field(default_factory=list)
+    next_action: str
+
+
+def _clean_line(line: str) -> str:
+    """Remove common GitHub Actions timestamp/noise prefixes from one log line."""
+    line = line.lstrip("\ufeff").strip()
+    line = re.sub(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+", "", line)
+    line = re.sub(r"\x1b\[[0-9;]*m", "", line)
+    return line.strip()
+
+
+def _clean_lines(log_text: str) -> list[str]:
+    return [line for raw_line in log_text.splitlines() if (line := _clean_line(raw_line))]
+
+
+def _short_evidence(lines: list[str]) -> list[str]:
+    return lines[:MAX_EVIDENCE_LINES]
+
+
+def _extract_failed_step(lines: list[str]) -> str | None:
+    for line in lines:
+        if "Run Black check" in line:
+            return "Run Black check"
+        if "Run Ruff" in line:
+            return "Run Ruff"
+        if "Run tests" in line or "python -m pytest" in line:
+            return "Run tests"
+        if "Validate Skeleton state" in line or "validate-state" in line:
+            return "Validate Skeleton state"
+        if "Install dependencies" in line or "make install" in line or "pip install" in line:
+            return "Install dependencies"
+    return None
+
+
+def _black_summary(lines: list[str]) -> JobLogSummary | None:
+    affected_files = []
+    evidence = []
+    for line in lines:
+        if "would reformat" in line.casefold():
+            evidence.append(line)
+            affected_files.append(line.split("would reformat", 1)[1].strip())
+        elif "files would be reformatted" in line.casefold() or "file would be reformatted" in line.casefold():
+            evidence.append(line)
+
+    if not evidence:
+        return None
+
+    count = len(affected_files) or 1
+    return JobLogSummary(
+        status="needs_fix",
+        detected_failure_type="black_formatting",
+        failed_step="Run Black check",
+        summary=f"Black formatting failed for {count} file(s).",
+        evidence_lines=_short_evidence(evidence),
+        affected_files=affected_files,
+        next_action="Run Black on the affected files, commit the formatting change, and wait for CI.",
+    )
+
+
+def _ruff_summary(lines: list[str]) -> JobLogSummary | None:
+    evidence = [
+        line
+        for line in lines
+        if re.match(r"^[A-Z][0-9]{3}\b", line)
+        or "ruff failed" in line.casefold()
+        or "Found " in line and "error" in line.casefold()
+    ]
+    if not evidence:
+        return None
+
+    affected_files = []
+    for line in evidence:
+        match = re.search(r"([\w./-]+\.py)(?::\d+)?", line)
+        if match:
+            affected_files.append(match.group(1))
+
+    return JobLogSummary(
+        status="needs_fix",
+        detected_failure_type="ruff_lint",
+        failed_step="Run Ruff",
+        summary="Ruff linting failed.",
+        evidence_lines=_short_evidence(evidence),
+        affected_files=affected_files,
+        next_action="Fix the Ruff lint errors, commit the change, and wait for CI.",
+    )
+
+
+def _pytest_summary(lines: list[str]) -> JobLogSummary | None:
+    evidence = [
+        line
+        for line in lines
+        if line.startswith("FAILED ")
+        or "short test summary info" in line.casefold()
+        or "assert " in line
+        or "= FAILURES =" in line
+    ]
+    if not evidence:
+        return None
+
+    affected_files = []
+    for line in evidence:
+        match = re.search(r"([\w./-]*test[\w./-]*\.py)", line)
+        if match:
+            affected_files.append(match.group(1))
+
+    return JobLogSummary(
+        status="needs_fix",
+        detected_failure_type="tests_failed",
+        failed_step="Run tests",
+        summary="Pytest reported failing tests.",
+        evidence_lines=_short_evidence(evidence),
+        affected_files=affected_files,
+        next_action="Fix the failing tests or implementation, commit the change, and wait for CI.",
+    )
+
+
+def _validate_state_summary(lines: list[str]) -> JobLogSummary | None:
+    has_validate_context = any("validate-state" in line or "Validate Skeleton state" in line for line in lines)
+    evidence = [
+        line
+        for line in lines
+        if "ok: false" in line.casefold()
+        or "missing_files" in line
+        or "missing_anchors" in line
+        or "state validation" in line.casefold()
+    ]
+    if not has_validate_context or not evidence:
+        return None
+
+    return JobLogSummary(
+        status="needs_fix",
+        detected_failure_type="validate_state_failed",
+        failed_step="Validate Skeleton state",
+        summary="Skeleton state validation failed.",
+        evidence_lines=_short_evidence(evidence),
+        affected_files=[],
+        next_action="Fix the missing Skeleton state files or anchors, then rerun validate-state.",
+    )
+
+
+def _dependency_summary(lines: list[str]) -> JobLogSummary | None:
+    evidence = [
+        line
+        for line in lines
+        if "ERROR: Could not" in line
+        or "No matching distribution found" in line
+        or "subprocess-exited-with-error" in line
+        or "make: ***" in line
+    ]
+    if not evidence:
+        return None
+
+    return JobLogSummary(
+        status="needs_fix",
+        detected_failure_type="dependency_install_failed",
+        failed_step="Install dependencies",
+        summary="Dependency installation failed.",
+        evidence_lines=_short_evidence(evidence),
+        affected_files=[],
+        next_action="Fix dependency metadata or installation commands, then rerun CI.",
+    )
+
+
+def summarize_job_log(log_text: str) -> JobLogSummary:
+    """Summarize a public-safe GitHub Actions log excerpt into a diagnosis packet."""
+    lines = _clean_lines(log_text)
+    for detector in (
+        _black_summary,
+        _ruff_summary,
+        _pytest_summary,
+        _validate_state_summary,
+        _dependency_summary,
+    ):
+        if summary := detector(lines):
+            return summary
+
+    failure_lines = [
+        line
+        for line in lines
+        if "##[error]" in line or "Process completed with exit code" in line or "error" in line.casefold()
+    ]
+    if failure_lines:
+        return JobLogSummary(
+            status="unknown_needs_review",
+            detected_failure_type="unknown",
+            failed_step=_extract_failed_step(lines),
+            summary="The log contains a failure, but no known deterministic pattern matched.",
+            evidence_lines=_short_evidence(failure_lines),
+            affected_files=[],
+            next_action="Review the public-safe log excerpt manually and add a detector if repeated.",
+        )
+
+    return JobLogSummary(
+        status="no_failure_detected",
+        detected_failure_type="unknown",
+        failed_step=None,
+        summary="No actionable failure was detected in the provided log excerpt.",
+        evidence_lines=[],
+        affected_files=[],
+        next_action="No fix needed from this log excerpt.",
+    )


### PR DESCRIPTION
## Summary

Adds a local offline `job-log-summary` command that turns public-safe GitHub Actions log excerpts into deterministic diagnosis packets:

```bash
python -m tools.skeleton_core.cli job-log-summary --input tests/fixtures/job_log_black_failed.txt
python -m tools.skeleton_core.cli job-log-summary --input tests/fixtures/job_log_tests_failed.txt
python -m tools.skeleton_core.cli job-log-summary --input tests/fixtures/job_log_success.txt
```

## Changed files

```text
tools/skeleton_core/job_log_summary.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_pr_status.py
tests/skeleton_core/test_cli_pr_status.py
tests/skeleton_core/test_job_log_summary.py
tests/fixtures/job_log_black_failed.txt
tests/fixtures/job_log_tests_failed.txt
tests/fixtures/job_log_success.txt
```

## Behavior

It currently detects:

```text
black_formatting
tests_failed
ruff_lint
validate_state_failed
dependency_install_failed
unknown
```

Allowed status values:

```text
needs_fix
no_failure_detected
unknown_needs_review
```

## CI result

GitHub Actions run on PR head `002c8e320bbe7c28880cdc0f7cc0a02ded3b41ad`:

```text
Workflow: Skeleton Core
Run: 25406576201
Status: completed
Conclusion: success
Job: Validate Skeleton core -> success
```

Completed steps:

```text
Run tests: success
Run Ruff: success
Run Black check: success
Validate Skeleton state: success
```

Validation details from CI:

```text
pytest: passed
ruff: passed
black --check: passed
validate-state: passed
```

## Safety note

Local read-only Skeleton CLI/test-only change. No runtime behavior changes. No file writes. No GitHub/API/network calls from the CLI. No merge/deploy authority.

## Related issue

Implements #56.