### PR TITLE
Make issue runner bridge negation-aware

### DIFF
--- a/tests/fixtures/issue_runner_bauclock_green_safe_forbidden.json
+++ b/tests/fixtures/issue_runner_bauclock_green_safe_forbidden.json
@@ -1,0 +1,8 @@
+{
+  "issue_number": 22,
+  "title": "BauClock docs cleanup",
+  "body": "Update public-safe docs only.\n\nSafety note:\nNo merge.\nNo deploy.\nNo production database.\nNo `.env` reading or printing.\nNo secrets.\nNo tokens.\nForbidden: merge/deploy/server/production DB/.env/secrets.",
+  "labels": ["risk:green", "skeleton"],
+  "project": "bauclock",
+  "requested_by": "oleksii"
+}

--- a/tests/skeleton_core/test_issue_runner_bridge_negation.py
+++ b/tests/skeleton_core/test_issue_runner_bridge_negation.py
@@ -1,0 +1,80 @@
+from tools.skeleton_core.issue_runner_bridge import IssueRunnerInput, build_issue_runner_packet
+
+
+def test_accepts_bauclock_green_safe_forbidden_clauses() -> None:
+    result = build_issue_runner_packet(
+        IssueRunnerInput(
+            issue_number=22,
+            title="BauClock docs cleanup",
+            body=(
+                "Update public-safe docs only.\n\n"
+                "Safety note:\n"
+                "No merge.\n"
+                "No deploy.\n"
+                "No production database.\n"
+                "No .env reading or printing.\n"
+                "No secrets.\n"
+                "No tokens.\n"
+                "Forbidden: merge/deploy/server/production DB/.env/secrets."
+            ),
+            labels=["risk:green"],
+            project="bauclock",
+        )
+    )
+
+    assert result.status == "accepted"
+    assert result.risk_level == "GREEN"
+    assert result.runner_route == "RUNNER_GREEN"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.blockers == []
+
+
+def test_accepts_bauclock_yellow_safe_negations() -> None:
+    result = build_issue_runner_packet(
+        IssueRunnerInput(
+            issue_number=23,
+            title="BauClock role docs note",
+            body=(
+                "Create a public-safe planning note.\n\n"
+                "Hard safety rules:\n"
+                "Do not merge.\n"
+                "Do not deploy.\n"
+                "Do not access production DB.\n"
+                "Do not read or print .env.\n"
+                "Never show secrets.\n"
+                "Never include tokens."
+            ),
+            labels=["risk:yellow"],
+            project="bauclock",
+        )
+    )
+
+    assert result.status == "accepted"
+    assert result.risk_level == "YELLOW"
+    assert result.runner_route == "RUNNER_YELLOW"
+    assert result.review_required is True
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.blockers == []
+
+
+def test_blocks_positive_deploy_request() -> None:
+    result = build_issue_runner_packet(
+        IssueRunnerInput(
+            issue_number=66,
+            title="Deploy BauClock",
+            body="Deploy to production, read .env, use API key, and call external network service.",
+            labels=["risk:yellow"],
+            project="bauclock",
+        )
+    )
+
+    assert result.status == "blocked"
+    assert result.runner_route == "BLOCKED"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert any("deploy" in blocker for blocker in result.blockers)
+    assert any("production" in blocker for blocker in result.blockers)
+    assert any("secret" in blocker for blocker in result.blockers)
+    assert any("network" in blocker for blocker in result.blockers)

--- a/tools/skeleton_core/issue_runner_bridge.py
+++ b/tools/skeleton_core/issue_runner_bridge.py
@@ -17,9 +17,23 @@ BLOCKED_PATTERNS = {
     "deploy": r"\bdeploy\b|\bdeployment\b|\bdeployed\b|\bдеплой",
     "release": r"\brelease\b|\bproduction release\b",
     "production": r"\bproduction\b|\bprod\b|\bпрод\b",
-    "secret": r"\bsecret\b|\bsecrets\b|\btoken\b|\btokens\b|\bcredential\b|\bcredentials\b|api key|apikey|ключ",
-    "network": r"\bnetwork\b|\bexternal service\b|\bexternal api\b|\blive mode\b|\bhttp[s]?://",
+    "secret": r"\bsecret\b|\bsecrets\b|\btoken\b|\btokens\b|\bcredential\b|\bcredentials\b|api key|apikey|ключ|\.env",
+    "network": r"\bnetwork\b|\bexternal service\b|\bexternal api\b|\blive mode\b|\bhttp[s]?://|\bserver ssh\b|\bssh\b",
 }
+NEGATION_PREFIXES = (
+    "no ",
+    "no.",
+    "do not ",
+    "don't ",
+    "never ",
+    "forbidden:",
+    "forbidden ",
+    "hard safety:",
+    "hard safety rules:",
+    "safety:",
+    "safety note:",
+    "security rule:",
+)
 
 
 class IssueLabel(BaseModel):
@@ -97,12 +111,34 @@ def _content(packet: IssueRunnerInput) -> str:
     return f"{packet.title}\n{packet.body}"
 
 
+def _line_fragments(text: str) -> list[str]:
+    fragments = []
+    for line in text.splitlines():
+        cleaned = " ".join(line.strip(" -\t").split())
+        if cleaned:
+            fragments.append(cleaned)
+    return fragments
+
+
+def _is_negated_or_prohibitive(fragment: str, match_start: int) -> bool:
+    lower = fragment.casefold().strip()
+    before_match = lower[:match_start].strip()
+    if lower.startswith(NEGATION_PREFIXES):
+        return True
+    if before_match.endswith(("no", "do not", "don't", "never", "forbidden")):
+        return True
+    return bool(re.search(r"\b(no|do not|don't|never|forbidden)\b\W*$", before_match))
+
+
 def _safety_blockers(text: str) -> list[str]:
     blockers = []
-    for name, pattern in BLOCKED_PATTERNS.items():
-        if re.search(pattern, text, flags=re.IGNORECASE):
-            blockers.append(f"Blocked unsafe request: {name}")
-    return blockers
+    for fragment in _line_fragments(text):
+        for name, pattern in BLOCKED_PATTERNS.items():
+            for match in re.finditer(pattern, fragment, flags=re.IGNORECASE):
+                if not _is_negated_or_prohibitive(fragment, match.start()):
+                    blockers.append(f"Blocked unsafe request: {name}")
+                    break
+    return sorted(set(blockers))
 
 
 def build_issue_runner_packet(packet: IssueRunnerInput) -> IssueRunnerPacket:


### PR DESCRIPTION
## Summary

Fixes the `issue-runner-bridge` safety scanner so protective safety clauses do not become false-positive blockers.

Safe clauses now allowed:

```text
No merge.
No deploy.
No production database.
No .env reading or printing.
No secrets.
No tokens.
Do not merge.
Do not deploy.
Never show secrets.
Forbidden: merge/deploy/server/production DB/.env/secrets.
```

Still blocked:

```text
Merge the PR.
Deploy to production.
read .env
use API key
call external network service
```

## Changed files

```text
tools/skeleton_core/issue_runner_bridge.py
tests/skeleton_core/test_issue_runner_bridge_negation.py
tests/fixtures/issue_runner_bauclock_green_safe_forbidden.json
```

## Safety invariant

```text
merge_allowed=false
deploy_allowed=false
positive merge/deploy/release/production/secrets/tokens/credentials/network/live-mode scope still blocks
```

## CI result

GitHub Actions run on PR head `e0525f27d4538e373c5408c4d09c26b09424eab8`:

```text
Workflow: Skeleton Core
Run: 25428286095
Status: completed
Conclusion: success
Job: Validate Skeleton core -> success
```

Validation details:

```text
pytest: passed
ruff: passed
black --check: passed
validate-state: passed
```

## Related issue

Implements #64.

## Note

No runtime app code touched. No GitHub API calls from CLI. No network calls. No secrets/private data.