### PR TITLE
Add Skeleton runner-command-pack command

### DIFF
--- a/tests/fixtures/runner_command_bauclock_22_green.json
+++ b/tests/fixtures/runner_command_bauclock_22_green.json
@@ -1,0 +1,13 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 22,
+  "title": "[agent-task-green] BauClock overnight baseline validation",
+  "risk_level": "GREEN",
+  "runner_route": "RUNNER_GREEN",
+  "review_required": false,
+  "allowed_files": [],
+  "expected_commands": ["python -m pytest"],
+  "blocked_by": [],
+  "merge_allowed": false,
+  "deploy_allowed": false
+}

--- a/tests/fixtures/runner_command_bauclock_23_yellow.json
+++ b/tests/fixtures/runner_command_bauclock_23_yellow.json
@@ -1,0 +1,19 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 23,
+  "title": "[agent-task-yellow] BauClock test-only calendar and manual-time access-control hardening",
+  "risk_level": "YELLOW",
+  "runner_route": "RUNNER_YELLOW",
+  "review_required": true,
+  "allowed_files": [
+    "tests/test_calendar_service.py",
+    "tests/test_legal_hardening.py"
+  ],
+  "expected_commands": [
+    "python -m pytest tests/test_calendar_service.py tests/test_legal_hardening.py -q",
+    "python -m pytest"
+  ],
+  "blocked_by": [],
+  "merge_allowed": false,
+  "deploy_allowed": false
+}

--- a/tests/fixtures/runner_command_blocked_red.json
+++ b/tests/fixtures/runner_command_blocked_red.json
@@ -1,0 +1,13 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 999,
+  "title": "[agent-task-red] Deploy production fix",
+  "risk_level": "RED",
+  "runner_route": "BLOCKED",
+  "review_required": true,
+  "allowed_files": [],
+  "expected_commands": [],
+  "blocked_by": ["RED task is not eligible for runner command"],
+  "merge_allowed": false,
+  "deploy_allowed": false
+}

--- a/tests/fixtures/runner_command_missing_fields.json
+++ b/tests/fixtures/runner_command_missing_fields.json
@@ -1,0 +1,6 @@
+{
+  "repository": "alanua/bauclock",
+  "risk_level": "YELLOW",
+  "merge_allowed": false,
+  "deploy_allowed": false
+}

--- a/tests/fixtures/runner_command_unsafe_text.json
+++ b/tests/fixtures/runner_command_unsafe_text.json
@@ -1,0 +1,13 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 1000,
+  "title": "[agent-task-yellow] Use token and live mode",
+  "risk_level": "YELLOW",
+  "runner_route": "RUNNER_YELLOW",
+  "review_required": true,
+  "allowed_files": ["tests/test_example.py"],
+  "expected_commands": ["python -m pytest"],
+  "blocked_by": [],
+  "merge_allowed": false,
+  "deploy_allowed": false
+}

--- a/tests/skeleton_core/test_cli_runner_command_pack.py
+++ b/tests/skeleton_core/test_cli_runner_command_pack.py
@@ -1,0 +1,58 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["runner-command-pack", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_runner_command_pack_green_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_command_bauclock_22_green.json", capsys)
+
+    assert payload["status"] == "ready"
+    assert payload["issue_number"] == 22
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert "GREEN read-only validation" in payload["command_text"]
+    assert "Do not merge or deploy" in payload["command_text"]
+
+
+def test_cli_runner_command_pack_yellow_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_command_bauclock_23_yellow.json", capsys)
+
+    assert payload["status"] == "ready"
+    assert payload["issue_number"] == 23
+    assert "YELLOW test-only task" in payload["command_text"]
+    assert "tests/test_calendar_service.py" in payload["command_text"]
+    assert "Do not merge or deploy" in payload["command_text"]
+
+
+def test_cli_runner_command_pack_blocked_red_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_command_blocked_red.json", capsys)
+
+    assert payload["status"] == "blocked"
+    assert payload["issue_number"] == 999
+    assert payload["command_text"].startswith("BLOCKED")
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_runner_command_pack_missing_fields_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_command_missing_fields.json", capsys)
+
+    assert payload["status"] == "blocked"
+    assert "Missing required field: issue_number" in payload["blockers"]
+    assert "Missing required field: title" in payload["blockers"]
+
+
+def test_cli_runner_command_pack_unsafe_text_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_command_unsafe_text.json", capsys)
+
+    assert payload["status"] == "blocked"
+    assert any("secret" in blocker for blocker in payload["blockers"])
+    assert any("network" in blocker for blocker in payload["blockers"])

--- a/tests/skeleton_core/test_runner_command_pack.py
+++ b/tests/skeleton_core/test_runner_command_pack.py
@@ -1,0 +1,117 @@
+from tools.skeleton_core.runner_command_pack import (
+    RunnerCommandInput,
+    build_runner_command_pack,
+)
+
+
+def test_runner_command_pack_green_read_only() -> None:
+    result = build_runner_command_pack(
+        RunnerCommandInput(
+            repository="alanua/bauclock",
+            issue_number=22,
+            title="[agent-task-green] BauClock overnight baseline validation",
+            risk_level="GREEN",
+            runner_route="RUNNER_GREEN",
+            review_required=False,
+            expected_commands=["python -m pytest"],
+        )
+    )
+
+    assert result.status == "ready"
+    assert result.issue_number == 22
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert "КОД BauClock" in result.command_text
+    assert "GREEN read-only validation" in result.command_text
+    assert "Do not change files" in result.command_text
+    assert "python -m pytest" in result.command_text
+    assert "Do not merge or deploy" in result.command_text
+
+
+def test_runner_command_pack_yellow_allowed_files() -> None:
+    result = build_runner_command_pack(
+        RunnerCommandInput(
+            repository="alanua/bauclock",
+            issue_number=23,
+            title="[agent-task-yellow] BauClock access-control hardening",
+            risk_level="YELLOW",
+            runner_route="RUNNER_YELLOW",
+            review_required=True,
+            allowed_files=["tests/test_calendar_service.py"],
+            expected_commands=["python -m pytest tests/test_calendar_service.py -q"],
+        )
+    )
+
+    assert result.status == "ready"
+    assert result.issue_number == 23
+    assert "YELLOW test-only task" in result.command_text
+    assert "tests/test_calendar_service.py" in result.command_text
+    assert "Open a draft PR or blocked report" in result.command_text
+    assert "Do not merge or deploy" in result.command_text
+
+
+def test_runner_command_pack_blocks_red() -> None:
+    result = build_runner_command_pack(
+        RunnerCommandInput(
+            repository="alanua/bauclock",
+            issue_number=999,
+            title="[agent-task-red] risky task",
+            risk_level="RED",
+            runner_route="BLOCKED",
+            review_required=True,
+        )
+    )
+
+    assert result.status == "blocked"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.command_text.startswith("BLOCKED")
+    assert any("Unsupported risk level: RED" == blocker for blocker in result.blockers)
+
+
+def test_runner_command_pack_blocks_missing_fields() -> None:
+    result = build_runner_command_pack(
+        RunnerCommandInput(repository="alanua/bauclock", risk_level="YELLOW")
+    )
+
+    assert result.status == "blocked"
+    assert "Missing required field: issue_number" in result.blockers
+    assert "Missing required field: title" in result.blockers
+    assert "YELLOW task must include allowed_files" in result.blockers
+
+
+def test_runner_command_pack_blocks_unsafe_text() -> None:
+    result = build_runner_command_pack(
+        RunnerCommandInput(
+            repository="alanua/bauclock",
+            issue_number=1000,
+            title="Use token and live mode",
+            risk_level="YELLOW",
+            runner_route="RUNNER_YELLOW",
+            review_required=True,
+            allowed_files=["tests/test_example.py"],
+        )
+    )
+
+    assert result.status == "blocked"
+    assert any("secret" in blocker for blocker in result.blockers)
+    assert any("network" in blocker for blocker in result.blockers)
+
+
+def test_runner_command_pack_blocks_merge_or_deploy_allowed_true() -> None:
+    result = build_runner_command_pack(
+        RunnerCommandInput(
+            repository="alanua/bauclock",
+            issue_number=24,
+            title="[agent-task-green] baseline",
+            risk_level="GREEN",
+            runner_route="RUNNER_GREEN",
+            review_required=False,
+            merge_allowed=True,
+            deploy_allowed=True,
+        )
+    )
+
+    assert result.status == "blocked"
+    assert "merge_allowed must be false" in result.blockers
+    assert "deploy_allowed must be false" in result.blockers

--- a/tests/skeleton_core/test_runner_command_pack.py
+++ b/tests/skeleton_core/test_runner_command_pack.py
@@ -66,7 +66,7 @@ def test_runner_command_pack_blocks_red() -> None:
     assert result.merge_allowed is False
     assert result.deploy_allowed is False
     assert result.command_text.startswith("BLOCKED")
-    assert any("Unsupported risk level: RED" == blocker for blocker in result.blockers)
+    assert any(blocker == "Unsupported risk level: RED" for blocker in result.blockers)
 
 
 def test_runner_command_pack_blocks_missing_fields() -> None:

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -20,6 +20,7 @@ from tools.skeleton_core.pr_status import PRStatusInput, build_pr_status
 from tools.skeleton_core.queue_classifier import classify_queue_items
 from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
+from tools.skeleton_core.runner_command_pack import RunnerCommandInput, build_runner_command_pack
 from tools.skeleton_core.state_validator import validate_state
 from tools.skeleton_core.task_lifecycle import build_task_lifecycle_packet
 from tools.skeleton_core.templates import render_runner_issue
@@ -35,6 +36,7 @@ SUBCOMMANDS = {
     "job-log-summary",
     "pr-status",
     "queue-summary",
+    "runner-command-pack",
     "runner-report-from-trace",
     "task-from-text",
     "task-lifecycle",
@@ -74,6 +76,11 @@ def load_pr_status_input(input_path: Path) -> PRStatusInput:
 def load_issue_runner_input(input_path: Path) -> IssueRunnerInput:
     """Load public-safe issue runner input from JSON."""
     return IssueRunnerInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_runner_command_input(input_path: Path) -> RunnerCommandInput:
+    """Load public-safe runner command input from JSON."""
+    return RunnerCommandInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def build_queue_summary_payload(input_path: Path) -> dict[str, int]:
@@ -188,13 +195,12 @@ def _add_trace_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_input_arg(parser: argparse.ArgumentParser, help_text: str) -> None:
+    parser.add_argument("--input", required=True, type=Path, help=help_text)
+
+
 def _add_issue_input_arg(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--input",
-        required=True,
-        type=Path,
-        help="Path to public-safe GitHub issue JSON",
-    )
+    _add_input_arg(parser, "Path to public-safe GitHub issue JSON")
 
 
 def _subcommand_parser() -> argparse.ArgumentParser:
@@ -211,12 +217,7 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         "classify-queue",
         help="Classify offline queue JSON items",
     )
-    classify_queue_parser.add_argument(
-        "--input",
-        required=True,
-        type=Path,
-        help="Path to public-safe queue JSON",
-    )
+    _add_input_arg(classify_queue_parser, "Path to public-safe queue JSON")
 
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
@@ -242,45 +243,31 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         "job-log-summary",
         help="Summarize a public-safe GitHub Actions job log excerpt",
     )
-    job_log_parser.add_argument(
-        "--input",
-        required=True,
-        type=Path,
-        help="Path to public-safe job log text",
-    )
+    _add_input_arg(job_log_parser, "Path to public-safe job log text")
 
     pr_status_parser = subparsers.add_parser(
         "pr-status",
         help="Build a deterministic PR status packet from public-safe JSON",
     )
-    pr_status_parser.add_argument(
-        "--input",
-        required=True,
-        type=Path,
-        help="Path to public-safe PR status JSON",
-    )
+    _add_input_arg(pr_status_parser, "Path to public-safe PR status JSON")
 
     queue_parser = subparsers.add_parser(
         "queue-summary",
         help="Summarize an offline queue JSON file",
     )
-    queue_parser.add_argument(
-        "--input",
-        required=True,
-        type=Path,
-        help="Path to public-safe queue JSON",
+    _add_input_arg(queue_parser, "Path to public-safe queue JSON")
+
+    runner_command_parser = subparsers.add_parser(
+        "runner-command-pack",
+        help="Build a compact runner command from public-safe JSON",
     )
+    _add_input_arg(runner_command_parser, "Path to public-safe runner command JSON")
 
     report_parser = subparsers.add_parser(
         "runner-report-from-trace",
         help="Render a short runner report from a TracePacket JSON file",
     )
-    report_parser.add_argument(
-        "--input",
-        required=True,
-        type=Path,
-        help="Path to public-safe TracePacket JSON",
-    )
+    _add_input_arg(report_parser, "Path to public-safe TracePacket JSON")
 
     task_from_text_parser = subparsers.add_parser(
         "task-from-text",
@@ -406,6 +393,17 @@ def _run_queue_summary(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_runner_command_pack(args: argparse.Namespace) -> int:
+    try:
+        result = build_runner_command_pack(load_runner_command_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_runner_report_from_trace(args: argparse.Namespace) -> int:
     try:
         packet = load_trace_packet(args.input)
@@ -516,6 +514,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_pr_status(args)
     if args.command == "queue-summary":
         return _run_queue_summary(args)
+    if args.command == "runner-command-pack":
+        return _run_runner_command_pack(args)
     if args.command == "runner-report-from-trace":
         return _run_runner_report_from_trace(args)
     if args.command == "task-from-text":

--- a/tools/skeleton_core/runner_command_pack.py
+++ b/tools/skeleton_core/runner_command_pack.py
@@ -1,0 +1,184 @@
+"""Local offline runner command generator for public-safe task packets."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+RunnerCommandStatus = Literal["ready", "blocked", "unknown_needs_review"]
+
+UNSAFE_PATTERNS = {
+    "secret": r"\bsecret\b|\bsecrets\b|\btoken\b|\btokens\b|\bcredential\b|\bcredentials\b|api key|apikey|password|\.env",
+    "server": r"\bserver ssh\b|\bssh\b|production db|production database|\bprod db\b",
+    "network": r"\bnetwork\b|\bexternal service\b|\bexternal api\b|\blive mode\b|http[s]?://",
+    "merge": r"\bmerge this\b|\bmerge pr\b|\bmerge pull request\b|\bauto-merge\b",
+    "deploy": r"\bdeploy to\b|\bdeployment\b|\bdeploy production\b|\brelease to\b",
+}
+
+
+class RunnerCommandInput(BaseModel):
+    """Public-safe task/lifecycle packet accepted by runner-command-pack."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    repository: str | None = None
+    issue_number: int | None = None
+    title: str | None = None
+    risk_level: str | None = None
+    runner_route: str | None = None
+    review_required: bool | None = None
+    allowed_files: list[str] = Field(default_factory=list)
+    expected_commands: list[str] = Field(default_factory=list)
+    blocked_by: list[str] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    body: str = ""
+
+
+class RunnerCommandPack(BaseModel):
+    """Deterministic local/offline runner command output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: RunnerCommandStatus
+    issue_number: int | None
+    command_text: str
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    blockers: list[str] = Field(default_factory=list)
+
+
+def _project_from_repository(repository: str | None) -> str:
+    if not repository:
+        return "Skeleton"
+    name = repository.rsplit("/", 1)[-1]
+    if name.casefold() == "bauclock":
+        return "BauClock"
+    if name.casefold() == "jeeves":
+        return "Skeleton"
+    return name
+
+
+def _normalized_risk(packet: RunnerCommandInput) -> str:
+    return (packet.risk_level or "UNKNOWN").strip().upper()
+
+
+def _unsafe_blockers(packet: RunnerCommandInput) -> list[str]:
+    text_parts = [
+        packet.repository or "",
+        packet.title or "",
+        packet.body,
+        "\n".join(packet.allowed_files),
+        "\n".join(packet.expected_commands),
+    ]
+    text = "\n".join(text_parts)
+    blockers: list[str] = []
+    for name, pattern in UNSAFE_PATTERNS.items():
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            blockers.append(f"Unsafe text detected: {name}")
+    return sorted(set(blockers))
+
+
+def _missing_field_blockers(packet: RunnerCommandInput) -> list[str]:
+    missing = []
+    if not packet.repository:
+        missing.append("Missing required field: repository")
+    if packet.issue_number is None:
+        missing.append("Missing required field: issue_number")
+    if not packet.title:
+        missing.append("Missing required field: title")
+    if not packet.risk_level:
+        missing.append("Missing required field: risk_level")
+    return missing
+
+
+def _blocked_result(packet: RunnerCommandInput, blockers: list[str]) -> RunnerCommandPack:
+    issue_label = f"issue #{packet.issue_number}" if packet.issue_number is not None else "packet"
+    reason = "; ".join(blockers) if blockers else "not safe for runner command"
+    return RunnerCommandPack(
+        status="blocked",
+        issue_number=packet.issue_number,
+        command_text=f"BLOCKED: {issue_label} is not safe for runner command. Reason: {reason}.",
+        merge_allowed=False,
+        deploy_allowed=False,
+        blockers=blockers,
+    )
+
+
+def _format_expected_commands(commands: list[str]) -> str:
+    if not commands:
+        return "Run the validation commands from the issue."
+    return " Expected commands: " + " ; ".join(commands) + "."
+
+
+def _format_allowed_files(files: list[str]) -> str:
+    if not files:
+        return ""
+    return " Change only allowed files: " + ", ".join(files) + "."
+
+
+def _green_command(packet: RunnerCommandInput) -> str:
+    project = _project_from_repository(packet.repository)
+    issue_number = packet.issue_number or 0
+    return (
+        f"КОД {project}: execute issue #{issue_number} as GREEN read-only validation. "
+        "Use latest main. Do not change files."
+        f"{_format_expected_commands(packet.expected_commands)} "
+        "Post report with branch, head SHA, commands, result, failures, open PRs, and clean/dirty state. "
+        "Do not merge or deploy."
+    )
+
+
+def _yellow_command(packet: RunnerCommandInput) -> str:
+    project = _project_from_repository(packet.repository)
+    issue_number = packet.issue_number or 0
+    return (
+        f"КОД {project}: execute issue #{issue_number} as YELLOW test-only task. "
+        "Create a fresh branch from latest main."
+        f"{_format_allowed_files(packet.allowed_files)}"
+        f"{_format_expected_commands(packet.expected_commands)} "
+        "Open a draft PR or blocked report. "
+        "Do not change production code unless stopped and reported first. "
+        "Do not merge or deploy."
+    )
+
+
+def build_runner_command_pack(packet: RunnerCommandInput) -> RunnerCommandPack:
+    """Build one compact safe runner command from a local public-safe packet."""
+    blockers = []
+    blockers.extend(_missing_field_blockers(packet))
+    blockers.extend(_unsafe_blockers(packet))
+    blockers.extend(packet.blocked_by)
+    blockers.extend(packet.blockers)
+
+    if packet.merge_allowed:
+        blockers.append("merge_allowed must be false")
+    if packet.deploy_allowed:
+        blockers.append("deploy_allowed must be false")
+
+    risk = _normalized_risk(packet)
+    if risk not in {"GREEN", "YELLOW"}:
+        blockers.append(f"Unsupported risk level: {risk}")
+    if risk == "YELLOW" and not packet.allowed_files:
+        blockers.append("YELLOW task must include allowed_files")
+
+    if blockers:
+        return _blocked_result(packet, sorted(set(blockers)))
+
+    command = _green_command(packet) if risk == "GREEN" else _yellow_command(packet)
+    return RunnerCommandPack(
+        status="ready",
+        issue_number=packet.issue_number,
+        command_text=command,
+        merge_allowed=False,
+        deploy_allowed=False,
+        blockers=[],
+    )
+
+
+def build_runner_command_pack_from_json(raw_json: str) -> RunnerCommandPack:
+    """Validate local JSON text and build a runner command pack."""
+    return build_runner_command_pack(RunnerCommandInput.model_validate_json(raw_json))


### PR DESCRIPTION
## Summary

Implements #75 as a local/offline Skeleton Core command:

```text
python -m tools.skeleton_core.cli runner-command-pack --input tests/fixtures/runner_command_bauclock_22_green.json
python -m tools.skeleton_core.cli runner-command-pack --input tests/fixtures/runner_command_bauclock_23_yellow.json
python -m tools.skeleton_core.cli runner-command-pack --input tests/fixtures/runner_command_blocked_red.json
```

The command reads public-safe JSON only and emits a compact runner command packet with:

```text
status
issue_number
command_text
merge_allowed=false
deploy_allowed=false
blockers
```

## Safety

```text
No Jeeves runtime changes.
No BauClock runtime changes.
No GitHub API calls from the CLI.
No network calls.
No runner/shell execution.
No secrets/private data.
No merge/deploy authority.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Manual fixture commands to verify after checkout:

```bash
python -m tools.skeleton_core.cli runner-command-pack --input tests/fixtures/runner_command_bauclock_22_green.json
python -m tools.skeleton_core.cli runner-command-pack --input tests/fixtures/runner_command_bauclock_23_yellow.json
python -m tools.skeleton_core.cli runner-command-pack --input tests/fixtures/runner_command_blocked_red.json
```

Closes #75.