### PR TITLE
Add generic project-state layer

### DIFF
--- a/knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
+++ b/knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
@@ -17,6 +17,7 @@ Current work is the ChatGPT-side external control/support layer, not Jeeves runt
 Skeleton Stage 1 is complete enough for active use.
 Skeleton Stage 2+ is active as practical productivity growth.
 Externalizer v1 includes local offline `work-packet`, `validate-state`, `checkpoint`, `classify-queue`, `handoff-pack`, `pr-status`, and `job-log-summary` commands.
+Project-state layer exists as the intended public-safe mechanism for applying Skeleton to BauClock and other projects without mixing context with СК/Jeeves.
 Skeleton core has GitHub Actions CI validation.
 Gemini Adapter is a Stage 3 candidate only, with evidence-only mock tests recorded in #40. It is not implemented.
 
@@ -67,10 +68,24 @@ Do not add abstract policy or runtime behavior by default.
 #56 job-log-summary CLI -> merged, SHA aaad43ae5e3620012e3786988edda9c5bcb76ed8
 ```
 
+## Project-state layer
+
+```text
+knowledge_base/project_state/PROJECT_STATE_TEMPLATE.md
+knowledge_base/project_state/BAUCLOCK_PROJECT_STATE.md
+```
+
+Purpose:
+
+```text
+Use Skeleton tools for BauClock and other products while keeping each target product state separate from СК/Jeeves canon.
+```
+
 ## Active GitHub queue
 
 ```text
 #40 [skeleton] Stage 2 practical exoskeleton growth
+#57 [agent-task-yellow] Add generic project-state template
 ```
 
 Closed/completed Skeleton references:
@@ -143,6 +158,8 @@ knowledge_base/CHATGPT_EXOSKELETON.md
 knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md
 knowledge_base/jeeves_runtime/START_HERE.md
 knowledge_base/assistant_startup_prompt.md
+knowledge_base/project_state/PROJECT_STATE_TEMPLATE.md
+knowledge_base/project_state/BAUCLOCK_PROJECT_STATE.md
 tools/skeleton_core/
 .github/workflows/skeleton-core.yml
 ```
@@ -206,6 +223,13 @@ Job log summary:
 python -m tools.skeleton_core.cli job-log-summary --input tests/fixtures/job_log_black_failed.txt
 python -m tools.skeleton_core.cli job-log-summary --input tests/fixtures/job_log_tests_failed.txt
 python -m tools.skeleton_core.cli job-log-summary --input tests/fixtures/job_log_success.txt
+```
+
+Project state files:
+
+```text
+knowledge_base/project_state/PROJECT_STATE_TEMPLATE.md
+knowledge_base/project_state/BAUCLOCK_PROJECT_STATE.md
 ```
 
 State validation:
@@ -272,6 +296,7 @@ Current validated behavior:
 - handoff-pack emits compact branch/session handoff with validation and CURRENT_STATE excerpt
 - pr-status converts public-safe PR/CI/job-log exports into deterministic status packets
 - job-log-summary converts public-safe GitHub Actions log excerpts into deterministic diagnosis packets
+- project-state files keep target project context separate from СК/Jeeves canon
 - validate-state checks required Skeleton boot/current-state files and anchors
 - normal docs task -> YELLOW / RUNNER_YELLOW
 - code-like task -> ORANGE / RUNNER_ORANGE
@@ -302,6 +327,7 @@ Skeleton CI: #49/#50 PASS; PR CI run 25397481083 completed successfully.
 Handoff-pack CLI: #51/#52 PASS; CI run 25403326633, pytest 119 passed, ruff passed, black passed, validate-state passed.
 PR-status reader CLI: #53/#55 PASS; CI run 25405435005, pytest 126 passed, ruff passed, black passed, validate-state passed.
 Job-log-summary CLI: #56 PASS; CI run 25406576201, pytest 136 passed, ruff passed, black passed, validate-state passed.
+Project-state layer: #57 in progress, docs-only PR pending.
 Gemini Adapter mock evidence: six baseline mock tests recorded in #40 as evidence-only Stage 3 candidate.
 Queue/runner audits: #25 PASS; #24 PASS via #39; #22 PASS.
 Stage 1: #23 PASS / closed.
@@ -314,6 +340,7 @@ A future Skeleton branch can reconstruct and validate the current СК state fro
 Jeeves runtime docs are aligned for explicit runtime work.
 Fast `+` continuation and compact reporting are part of the working protocol.
 Externalizer has usable merged code on main: handoff-pack, pr-status, job-log-summary, validate-state, task-from-text, decision gate, work-packet, checkpoint, classify-queue, queue-summary, trace-packet, and runner-report-from-trace.
+Project-state layer is being added so Skeleton can support BauClock and other projects without context mixing.
 Skeleton Stage 2+ is now active through #40 and should grow around maximum practical productivity.
 Gemini/Antigravity/NotebookLM are external tool layers, not current Skeleton Core runtime.
 ```
@@ -323,13 +350,12 @@ Gemini/Antigravity/NotebookLM are external tool layers, not current Skeleton Cor
 Recommended next Stage 2+ step:
 
 ```text
-Add generic project-state template/layer so Skeleton can be used for BauClock and other projects without mixing context with СК/Jeeves.
+Finish #57 docs-only project-state PR and merge after CI.
 ```
 
 Candidate productivity areas:
 
 ```text
-project-state template/layer for BauClock and other repos
 one-command task lifecycle wrapper
 branch recovery pack
 Gemini Adapter mock-mode acceptance suite

--- a/knowledge_base/project_state/BAUCLOCK_PROJECT_STATE.md
+++ b/knowledge_base/project_state/BAUCLOCK_PROJECT_STATE.md
@@ -1,0 +1,80 @@
+# BauClock Project State
+
+Status: STARTER_PUBLIC_SAFE
+Scope: public-safe per-project state for using the ChatGPT Skeleton / Externalizer with BauClock
+
+## Project identity
+
+```text
+project_name: BauClock
+project_type: product / time tracking and cash-settlement support system
+runtime_scope: BauClock application, bot, dashboard, roles, audit trail, reporting, and related product logic
+support_layer: ChatGPT Skeleton / Externalizer only
+```
+
+## Separation rule
+
+```text
+BauClock is a separate product/runtime.
+Skeleton is an external development support layer used to structure tasks, PR review, CI diagnosis, checkpoints, and handoff.
+This file must not be used as Jeeves runtime canon or Skeleton implementation canon.
+```
+
+## Current public-safe product concept
+
+```text
+BauClock is a Telegram-first time tracking and cash-settlement support system for small construction firms.
+Core idea: simple, dispute-resistant work-time capture, role-based review, and clear settlement state.
+```
+
+## Current goal
+
+```text
+current_goal: prepare BauClock for Skeleton-assisted development without mixing context with СК/Jeeves
+active_repo: not recorded here
+active_branch_or_pr: not recorded here
+```
+
+## Current state
+
+```text
+current_state: project-state starter created
+last_completed_step: Skeleton tools confirmed usable for BauClock as an external development layer
+last_validation: pending PR/CI validation for project-state docs
+```
+
+## Next safe step
+
+```text
+next_safe_step: use Skeleton work-packet for the next explicit BauClock implementation request
+blocked_by: none for planning; implementation requires explicit switch to BauClock work
+```
+
+## Active constraints
+
+```text
+forbidden_context_mix:
+- do not modify BauClock runtime/app code from Skeleton state-maintenance tasks
+- do not add private client data, server details, domains, credentials, tokens, banking/accounting data, or personal financial data
+- do not treat BauClock project state as Jeeves runtime canon
+- do not treat BauClock project state as ChatGPT Skeleton implementation state
+- do not merge or deploy BauClock changes without explicit instruction
+```
+
+## Skeleton tools usable for BauClock
+
+```text
+work-packet: convert "КОД BauClock: ..." into a bounded task
+task-from-text: create deterministic task packets from free-form requests
+pr-status: review public-safe PR/CI status exports
+job-log-summary: diagnose public-safe CI log excerpts
+checkpoint: record completed public-safe steps and next action
+handoff-pack: hand off Skeleton state between branches/chats
+```
+
+## Handoff notes
+
+```text
+When Oleksii switches to BauClock work, use this file as the public-safe project-state starter.
+Keep BauClock runtime decisions in BauClock-specific work, not in СК/Jeeves canon.
+```

--- a/knowledge_base/project_state/PROJECT_STATE_TEMPLATE.md
+++ b/knowledge_base/project_state/PROJECT_STATE_TEMPLATE.md
@@ -1,0 +1,71 @@
+# Project State Template
+
+Status: TEMPLATE
+Scope: public-safe per-project state for using the ChatGPT Skeleton / Externalizer with a target project
+
+## Project identity
+
+```text
+project_name:
+project_type:
+runtime_scope:
+support_layer: ChatGPT Skeleton / Externalizer
+```
+
+## Separation rule
+
+```text
+The target project is separate from the Skeleton and from Jeeves runtime.
+The Skeleton is only the external development support layer: task intake, PR/CI review, log diagnosis, handoff, and checkpoints.
+Do not mix target project runtime decisions into Skeleton canon except as short pointers.
+```
+
+## Current goal
+
+```text
+current_goal:
+active_repo:
+active_branch_or_pr:
+```
+
+## Current state
+
+```text
+current_state:
+last_completed_step:
+last_validation:
+```
+
+## Next safe step
+
+```text
+next_safe_step:
+blocked_by:
+```
+
+## Active constraints
+
+```text
+forbidden_context_mix:
+- do not mix this project state with Jeeves runtime canon
+- do not mix this project state with ChatGPT Skeleton implementation state
+- do not add private infrastructure, secrets, credentials, client data, or financial/accounting details
+- do not change runtime/app code unless the user explicitly switches to implementation work
+```
+
+## Skeleton tools usable for this project
+
+```text
+work-packet
+task-from-text
+pr-status
+job-log-summary
+checkpoint
+handoff-pack
+```
+
+## Handoff notes
+
+```text
+handoff_notes:
+```


### PR DESCRIPTION
## Summary

Adds a short public-safe project-state layer so Skeleton can support BauClock and other target projects without mixing context with СК/Jeeves canon.

## Changed files

```text
knowledge_base/project_state/PROJECT_STATE_TEMPLATE.md
knowledge_base/project_state/BAUCLOCK_PROJECT_STATE.md
knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
```

## Behavior

```text
- PROJECT_STATE_TEMPLATE.md defines a reusable per-project state structure.
- BAUCLOCK_PROJECT_STATE.md starts a public-safe BauClock state file.
- CURRENT_STATE.md points to project-state as the mechanism for multi-project Skeleton support.
```

## Safety note

Docs-only change. No runtime code. No BauClock app changes. No Jeeves runtime changes. No private infrastructure details, credentials, client data, accounting data, or deployment changes.

## Validation

Pending GitHub Actions CI.

## Related issue

Implements #57.