### PR TITLE
Add task lifecycle wrapper

### DIFF
--- a/tests/skeleton_core/test_cli_task_lifecycle.py
+++ b/tests/skeleton_core/test_cli_task_lifecycle.py
@@ -1,0 +1,32 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def test_cli_task_lifecycle_green_fixture(capsys) -> None:
+    exit_code = main(["task-lifecycle", "--input", "tests/fixtures/issue_runner_green.json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["status"] == "accepted"
+    assert payload["risk_level"] == "GREEN"
+    assert payload["runner_route"] == "RUNNER_GREEN"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert payload["initial_checkpoint"]["result"] == "queued"
+
+
+def test_cli_task_lifecycle_blocks_merge_fixture(capsys) -> None:
+    exit_code = main(["task-lifecycle", "--input", "tests/fixtures/issue_runner_red_merge.json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["status"] == "blocked"
+    assert payload["runner_route"] == "BLOCKED"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert payload["initial_checkpoint"]["result"] == "blocked"

--- a/tests/skeleton_core/test_task_lifecycle.py
+++ b/tests/skeleton_core/test_task_lifecycle.py
@@ -1,0 +1,86 @@
+from tools.skeleton_core.issue_runner_bridge import IssueRunnerInput
+from tools.skeleton_core.task_lifecycle import build_task_lifecycle_packet
+
+
+def test_task_lifecycle_accepts_green() -> None:
+    result = build_task_lifecycle_packet(
+        IssueRunnerInput(
+            issue_number=61,
+            title="Docs cleanup",
+            body="Update public-safe wording in docs only.",
+            labels=["risk:green"],
+            project="skeleton",
+        )
+    )
+
+    assert result.status == "accepted"
+    assert result.risk_level == "GREEN"
+    assert result.runner_route == "RUNNER_GREEN"
+    assert result.review_required is False
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.work_summary == "Issue #61: Docs cleanup"
+    assert result.initial_checkpoint.task_id == "issue-61"
+    assert result.initial_checkpoint.project == "skeleton"
+    assert result.initial_checkpoint.result == "queued"
+    assert result.blockers == []
+
+
+def test_task_lifecycle_accepts_yellow_with_review() -> None:
+    result = build_task_lifecycle_packet(
+        IssueRunnerInput(
+            issue_number=62,
+            title="Add project-state docs note",
+            body="Create a public-safe docs note.",
+            labels=["risk:yellow"],
+            project="skeleton",
+        )
+    )
+
+    assert result.status == "accepted"
+    assert result.risk_level == "YELLOW"
+    assert result.runner_route == "RUNNER_YELLOW"
+    assert result.review_required is True
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.initial_checkpoint.result == "queued"
+
+
+def test_task_lifecycle_blocks_unsafe_scope() -> None:
+    result = build_task_lifecycle_packet(
+        IssueRunnerInput(
+            issue_number=63,
+            title="Merge and deploy runner bridge",
+            body="Merge the PR and deploy to production using tokens.",
+            labels=["risk:yellow"],
+            project="skeleton",
+        )
+    )
+
+    assert result.status == "blocked"
+    assert result.runner_route == "BLOCKED"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.initial_checkpoint.result == "blocked"
+    assert any("merge" in blocker for blocker in result.blockers)
+    assert any("deploy" in blocker for blocker in result.blockers)
+    assert any("secret" in blocker for blocker in result.blockers)
+
+
+def test_task_lifecycle_unknown_without_risk() -> None:
+    result = build_task_lifecycle_packet(
+        IssueRunnerInput(
+            issue_number=64,
+            title="Ambiguous task",
+            body="Do something.",
+            labels=[],
+            project="skeleton",
+        )
+    )
+
+    assert result.status == "unknown_needs_review"
+    assert result.risk_level == "UNKNOWN"
+    assert result.runner_route == "BLOCKED"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.initial_checkpoint.result == "unknown_needs_review"

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -21,6 +21,7 @@ from tools.skeleton_core.queue_classifier import classify_queue_items
 from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.state_validator import validate_state
+from tools.skeleton_core.task_lifecycle import build_task_lifecycle_packet
 from tools.skeleton_core.templates import render_runner_issue
 from tools.skeleton_core.trace import TracePacket
 from tools.skeleton_core.work_packet import render_work_packet
@@ -36,6 +37,7 @@ SUBCOMMANDS = {
     "queue-summary",
     "runner-report-from-trace",
     "task-from-text",
+    "task-lifecycle",
     "trace-packet",
     "validate-state",
     "work-packet",
@@ -186,6 +188,15 @@ def _add_trace_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_issue_input_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to public-safe GitHub issue JSON",
+    )
+
+
 def _subcommand_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Skeleton Externalizer CLI.")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -225,12 +236,7 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         "issue-runner-bridge",
         help="Build a GREEN/YELLOW runner packet from public-safe issue JSON",
     )
-    issue_runner_parser.add_argument(
-        "--input",
-        required=True,
-        type=Path,
-        help="Path to public-safe GitHub issue JSON",
-    )
+    _add_issue_input_arg(issue_runner_parser)
 
     job_log_parser = subparsers.add_parser(
         "job-log-summary",
@@ -281,6 +287,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Build a Skeleton decision packet from free-form text",
     )
     _add_task_from_text_args(task_from_text_parser)
+
+    task_lifecycle_parser = subparsers.add_parser(
+        "task-lifecycle",
+        help="Build a compact lifecycle packet from public-safe issue JSON",
+    )
+    _add_issue_input_arg(task_lifecycle_parser)
 
     trace_parser = subparsers.add_parser("trace-packet", help="Build a Skeleton trace packet")
     _add_trace_args(trace_parser)
@@ -405,6 +417,17 @@ def _run_runner_report_from_trace(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_task_lifecycle(args: argparse.Namespace) -> int:
+    try:
+        result = build_task_lifecycle_packet(load_issue_runner_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _trace_packet_from_args(args: argparse.Namespace) -> TracePacket:
     return TracePacket(
         task_id=args.task_id,
@@ -497,6 +520,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_runner_report_from_trace(args)
     if args.command == "task-from-text":
         return _run_task_from_text(args)
+    if args.command == "task-lifecycle":
+        return _run_task_lifecycle(args)
     if args.command == "trace-packet":
         return _run_trace_packet(args)
     if args.command == "validate-state":

--- a/tools/skeleton_core/task_lifecycle.py
+++ b/tools/skeleton_core/task_lifecycle.py
@@ -1,0 +1,90 @@
+"""Offline task lifecycle packet builder for public-safe issue exports."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.issue_runner_bridge import (
+    BridgeRisk,
+    BridgeStatus,
+    IssueRunnerInput,
+    RunnerRoute,
+    build_issue_runner_packet,
+)
+
+LifecycleStatus = Literal["accepted", "blocked", "unknown_needs_review"]
+
+
+class InitialCheckpoint(BaseModel):
+    """Small public-safe checkpoint skeleton for a queued runner task."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str
+    project: str
+    result: str
+    next_safe_step: str
+
+
+class TaskLifecyclePacket(BaseModel):
+    """Compact lifecycle packet for one public-safe issue export."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    issue_number: int
+    status: LifecycleStatus
+    risk_level: BridgeRisk
+    runner_route: RunnerRoute
+    review_required: bool
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    work_summary: str
+    initial_checkpoint: InitialCheckpoint
+    blockers: list[str] = Field(default_factory=list)
+    next_safe_runner_instruction: str
+
+
+def _issue_number(packet: IssueRunnerInput) -> int:
+    return packet.issue_number or packet.number or 0
+
+
+def _work_summary(packet: IssueRunnerInput) -> str:
+    issue_number = _issue_number(packet)
+    title = " ".join(packet.title.split())
+    return f"Issue #{issue_number}: {title}"
+
+
+def _checkpoint_result(status: BridgeStatus) -> str:
+    if status == "accepted":
+        return "queued"
+    if status == "unknown_needs_review":
+        return "unknown_needs_review"
+    return "blocked"
+
+
+def build_task_lifecycle_packet(packet: IssueRunnerInput) -> TaskLifecyclePacket:
+    """Build one local/offline task lifecycle packet from a public-safe issue export."""
+    bridge = build_issue_runner_packet(packet)
+    issue_number = _issue_number(packet)
+    next_safe_step = bridge.next_action
+
+    return TaskLifecyclePacket(
+        issue_number=issue_number,
+        status=bridge.status,
+        risk_level=bridge.risk_level,
+        runner_route=bridge.runner_route,
+        review_required=bridge.review_required,
+        merge_allowed=False,
+        deploy_allowed=False,
+        work_summary=_work_summary(packet),
+        initial_checkpoint=InitialCheckpoint(
+            task_id=f"issue-{issue_number}",
+            project=packet.project,
+            result=_checkpoint_result(bridge.status),
+            next_safe_step=next_safe_step,
+        ),
+        blockers=bridge.blockers,
+        next_safe_runner_instruction=next_safe_step,
+    )


### PR DESCRIPTION
## Summary

Adds a local offline `task-lifecycle` command that reads a public-safe GitHub issue JSON export and emits one compact lifecycle packet:

```text
bridge_result fields
work_summary
initial_checkpoint
next_safe_runner_instruction
```

## Commands

```bash
python -m tools.skeleton_core.cli task-lifecycle --input tests/fixtures/issue_runner_green.json
python -m tools.skeleton_core.cli task-lifecycle --input tests/fixtures/issue_runner_yellow.json
python -m tools.skeleton_core.cli task-lifecycle --input tests/fixtures/issue_runner_red_merge.json
```

## Changed files

```text
tools/skeleton_core/task_lifecycle.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_task_lifecycle.py
tests/skeleton_core/test_cli_task_lifecycle.py
```

## Behavior

```text
- Reuses issue-runner-bridge safety decision.
- Accepted GREEN/YELLOW emits lifecycle status accepted.
- Blocked/unknown bridge results remain blocked or unknown_needs_review.
- initial_checkpoint records issue-N, project, result, and next safe step.
- merge_allowed=false and deploy_allowed=false remain invariant.
- No shell commands are emitted.
```

## CI result

GitHub Actions run on PR head `d1b61d8071e3747c0314604caa6a4e0f6f43f5ed`:

```text
Workflow: Skeleton Core
Run: 25430798839
Status: completed
Conclusion: success
Job: Validate Skeleton core -> success
```

Validation details:

```text
pytest: passed
ruff: passed
black --check: passed
validate-state: passed
```

## Safety note

Local offline Skeleton CLI/test change only. No GitHub API calls from the CLI. No network calls. No merge/deploy authority. No runtime/app changes. Uses negation-aware issue-runner-bridge from #64/#66.

## Related issue

Implements #63.