### PR TITLE
Add Skeleton queue-state command

### DIFF
--- a/tests/fixtures/bauclock_queue_21_after_22_green.json
+++ b/tests/fixtures/bauclock_queue_21_after_22_green.json
@@ -1,0 +1,36 @@
+{
+  "controller_issue": {
+    "repository": "alanua/bauclock",
+    "issue_number": 21,
+    "title": "[night-queue] BauClock expanded safe overnight queue",
+    "body": "Queue order: #22 then #23 then #24."
+  },
+  "items": [
+    {
+      "issue_number": 22,
+      "title": "[agent-task-green] BauClock overnight baseline validation",
+      "risk_level": "GREEN",
+      "state": "open",
+      "comments": ["Agent report: validation passed."],
+      "prs": []
+    },
+    {
+      "issue_number": 23,
+      "title": "[agent-task-yellow] BauClock test-only calendar and manual-time access-control hardening",
+      "risk_level": "YELLOW",
+      "state": "open",
+      "depends_on": [22],
+      "comments": [],
+      "prs": []
+    },
+    {
+      "issue_number": 24,
+      "title": "[agent-task-yellow] BauClock follow-up implementation guard",
+      "risk_level": "YELLOW",
+      "state": "open",
+      "depends_on": [23],
+      "comments": [],
+      "prs": []
+    }
+  ]
+}

--- a/tests/fixtures/bauclock_queue_21_blocked_impl_green_audit_fallback.json
+++ b/tests/fixtures/bauclock_queue_21_blocked_impl_green_audit_fallback.json
@@ -1,0 +1,43 @@
+{
+  "controller_issue": {
+    "repository": "alanua/bauclock",
+    "issue_number": 21,
+    "title": "[night-queue] BauClock expanded safe overnight queue",
+    "body": "Queue order: #22 then #23 then #24 then #25."
+  },
+  "items": [
+    {
+      "issue_number": 22,
+      "title": "[agent-task-green] BauClock overnight baseline validation",
+      "risk_level": "GREEN",
+      "state": "open",
+      "comments": ["Agent report: validation passed."],
+      "prs": []
+    },
+    {
+      "issue_number": 23,
+      "title": "[agent-task-yellow] BauClock test-only calendar hardening",
+      "risk_level": "YELLOW",
+      "state": "open",
+      "comments": ["blocked until #99 external prerequisite"],
+      "prs": []
+    },
+    {
+      "issue_number": 24,
+      "title": "[agent-task-yellow] BauClock follow-up implementation guard",
+      "risk_level": "YELLOW",
+      "state": "open",
+      "depends_on": [23],
+      "comments": [],
+      "prs": []
+    },
+    {
+      "issue_number": 25,
+      "title": "[agent-task-green] BauClock fallback audit",
+      "risk_level": "GREEN",
+      "state": "open",
+      "comments": [],
+      "prs": []
+    }
+  ]
+}

--- a/tests/fixtures/bauclock_queue_21_state.json
+++ b/tests/fixtures/bauclock_queue_21_state.json
@@ -1,0 +1,36 @@
+{
+  "controller_issue": {
+    "repository": "alanua/bauclock",
+    "issue_number": 21,
+    "title": "[night-queue] BauClock expanded safe overnight queue",
+    "body": "Queue order: #22 then #23 then #24."
+  },
+  "items": [
+    {
+      "issue_number": 22,
+      "title": "[agent-task-green] BauClock overnight baseline validation",
+      "risk_level": "GREEN",
+      "state": "open",
+      "comments": [],
+      "prs": []
+    },
+    {
+      "issue_number": 23,
+      "title": "[agent-task-yellow] BauClock test-only calendar and manual-time access-control hardening",
+      "risk_level": "YELLOW",
+      "state": "open",
+      "depends_on": [22],
+      "comments": [],
+      "prs": []
+    },
+    {
+      "issue_number": 24,
+      "title": "[agent-task-yellow] BauClock follow-up implementation guard",
+      "risk_level": "YELLOW",
+      "state": "open",
+      "depends_on": [23],
+      "comments": [],
+      "prs": []
+    }
+  ]
+}

--- a/tests/skeleton_core/test_cli_queue_state.py
+++ b/tests/skeleton_core/test_cli_queue_state.py
@@ -1,0 +1,44 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["queue-state", "--input", path, "--project", "bauclock"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_queue_state_initial_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/bauclock_queue_21_state.json", capsys)
+
+    assert payload["repository"] == "alanua/bauclock"
+    assert payload["controller_issue"] == 21
+    assert payload["next_runnable_issue"] == 22
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert payload["summary"]["runnable"] == 1
+    assert payload["summary"]["blocked_by_dependency"] == 2
+
+
+def test_cli_queue_state_after_green_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/bauclock_queue_21_after_22_green.json", capsys)
+
+    assert payload["next_runnable_issue"] == 23
+    assert payload["summary"]["completed_or_reported"] == 1
+    assert payload["summary"]["runnable"] == 1
+    assert "bauclock" in payload["next_runnable_reason"]
+
+
+def test_cli_queue_state_fallback_fixture(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/bauclock_queue_21_blocked_impl_green_audit_fallback.json",
+        capsys,
+    )
+
+    assert payload["next_runnable_issue"] == 25
+    assert payload["summary"]["runnable"] == 1
+    assert payload["summary"]["blocked_by_dependency"] == 2
+    assert payload["items"][1]["blocked_by"] == [99]

--- a/tests/skeleton_core/test_queue_state.py
+++ b/tests/skeleton_core/test_queue_state.py
@@ -1,0 +1,133 @@
+from tools.skeleton_core.queue_state import (
+    QueueControllerIssue,
+    QueueStateInput,
+    QueueStateInputItem,
+    build_queue_state,
+)
+
+
+def _controller(body: str = "Queue order: #22 then #23 then #24.") -> QueueControllerIssue:
+    return QueueControllerIssue(
+        repository="alanua/bauclock",
+        issue_number=21,
+        title="[night-queue] BauClock expanded safe overnight queue",
+        body=body,
+    )
+
+
+def test_queue_state_initial_returns_green_baseline() -> None:
+    result = build_queue_state(
+        QueueStateInput(
+            controller_issue=_controller(),
+            items=[
+                QueueStateInputItem(
+                    issue_number=22,
+                    title="[agent-task-green] BauClock overnight baseline validation",
+                    risk_level="GREEN",
+                ),
+                QueueStateInputItem(
+                    issue_number=23,
+                    title="[agent-task-yellow] BauClock hardening",
+                    risk_level="YELLOW",
+                    depends_on=[22],
+                ),
+            ],
+        )
+    )
+
+    assert result.next_runnable_issue == 22
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.summary["runnable"] == 1
+    assert result.summary["blocked_by_dependency"] == 1
+    assert result.items[0].state == "runnable"
+    assert result.items[1].state == "blocked_by_dependency"
+    assert result.items[1].blocked_by == [22]
+
+
+def test_queue_state_after_green_returns_yellow() -> None:
+    result = build_queue_state(
+        QueueStateInput(
+            controller_issue=_controller(),
+            items=[
+                QueueStateInputItem(
+                    issue_number=22,
+                    title="[agent-task-green] BauClock overnight baseline validation",
+                    risk_level="GREEN",
+                    comments=["Agent report: validation passed."],
+                ),
+                QueueStateInputItem(
+                    issue_number=23,
+                    title="[agent-task-yellow] BauClock hardening",
+                    risk_level="YELLOW",
+                    depends_on=[22],
+                ),
+            ],
+        )
+    )
+
+    assert result.next_runnable_issue == 23
+    assert result.summary["completed_or_reported"] == 1
+    assert result.summary["runnable"] == 1
+    assert result.items[0].state == "completed_or_reported"
+    assert result.items[1].state == "runnable"
+
+
+def test_queue_state_green_fallback_when_impl_blocked() -> None:
+    result = build_queue_state(
+        QueueStateInput(
+            controller_issue=_controller("Queue order: #22 then #23 then #24 then #25."),
+            items=[
+                QueueStateInputItem(
+                    issue_number=22,
+                    title="[agent-task-green] BauClock baseline",
+                    risk_level="GREEN",
+                    comments=["Agent report: validation passed."],
+                ),
+                QueueStateInputItem(
+                    issue_number=23,
+                    title="[agent-task-yellow] BauClock hardening",
+                    risk_level="YELLOW",
+                    comments=["blocked until #99 external prerequisite"],
+                ),
+                QueueStateInputItem(
+                    issue_number=24,
+                    title="[agent-task-yellow] BauClock implementation guard",
+                    risk_level="YELLOW",
+                    depends_on=[23],
+                ),
+                QueueStateInputItem(
+                    issue_number=25,
+                    title="[agent-task-green] BauClock fallback audit",
+                    risk_level="GREEN",
+                ),
+            ],
+        )
+    )
+
+    assert result.next_runnable_issue == 25
+    assert result.summary["runnable"] == 1
+    assert result.summary["blocked_by_dependency"] == 2
+    assert result.items[1].blocked_by == [99]
+    assert result.items[3].state == "runnable"
+
+
+def test_queue_state_blocks_unsafe_or_unknown() -> None:
+    result = build_queue_state(
+        QueueStateInput(
+            controller_issue=_controller("Queue order: #30."),
+            items=[
+                QueueStateInputItem(
+                    issue_number=30,
+                    title="[agent-task-red] Deploy production with token",
+                    risk_level="RED",
+                    body="Deploy to production with API key from .env.",
+                )
+            ],
+        )
+    )
+
+    assert result.next_runnable_issue is None
+    assert result.summary["unsafe_or_unknown"] == 1
+    assert result.items[0].state == "unsafe_or_unknown"
+    assert result.items[0].blockers

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -19,6 +19,7 @@ from tools.skeleton_core.job_log_summary import summarize_job_log
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.pr_status import PRStatusInput, build_pr_status
 from tools.skeleton_core.queue_classifier import classify_queue_items
+from tools.skeleton_core.queue_state import QueueStateInput, build_queue_state
 from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.runner_command_pack import RunnerCommandInput, build_runner_command_pack
@@ -37,6 +38,7 @@ SUBCOMMANDS = {
     "issue-runner-bridge",
     "job-log-summary",
     "pr-status",
+    "queue-state",
     "queue-summary",
     "runner-command-pack",
     "runner-report-from-trace",
@@ -68,6 +70,11 @@ def load_queue_items(input_path: Path) -> list[dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("queue input must be a JSON list")
     return raw_items
+
+
+def load_queue_state_input(input_path: Path) -> QueueStateInput:
+    """Load public-safe queue-state input from JSON."""
+    return QueueStateInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_pr_status_input(input_path: Path) -> PRStatusInput:
@@ -280,6 +287,17 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
     _add_input_arg(pr_status_parser, "Path to public-safe PR status JSON")
 
+    queue_state_parser = subparsers.add_parser(
+        "queue-state",
+        help="Determine the next runnable item from public-safe queue state JSON",
+    )
+    _add_input_arg(queue_state_parser, "Path to public-safe queue state JSON")
+    queue_state_parser.add_argument(
+        "--project",
+        default=None,
+        help="Optional project label for the next runnable reason",
+    )
+
     queue_parser = subparsers.add_parser(
         "queue-summary",
         help="Summarize an offline queue JSON file",
@@ -430,6 +448,17 @@ def _run_pr_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_queue_state(args: argparse.Namespace) -> int:
+    try:
+        result = build_queue_state(load_queue_state_input(args.input), project=args.project)
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_queue_summary(args: argparse.Namespace) -> int:
     print(
         json.dumps(build_queue_summary_payload(args.input), ensure_ascii=False, indent=2),
@@ -559,6 +588,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_job_log_summary(args)
     if args.command == "pr-status":
         return _run_pr_status(args)
+    if args.command == "queue-state":
+        return _run_queue_state(args)
     if args.command == "queue-summary":
         return _run_queue_summary(args)
     if args.command == "runner-command-pack":

--- a/tools/skeleton_core/queue_state.py
+++ b/tools/skeleton_core/queue_state.py
@@ -21,7 +21,9 @@ UNSAFE_PATTERNS = {
     "deploy": r"\bdeploy\b|\bdeployment\b|\brelease\b",
     "production": r"production db|production database|\bprod db\b",
     "server": r"server ssh|\bssh\b",
-    "secret": r"\.env|\bsecret\b|\bsecrets\b|\btoken\b|\btokens\b|api key|apikey|credential|password",
+    "secret": (
+        r"\.env|\bsecret\b|\bsecrets\b|\btoken\b|\btokens\b|api key|apikey|credential|password"
+    ),
     "network": r"live network|live executor|external service|external api|http[s]?://",
 }
 
@@ -97,7 +99,10 @@ def _completed_or_reported(item: QueueStateInputItem) -> bool:
     if item.state.casefold() in {"closed", "done", "completed"}:
         return True
     text = _combined_text(item).casefold()
-    if any(marker in text for marker in ("agent report", "completed", "validation passed", "ci success")):
+    if any(
+        marker in text
+        for marker in ("agent report", "completed", "validation passed", "ci success")
+    ):
         return True
     for pr in item.prs:
         merged = pr.get("merged")
@@ -177,7 +182,9 @@ def build_queue_state(queue: QueueStateInput, *, project: str | None = None) -> 
         item = item_by_number[issue_number]
         blockers = _unsafe_blockers(item)
         dependencies = _inferred_dependencies(item)
-        open_dependencies = [dependency for dependency in dependencies if dependency not in completed]
+        open_dependencies = [
+            dependency for dependency in dependencies if dependency not in completed
+        ]
 
         if _completed_or_reported(item):
             state: QueueItemState = "completed_or_reported"

--- a/tools/skeleton_core/queue_state.py
+++ b/tools/skeleton_core/queue_state.py
@@ -111,10 +111,7 @@ def _needs_review(item: QueueStateInputItem) -> bool:
     text = _combined_text(item).casefold()
     if "needs review" in text or "ready for review" in text:
         return True
-    for pr in item.prs:
-        if str(pr.get("state", "")).casefold() == "open":
-            return True
-    return False
+    return any(str(pr.get("state", "")).casefold() == "open" for pr in item.prs)
 
 
 def _unsafe_blockers(item: QueueStateInputItem) -> list[str]:

--- a/tools/skeleton_core/queue_state.py
+++ b/tools/skeleton_core/queue_state.py
@@ -1,0 +1,243 @@
+"""Local offline queue-state selector for Skeleton controller queues."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+QueueItemState = Literal[
+    "runnable",
+    "blocked_by_dependency",
+    "completed_or_reported",
+    "needs_review",
+    "unsafe_or_unknown",
+]
+QueueRiskLevel = Literal["GREEN", "YELLOW", "ORANGE", "RED", "UNKNOWN"]
+
+UNSAFE_PATTERNS = {
+    "merge": r"\bmerge\b|\bauto-merge\b",
+    "deploy": r"\bdeploy\b|\bdeployment\b|\brelease\b",
+    "production": r"production db|production database|\bprod db\b",
+    "server": r"server ssh|\bssh\b",
+    "secret": r"\.env|\bsecret\b|\bsecrets\b|\btoken\b|\btokens\b|api key|apikey|credential|password",
+    "network": r"live network|live executor|external service|external api|http[s]?://",
+}
+
+
+class QueueControllerIssue(BaseModel):
+    """Public-safe controller issue metadata."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    repository: str
+    issue_number: int
+    title: str
+    body: str = ""
+
+
+class QueueStateInputItem(BaseModel):
+    """Public-safe task item in a controller queue export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    issue_number: int
+    title: str
+    risk_level: QueueRiskLevel = "UNKNOWN"
+    state: str = "open"
+    body: str = ""
+    comments: list[str] = Field(default_factory=list)
+    prs: list[dict[str, object]] = Field(default_factory=list)
+    depends_on: list[int] = Field(default_factory=list)
+
+
+class QueueStateInput(BaseModel):
+    """Public-safe controller queue export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    controller_issue: QueueControllerIssue
+    items: list[QueueStateInputItem]
+
+
+class QueueStateItem(BaseModel):
+    """Deterministic state for one queue item."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    issue_number: int
+    risk_level: QueueRiskLevel
+    state: QueueItemState
+    blocked_by: list[int] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    recommended_command: str
+
+
+class QueueStateResult(BaseModel):
+    """Queue-state output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    controller_issue: int
+    next_runnable_issue: int | None
+    next_runnable_reason: str
+    summary: dict[QueueItemState, int]
+    items: list[QueueStateItem]
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+
+
+def _combined_text(item: QueueStateInputItem) -> str:
+    return "\n".join([item.title, item.body, *item.comments])
+
+
+def _completed_or_reported(item: QueueStateInputItem) -> bool:
+    if item.state.casefold() in {"closed", "done", "completed"}:
+        return True
+    text = _combined_text(item).casefold()
+    if any(marker in text for marker in ("agent report", "completed", "validation passed", "ci success")):
+        return True
+    for pr in item.prs:
+        merged = pr.get("merged")
+        state = str(pr.get("state", "")).casefold()
+        if merged is True or state in {"merged", "closed"}:
+            return True
+    return False
+
+
+def _needs_review(item: QueueStateInputItem) -> bool:
+    text = _combined_text(item).casefold()
+    if "needs review" in text or "ready for review" in text:
+        return True
+    for pr in item.prs:
+        if str(pr.get("state", "")).casefold() == "open":
+            return True
+    return False
+
+
+def _unsafe_blockers(item: QueueStateInputItem) -> list[str]:
+    text = _combined_text(item)
+    blockers = []
+    for name, pattern in UNSAFE_PATTERNS.items():
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            blockers.append(f"Unsafe text detected: {name}")
+    if item.risk_level not in {"GREEN", "YELLOW"}:
+        blockers.append(f"Unsupported risk level: {item.risk_level}")
+    return sorted(set(blockers))
+
+
+def _inferred_dependencies(item: QueueStateInputItem) -> list[int]:
+    dependencies = set(item.depends_on)
+    text = _combined_text(item)
+    for pattern in (
+        r"do not execute\s*#?\d+\s*until\s*#?(\d+)",
+        r"blocked until\s*#?(\d+)",
+        r"after\s*#(\d+)",
+        r"depends[_ -]?on\s*#?(\d+)",
+    ):
+        for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+            dependencies.add(int(match.group(1)))
+    return sorted(dependencies)
+
+
+def _recommended_command(item: QueueStateInputItem, state: QueueItemState) -> str:
+    if state == "runnable" and item.risk_level == "GREEN":
+        return "issue-dispatch then task-lifecycle then GREEN read-only validation"
+    if state == "runnable" and item.risk_level == "YELLOW":
+        return "issue-dispatch --run-bridge then runner-command-pack for YELLOW draft PR"
+    if state == "blocked_by_dependency":
+        return "wait for dependency completion/report"
+    if state == "completed_or_reported":
+        return "no action"
+    if state == "needs_review":
+        return "review report or PR before continuing"
+    return "manual review required"
+
+
+def _controller_order(queue: QueueStateInput) -> list[int]:
+    body = queue.controller_issue.body
+    ordered = []
+    for match in re.finditer(r"#(\d+)", body):
+        value = int(match.group(1))
+        if value != queue.controller_issue.issue_number and value not in ordered:
+            ordered.append(value)
+    item_numbers = [item.issue_number for item in queue.items]
+    return [number for number in ordered if number in item_numbers] + [
+        number for number in item_numbers if number not in ordered
+    ]
+
+
+def build_queue_state(queue: QueueStateInput, *, project: str | None = None) -> QueueStateResult:
+    """Build a deterministic local/offline queue-state result."""
+    completed = {item.issue_number for item in queue.items if _completed_or_reported(item)}
+    order = _controller_order(queue)
+    item_by_number = {item.issue_number: item for item in queue.items}
+    states: list[QueueStateItem] = []
+
+    for issue_number in order:
+        item = item_by_number[issue_number]
+        blockers = _unsafe_blockers(item)
+        dependencies = _inferred_dependencies(item)
+        open_dependencies = [dependency for dependency in dependencies if dependency not in completed]
+
+        if _completed_or_reported(item):
+            state: QueueItemState = "completed_or_reported"
+            blocked_by: list[int] = []
+        elif _needs_review(item):
+            state = "needs_review"
+            blocked_by = []
+        elif blockers:
+            state = "unsafe_or_unknown"
+            blocked_by = []
+        elif open_dependencies:
+            state = "blocked_by_dependency"
+            blocked_by = open_dependencies
+        else:
+            state = "runnable"
+            blocked_by = []
+
+        states.append(
+            QueueStateItem(
+                issue_number=item.issue_number,
+                risk_level=item.risk_level,
+                state=state,
+                blocked_by=blocked_by,
+                blockers=blockers,
+                recommended_command=_recommended_command(item, state),
+            )
+        )
+
+    next_item = next((item for item in states if item.state == "runnable"), None)
+    summary: dict[QueueItemState, int] = {
+        "runnable": 0,
+        "blocked_by_dependency": 0,
+        "completed_or_reported": 0,
+        "needs_review": 0,
+        "unsafe_or_unknown": 0,
+    }
+    for item in states:
+        summary[item.state] += 1
+
+    project_note = f" for {project}" if project else ""
+    if next_item is None:
+        reason = f"no runnable queue item{project_note}; review blocked/unknown items"
+    else:
+        reason = f"first safe runnable item{project_note} in controller order"
+
+    return QueueStateResult(
+        repository=queue.controller_issue.repository,
+        controller_issue=queue.controller_issue.issue_number,
+        next_runnable_issue=next_item.issue_number if next_item else None,
+        next_runnable_reason=reason,
+        summary=summary,
+        items=states,
+        merge_allowed=False,
+        deploy_allowed=False,
+    )
+
+
+def build_queue_state_from_json(raw_json: str, *, project: str | None = None) -> QueueStateResult:
+    """Validate local JSON text and build a queue-state result."""
+    return build_queue_state(QueueStateInput.model_validate_json(raw_json), project=project)


### PR DESCRIPTION
## Summary

Implements #71 as a local/offline Skeleton Core command:

```text
python -m tools.skeleton_core.cli queue-state --input tests/fixtures/bauclock_queue_21_state.json
python -m tools.skeleton_core.cli queue-state --input tests/fixtures/bauclock_queue_21_after_22_green.json
python -m tools.skeleton_core.cli queue-state --input tests/fixtures/bauclock_queue_21_blocked_impl_green_audit_fallback.json
```

The command reads public-safe controller queue JSON and emits deterministic queue state:

```text
next_runnable_issue
next_runnable_reason
summary
items[].state
items[].blocked_by
items[].recommended_command
merge_allowed=false
deploy_allowed=false
```

## Safety

```text
No Jeeves runtime changes.
No BauClock runtime changes.
No GitHub API calls from the CLI.
No network calls.
No runner/shell execution.
No secrets/private data.
No merge/deploy authority.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Manual fixture commands to verify after checkout:

```bash
python -m tools.skeleton_core.cli queue-state --input tests/fixtures/bauclock_queue_21_state.json
python -m tools.skeleton_core.cli queue-state --input tests/fixtures/bauclock_queue_21_after_22_green.json
python -m tools.skeleton_core.cli queue-state --input tests/fixtures/bauclock_queue_21_blocked_impl_green_audit_fallback.json
```

Closes #71.