### PR TITLE
Add Skeleton issue-dispatch command

### DIFF
--- a/tests/fixtures/bauclock_issue_22_export.json
+++ b/tests/fixtures/bauclock_issue_22_export.json
@@ -1,0 +1,8 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 22,
+  "title": "[agent-task-green] BauClock overnight baseline validation",
+  "body": "# GREEN — BauClock overnight baseline validation\n\n## Validation required\n\n```bash\npython -m pytest\n```\n\nSafety: No merge. No deploy. No secrets.",
+  "comments": [],
+  "state": "open"
+}

--- a/tests/fixtures/bauclock_issue_23_export.json
+++ b/tests/fixtures/bauclock_issue_23_export.json
@@ -1,0 +1,8 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 23,
+  "title": "[agent-task-yellow] BauClock test-only calendar and manual-time access-control hardening",
+  "body": "# YELLOW — BauClock test-only calendar and manual-time access-control hardening\n\n## Allowed files\n\n```text\ntests/test_calendar_service.py\ntests/test_legal_hardening.py\n```\n\n## Validation required\n\n```bash\npython -m pytest tests/test_calendar_service.py tests/test_legal_hardening.py -q\npython -m pytest\n```\n\nSafety: No merge. No deploy. No production DB. No .env. No secrets.",
+  "comments": ["depends_on #22"],
+  "state": "open"
+}

--- a/tests/fixtures/bauclock_issue_red_forbidden.json
+++ b/tests/fixtures/bauclock_issue_red_forbidden.json
@@ -1,0 +1,8 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 999,
+  "title": "[agent-task-red] Deploy production with token",
+  "body": "Deploy to production and use API key from .env.",
+  "comments": [],
+  "state": "open"
+}

--- a/tests/skeleton_core/test_cli_issue_dispatch.py
+++ b/tests/skeleton_core/test_cli_issue_dispatch.py
@@ -1,0 +1,87 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(args: list[str], capsys) -> dict:
+    exit_code = main(args)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_issue_dispatch_green_fixture(capsys) -> None:
+    payload = _run_fixture(
+        ["issue-dispatch", "--input", "tests/fixtures/bauclock_issue_22_export.json"],
+        capsys,
+    )
+
+    assert payload["status"] == "accepted"
+    assert payload["risk_level"] == "GREEN"
+    assert payload["runner_route"] == "RUNNER_GREEN"
+    assert payload["review_required"] is False
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert payload["expected_commands"] == ["python -m pytest"]
+
+
+def test_cli_issue_dispatch_yellow_run_bridge_fixture(capsys) -> None:
+    payload = _run_fixture(
+        [
+            "issue-dispatch",
+            "--input",
+            "tests/fixtures/bauclock_issue_23_export.json",
+            "--run-bridge",
+            "--parent-queue",
+            "21",
+        ],
+        capsys,
+    )
+
+    assert payload["status"] == "accepted"
+    assert payload["risk_level"] == "YELLOW"
+    assert payload["runner_route"] == "RUNNER_YELLOW"
+    assert payload["review_required"] is True
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert payload["allowed_files"] == [
+        "tests/test_calendar_service.py",
+        "tests/test_legal_hardening.py",
+    ]
+    assert payload["depends_on"] == [22]
+    assert "Parent queue #21" in payload["next_action"]
+
+
+def test_cli_issue_dispatch_red_forbidden_fixture(capsys) -> None:
+    payload = _run_fixture(
+        [
+            "issue-dispatch",
+            "--input",
+            "tests/fixtures/bauclock_issue_red_forbidden.json",
+            "--run-bridge",
+        ],
+        capsys,
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["risk_level"] == "RED"
+    assert payload["runner_route"] == "BLOCKED"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert payload["blockers"]
+
+
+def test_cli_issue_dispatch_depends_on_flag(capsys) -> None:
+    payload = _run_fixture(
+        [
+            "issue-dispatch",
+            "--input",
+            "tests/fixtures/bauclock_issue_22_export.json",
+            "--depends-on",
+            "20,21",
+        ],
+        capsys,
+    )
+
+    assert payload["depends_on"] == [20, 21]

--- a/tests/skeleton_core/test_issue_dispatch.py
+++ b/tests/skeleton_core/test_issue_dispatch.py
@@ -1,0 +1,103 @@
+from tools.skeleton_core.issue_dispatch import (
+    IssueDispatchInput,
+    build_issue_dispatch_packet,
+)
+
+
+def test_issue_dispatch_accepts_green() -> None:
+    result = build_issue_dispatch_packet(
+        IssueDispatchInput(
+            repository="alanua/bauclock",
+            issue_number=22,
+            title="[agent-task-green] BauClock overnight baseline validation",
+            body="""## Validation required
+
+```bash
+python -m pytest
+```""",
+        )
+    )
+
+    assert result.status == "accepted"
+    assert result.risk_level == "GREEN"
+    assert result.runner_route == "RUNNER_GREEN"
+    assert result.review_required is False
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.expected_commands == ["python -m pytest"]
+
+
+def test_issue_dispatch_accepts_yellow_with_allowed_files_and_dependency() -> None:
+    result = build_issue_dispatch_packet(
+        IssueDispatchInput(
+            repository="alanua/bauclock",
+            issue_number=23,
+            title="[agent-task-yellow] BauClock test-only hardening",
+            body="""## Allowed files
+
+```text
+tests/test_calendar_service.py
+tests/test_legal_hardening.py
+```
+
+## Validation required
+
+```bash
+python -m pytest tests/test_calendar_service.py tests/test_legal_hardening.py -q
+python -m pytest
+```""",
+            comments=["depends_on #22"],
+        ),
+        depends_on=[21],
+    )
+
+    assert result.status == "accepted"
+    assert result.risk_level == "YELLOW"
+    assert result.runner_route == "RUNNER_YELLOW"
+    assert result.review_required is True
+    assert result.allowed_files == [
+        "text",
+        "tests/test_calendar_service.py",
+        "tests/test_legal_hardening.py",
+    ]
+    assert result.expected_commands == [
+        "python -m pytest tests/test_calendar_service.py tests/test_legal_hardening.py -q",
+        "python -m pytest",
+    ]
+    assert result.depends_on == [21, 22]
+
+
+def test_issue_dispatch_run_bridge_reuses_bridge_blocking() -> None:
+    result = build_issue_dispatch_packet(
+        IssueDispatchInput(
+            repository="alanua/bauclock",
+            issue_number=999,
+            title="[agent-task-red] Deploy production with token",
+            body="Deploy to production and use API key from .env.",
+        ),
+        run_bridge=True,
+    )
+
+    assert result.status == "blocked"
+    assert result.risk_level == "RED"
+    assert result.runner_route == "BLOCKED"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.blockers
+    assert any("deploy" in blocker for blocker in result.blockers)
+
+
+def test_issue_dispatch_unknown_without_marker() -> None:
+    result = build_issue_dispatch_packet(
+        IssueDispatchInput(
+            repository="alanua/bauclock",
+            issue_number=24,
+            title="Plain task",
+            body="Do something public-safe.",
+        )
+    )
+
+    assert result.status == "unknown_needs_review"
+    assert result.risk_level == "UNKNOWN"
+    assert result.runner_route == "BLOCKED"
+    assert result.blockers == ["Unsupported risk level: UNKNOWN"]

--- a/tests/skeleton_core/test_issue_dispatch.py
+++ b/tests/skeleton_core/test_issue_dispatch.py
@@ -56,7 +56,6 @@ python -m pytest
     assert result.runner_route == "RUNNER_YELLOW"
     assert result.review_required is True
     assert result.allowed_files == [
-        "text",
         "tests/test_calendar_service.py",
         "tests/test_legal_hardening.py",
     ]

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from tools.skeleton_core.checkpoint import render_checkpoint
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.handoff_pack import render_handoff_pack
+from tools.skeleton_core.issue_dispatch import IssueDispatchInput, build_issue_dispatch_packet
 from tools.skeleton_core.issue_runner_bridge import IssueRunnerInput, build_issue_runner_packet
 from tools.skeleton_core.job_log_summary import summarize_job_log
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
@@ -32,6 +33,7 @@ SUBCOMMANDS = {
     "classify-queue",
     "decide",
     "handoff-pack",
+    "issue-dispatch",
     "issue-runner-bridge",
     "job-log-summary",
     "pr-status",
@@ -76,6 +78,11 @@ def load_pr_status_input(input_path: Path) -> PRStatusInput:
 def load_issue_runner_input(input_path: Path) -> IssueRunnerInput:
     """Load public-safe issue runner input from JSON."""
     return IssueRunnerInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_issue_dispatch_input(input_path: Path) -> IssueDispatchInput:
+    """Load public-safe issue dispatch input from JSON."""
+    return IssueDispatchInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_runner_command_input(input_path: Path) -> RunnerCommandInput:
@@ -233,6 +240,28 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Repository root to use",
     )
 
+    issue_dispatch_parser = subparsers.add_parser(
+        "issue-dispatch",
+        help="Normalize a public-safe issue export for runner bridge",
+    )
+    _add_issue_input_arg(issue_dispatch_parser)
+    issue_dispatch_parser.add_argument(
+        "--run-bridge",
+        action="store_true",
+        help="Run normalized packet through issue-runner-bridge locally",
+    )
+    issue_dispatch_parser.add_argument(
+        "--parent-queue",
+        type=int,
+        default=None,
+        help="Optional parent queue issue number",
+    )
+    issue_dispatch_parser.add_argument(
+        "--depends-on",
+        default="",
+        help="Optional comma-separated dependency issue numbers",
+    )
+
     issue_runner_parser = subparsers.add_parser(
         "issue-runner-bridge",
         help="Build a GREEN/YELLOW runner packet from public-safe issue JSON",
@@ -355,6 +384,22 @@ def _run_classify_queue(args: argparse.Namespace) -> int:
 
 def _run_handoff_pack(args: argparse.Namespace) -> int:
     print(render_handoff_pack(args.root), flush=True)
+    return 0
+
+
+def _run_issue_dispatch(args: argparse.Namespace) -> int:
+    try:
+        result = build_issue_dispatch_packet(
+            load_issue_dispatch_input(args.input),
+            run_bridge=args.run_bridge,
+            parent_queue=args.parent_queue,
+            depends_on=[int(value) for value in _split_csv(args.depends_on)],
+        )
+    except (ValidationError, ValueError) as exc:
+        print(str(exc), flush=True)
+        return 2
+
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
     return 0
 
 
@@ -506,6 +551,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_classify_queue(args)
     if args.command == "handoff-pack":
         return _run_handoff_pack(args)
+    if args.command == "issue-dispatch":
+        return _run_issue_dispatch(args)
     if args.command == "issue-runner-bridge":
         return _run_issue_runner_bridge(args)
     if args.command == "job-log-summary":

--- a/tools/skeleton_core/issue_dispatch.py
+++ b/tools/skeleton_core/issue_dispatch.py
@@ -83,7 +83,7 @@ def _section_lines(body: str, headings: tuple[str, ...]) -> list[str]:
     in_fence = False
     for line in lines:
         stripped = line.strip()
-        heading = stripped.strip("#:").casefold()
+        heading = stripped.strip("#:").strip().casefold()
         if any(heading.startswith(candidate) for candidate in headings):
             collecting = True
             continue

--- a/tools/skeleton_core/issue_dispatch.py
+++ b/tools/skeleton_core/issue_dispatch.py
@@ -153,6 +153,14 @@ def _bridge_input(packet: IssueDispatchInput, risk: BridgeRisk) -> IssueRunnerIn
     )
 
 
+def _route_without_bridge(risk: BridgeRisk) -> RunnerRoute:
+    if risk == "YELLOW":
+        return "RUNNER_YELLOW"
+    if risk == "GREEN":
+        return "RUNNER_GREEN"
+    return "BLOCKED"
+
+
 def build_issue_dispatch_packet(
     packet: IssueDispatchInput,
     *,
@@ -176,13 +184,7 @@ def build_issue_dispatch_packet(
         next_action = bridge_result.next_action
     else:
         status = "accepted" if risk in {"GREEN", "YELLOW"} else "unknown_needs_review"
-        runner_route = (
-            "RUNNER_YELLOW"
-            if risk == "YELLOW"
-            else "RUNNER_GREEN"
-            if risk == "GREEN"
-            else "BLOCKED"
-        )
+        runner_route = _route_without_bridge(risk)
         review_required = risk == "YELLOW"
         blockers = [] if risk in {"GREEN", "YELLOW"} else [f"Unsupported risk level: {risk}"]
         next_action = "Run issue-runner-bridge for the normalized packet; do not merge or deploy."

--- a/tools/skeleton_core/issue_dispatch.py
+++ b/tools/skeleton_core/issue_dispatch.py
@@ -80,15 +80,21 @@ def _section_lines(body: str, headings: tuple[str, ...]) -> list[str]:
     lines = body.splitlines()
     captured: list[str] = []
     collecting = False
+    in_fence = False
     for line in lines:
         stripped = line.strip()
         heading = stripped.strip("#:").casefold()
         if any(heading.startswith(candidate) for candidate in headings):
             collecting = True
             continue
-        if collecting and stripped.startswith("##"):
+        if collecting and stripped.startswith("##") and not in_fence:
             break
-        if collecting and stripped:
+        if not collecting:
+            continue
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if stripped:
             captured.append(stripped)
     return captured
 
@@ -99,12 +105,7 @@ def _clean_list_item(line: str) -> str:
 
 def _extract_allowed_files(body: str) -> list[str]:
     lines = _section_lines(body, ("allowed files", "allowed files only"))
-    files = []
-    for line in lines:
-        cleaned = _clean_list_item(line)
-        if cleaned and not cleaned.startswith("```"):
-            files.append(cleaned)
-    return files
+    return [_clean_list_item(line) for line in lines if _clean_list_item(line)]
 
 
 def _extract_expected_commands(body: str) -> list[str]:

--- a/tools/skeleton_core/issue_dispatch.py
+++ b/tools/skeleton_core/issue_dispatch.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from tools.skeleton_core.issue_runner_bridge import (
     BridgeRisk,
     BridgeStatus,
+    IssueRunnerInput,
     RunnerRoute,
     build_issue_runner_packet,
 )
@@ -129,22 +130,26 @@ def _extract_expected_commands(body: str) -> list[str]:
 def _extract_dependencies(packet: IssueDispatchInput) -> list[int]:
     text = _combined_text(packet)
     dependencies = set()
-    for pattern in (r"depends[_ -]?on\s*#?(\d+)", r"blocked until\s*#?(\d+)", r"after\s*#(\d+)"):
+    for pattern in (
+        r"depends[_ -]?on\s*#?(\d+)",
+        r"blocked until\s*#?(\d+)",
+        r"after\s*#(\d+)",
+    ):
         for match in re.finditer(pattern, text, flags=re.IGNORECASE):
             dependencies.add(int(match.group(1)))
     return sorted(dependencies)
 
 
-def _bridge_input(packet: IssueDispatchInput, risk: BridgeRisk) -> dict[str, object]:
-    return {
-        "issue_number": _issue_number(packet),
-        "title": packet.title,
-        "body": packet.body,
-        "labels": packet.labels,
-        "risk_level": risk,
-        "project": "skeleton",
-        "requested_by": "oleksii",
-    }
+def _bridge_input(packet: IssueDispatchInput, risk: BridgeRisk) -> IssueRunnerInput:
+    return IssueRunnerInput(
+        issue_number=_issue_number(packet),
+        title=packet.title,
+        body=packet.body,
+        labels=packet.labels,
+        risk_level=risk,
+        project="skeleton",
+        requested_by="oleksii",
+    )
 
 
 def build_issue_dispatch_packet(
@@ -161,13 +166,8 @@ def build_issue_dispatch_packet(
     allowed_files = _extract_allowed_files(packet.body)
     expected_commands = _extract_expected_commands(packet.body)
 
-    bridge = build_issue_runner_packet.model_validate if False else None
     if run_bridge:
-        from tools.skeleton_core.issue_runner_bridge import IssueRunnerInput
-
-        bridge_result = build_issue_runner_packet(
-            IssueRunnerInput.model_validate(_bridge_input(packet, risk))
-        )
+        bridge_result = build_issue_runner_packet(_bridge_input(packet, risk))
         status: BridgeStatus = bridge_result.status
         runner_route = bridge_result.runner_route
         review_required = bridge_result.review_required
@@ -175,7 +175,13 @@ def build_issue_dispatch_packet(
         next_action = bridge_result.next_action
     else:
         status = "accepted" if risk in {"GREEN", "YELLOW"} else "unknown_needs_review"
-        runner_route = "RUNNER_YELLOW" if risk == "YELLOW" else "RUNNER_GREEN" if risk == "GREEN" else "BLOCKED"
+        runner_route = (
+            "RUNNER_YELLOW"
+            if risk == "YELLOW"
+            else "RUNNER_GREEN"
+            if risk == "GREEN"
+            else "BLOCKED"
+        )
         review_required = risk == "YELLOW"
         blockers = [] if risk in {"GREEN", "YELLOW"} else [f"Unsupported risk level: {risk}"]
         next_action = "Run issue-runner-bridge for the normalized packet; do not merge or deploy."

--- a/tools/skeleton_core/issue_dispatch.py
+++ b/tools/skeleton_core/issue_dispatch.py
@@ -1,0 +1,216 @@
+"""Local offline issue export dispatcher for Skeleton runner bridge."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.issue_runner_bridge import (
+    BridgeRisk,
+    BridgeStatus,
+    RunnerRoute,
+    build_issue_runner_packet,
+)
+
+IssueDispatchStatus = Literal["accepted", "blocked", "unknown_needs_review"]
+
+RISK_TITLE_PATTERNS: tuple[tuple[str, BridgeRisk], ...] = (
+    (r"\[agent-task-green\]", "GREEN"),
+    (r"\[agent-task-yellow\]", "YELLOW"),
+    (r"\[agent-task-orange\]", "ORANGE"),
+    (r"\[agent-task-red\]", "RED"),
+)
+
+
+class IssueDispatchInput(BaseModel):
+    """Public-safe GitHub issue export accepted by issue-dispatch."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    repository: str
+    issue_number: int | None = None
+    number: int | None = None
+    title: str
+    body: str = ""
+    comments: list[str] = Field(default_factory=list)
+    state: str = "open"
+    labels: list[str] = Field(default_factory=list)
+
+
+class IssueDispatchPacket(BaseModel):
+    """Normalized public-safe dispatch output for issue-runner-bridge."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    issue_number: int
+    repository: str
+    status: IssueDispatchStatus
+    risk_level: BridgeRisk
+    runner_route: RunnerRoute
+    review_required: bool
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    allowed_files: list[str] = Field(default_factory=list)
+    expected_commands: list[str] = Field(default_factory=list)
+    depends_on: list[int] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    next_action: str
+
+
+def _issue_number(packet: IssueDispatchInput) -> int:
+    return packet.issue_number or packet.number or 0
+
+
+def _combined_text(packet: IssueDispatchInput) -> str:
+    return "\n".join([packet.title, packet.body, *packet.comments])
+
+
+def _infer_risk(packet: IssueDispatchInput) -> BridgeRisk:
+    text = _combined_text(packet)
+    for pattern, risk in RISK_TITLE_PATTERNS:
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            return risk
+    return "UNKNOWN"
+
+
+def _section_lines(body: str, headings: tuple[str, ...]) -> list[str]:
+    lines = body.splitlines()
+    captured: list[str] = []
+    collecting = False
+    for line in lines:
+        stripped = line.strip()
+        heading = stripped.strip("#:").casefold()
+        if any(heading.startswith(candidate) for candidate in headings):
+            collecting = True
+            continue
+        if collecting and stripped.startswith("##"):
+            break
+        if collecting and stripped:
+            captured.append(stripped)
+    return captured
+
+
+def _clean_list_item(line: str) -> str:
+    return line.strip().lstrip("-*").strip().strip("`")
+
+
+def _extract_allowed_files(body: str) -> list[str]:
+    lines = _section_lines(body, ("allowed files", "allowed files only"))
+    files = []
+    for line in lines:
+        cleaned = _clean_list_item(line)
+        if cleaned and not cleaned.startswith("```"):
+            files.append(cleaned)
+    return files
+
+
+def _extract_expected_commands(body: str) -> list[str]:
+    commands: list[str] = []
+    in_fence = False
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```bash") or stripped.startswith("```shell"):
+            in_fence = True
+            continue
+        if stripped.startswith("```"):
+            in_fence = False
+            continue
+        if in_fence and stripped:
+            commands.append(stripped)
+    if commands:
+        return commands
+
+    lines = _section_lines(body, ("validation", "validation required", "expected commands"))
+    return [_clean_list_item(line) for line in lines if _clean_list_item(line)]
+
+
+def _extract_dependencies(packet: IssueDispatchInput) -> list[int]:
+    text = _combined_text(packet)
+    dependencies = set()
+    for pattern in (r"depends[_ -]?on\s*#?(\d+)", r"blocked until\s*#?(\d+)", r"after\s*#(\d+)"):
+        for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+            dependencies.add(int(match.group(1)))
+    return sorted(dependencies)
+
+
+def _bridge_input(packet: IssueDispatchInput, risk: BridgeRisk) -> dict[str, object]:
+    return {
+        "issue_number": _issue_number(packet),
+        "title": packet.title,
+        "body": packet.body,
+        "labels": packet.labels,
+        "risk_level": risk,
+        "project": "skeleton",
+        "requested_by": "oleksii",
+    }
+
+
+def build_issue_dispatch_packet(
+    packet: IssueDispatchInput,
+    *,
+    run_bridge: bool = False,
+    parent_queue: int | None = None,
+    depends_on: list[int] | None = None,
+) -> IssueDispatchPacket:
+    """Normalize a public-safe issue export and optionally run issue-runner-bridge."""
+    risk = _infer_risk(packet)
+    issue_number = _issue_number(packet)
+    dependencies = sorted(set(_extract_dependencies(packet) + (depends_on or [])))
+    allowed_files = _extract_allowed_files(packet.body)
+    expected_commands = _extract_expected_commands(packet.body)
+
+    bridge = build_issue_runner_packet.model_validate if False else None
+    if run_bridge:
+        from tools.skeleton_core.issue_runner_bridge import IssueRunnerInput
+
+        bridge_result = build_issue_runner_packet(
+            IssueRunnerInput.model_validate(_bridge_input(packet, risk))
+        )
+        status: BridgeStatus = bridge_result.status
+        runner_route = bridge_result.runner_route
+        review_required = bridge_result.review_required
+        blockers = list(bridge_result.blockers)
+        next_action = bridge_result.next_action
+    else:
+        status = "accepted" if risk in {"GREEN", "YELLOW"} else "unknown_needs_review"
+        runner_route = "RUNNER_YELLOW" if risk == "YELLOW" else "RUNNER_GREEN" if risk == "GREEN" else "BLOCKED"
+        review_required = risk == "YELLOW"
+        blockers = [] if risk in {"GREEN", "YELLOW"} else [f"Unsupported risk level: {risk}"]
+        next_action = "Run issue-runner-bridge for the normalized packet; do not merge or deploy."
+
+    if parent_queue is not None:
+        next_action = f"Parent queue #{parent_queue}. {next_action}"
+
+    return IssueDispatchPacket(
+        issue_number=issue_number,
+        repository=packet.repository,
+        status=status,
+        risk_level=risk,
+        runner_route=runner_route,
+        review_required=review_required,
+        merge_allowed=False,
+        deploy_allowed=False,
+        allowed_files=allowed_files,
+        expected_commands=expected_commands,
+        depends_on=dependencies,
+        blockers=blockers,
+        next_action=next_action,
+    )
+
+
+def build_issue_dispatch_packet_from_json(
+    raw_json: str,
+    *,
+    run_bridge: bool = False,
+    parent_queue: int | None = None,
+    depends_on: list[int] | None = None,
+) -> IssueDispatchPacket:
+    """Validate local JSON text and build an issue dispatch packet."""
+    return build_issue_dispatch_packet(
+        IssueDispatchInput.model_validate_json(raw_json),
+        run_bridge=run_bridge,
+        parent_queue=parent_queue,
+        depends_on=depends_on,
+    )


### PR DESCRIPTION
## Summary

Implements #62 as a local/offline Skeleton Core command:

```text
python -m tools.skeleton_core.cli issue-dispatch --input tests/fixtures/bauclock_issue_22_export.json
python -m tools.skeleton_core.cli issue-dispatch --input tests/fixtures/bauclock_issue_23_export.json --run-bridge
python -m tools.skeleton_core.cli issue-dispatch --input tests/fixtures/bauclock_issue_red_forbidden.json --run-bridge
```

The command reads public-safe issue export JSON and emits a normalized dispatch packet with:

```text
risk_level
runner_route
review_required
allowed_files
expected_commands
depends_on
merge_allowed=false
deploy_allowed=false
```

It can optionally reuse `issue-runner-bridge` with `--run-bridge`.

## Safety

```text
No Jeeves runtime changes.
No BauClock runtime changes.
No GitHub API calls from the CLI.
No network calls.
No runner/shell execution.
No secrets/private data.
No merge/deploy authority.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Manual fixture commands to verify after checkout:

```bash
python -m tools.skeleton_core.cli issue-dispatch --input tests/fixtures/bauclock_issue_22_export.json
python -m tools.skeleton_core.cli issue-dispatch --input tests/fixtures/bauclock_issue_23_export.json --run-bridge
python -m tools.skeleton_core.cli issue-dispatch --input tests/fixtures/bauclock_issue_red_forbidden.json --run-bridge
```

Closes #62.