### PR TITLE
Add Skeleton runner-report-ingest command

### DIFF
--- a/tests/fixtures/runner_report_blocked_23.txt
+++ b/tests/fixtures/runner_report_blocked_23.txt
@@ -1,0 +1,11 @@
+Blocked report: missing dependency #22 report.
+
+issue_number: 23
+branch: bauclock/calendar-hardening
+blocked_reason: waiting for #22 green baseline validation
+commands_run:
+repo_status: clean
+private_data_seen: false
+runtime_code_touched: false
+external_services_called: false
+next_safe_step: wait for dependency completion

--- a/tests/fixtures/runner_report_failed_tests.txt
+++ b/tests/fixtures/runner_report_failed_tests.txt
@@ -1,0 +1,13 @@
+Agent report for issue #24
+
+issue_number: 24
+branch: bauclock/failing-validation
+commands_run: python -m pytest
+test_result: failed
+repo_status: dirty
+failure_summary: tests failed in test_calendar_service.py
+private_data_seen: false
+runtime_code_touched: false
+external_services_called: false
+
+validation failed: tests failed in test_calendar_service.py

--- a/tests/fixtures/runner_report_green_22.txt
+++ b/tests/fixtures/runner_report_green_22.txt
@@ -1,0 +1,16 @@
+Agent report for issue #22
+
+issue_number: 22
+branch: bauclock/overnight-baseline
+head_sha: abc123def456
+commands_run: python -m pytest
+test_result: passed
+repo_status: clean
+changed_files:
+private_data_seen: false
+runtime_code_touched: false
+external_services_called: false
+next_safe_step: queue may advance
+
+178 passed
+working tree clean

--- a/tests/fixtures/runner_report_needs_review_pr.txt
+++ b/tests/fixtures/runner_report_needs_review_pr.txt
@@ -1,0 +1,15 @@
+Runner report for issue #25
+
+issue_number: 25
+branch: bauclock/review-needed
+head_sha: def456abc123
+commands_run: python -m pytest
+Tests: passed
+repo_status: clean
+open_prs: PR #88
+private_data_seen: false
+runtime_code_touched: false
+external_services_called: false
+next_safe_step: needs review before merge
+
+Draft PR #88 is ready for ChatGPT/Oleksii review.

--- a/tests/fixtures/runner_report_unsafe_secret_flag.txt
+++ b/tests/fixtures/runner_report_unsafe_secret_flag.txt
@@ -1,0 +1,12 @@
+Runner report for issue #26
+
+issue_number: 26
+branch: unsafe/secret-touch
+commands_run: python -m pytest
+test_result: passed
+repo_status: clean
+private_data_seen: true
+runtime_code_touched: false
+external_services_called: false
+failure_summary: used secret from environment by mistake
+next_safe_step: stop and report policy violation

--- a/tests/skeleton_core/test_cli_runner_report_ingest.py
+++ b/tests/skeleton_core/test_cli_runner_report_ingest.py
@@ -1,0 +1,64 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["runner-report-ingest", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_runner_report_ingest_green_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_report_green_22.txt", capsys)
+
+    assert payload["status"] == "green_report"
+    assert payload["issue_number"] == 22
+    assert payload["test_result"] == "passed"
+    assert payload["repo_status"] == "clean"
+    assert payload["needs_review"] is False
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert payload["next_queue_signal"] == "dependency_satisfied"
+
+
+def test_cli_runner_report_ingest_blocked_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_report_blocked_23.txt", capsys)
+
+    assert payload["status"] == "blocked_report"
+    assert payload["issue_number"] == 23
+    assert payload["blocked_reason"] == "waiting for #22 green baseline validation"
+    assert payload["needs_review"] is True
+    assert payload["next_queue_signal"] == "blocked"
+
+
+def test_cli_runner_report_ingest_failed_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_report_failed_tests.txt", capsys)
+
+    assert payload["status"] == "failed_validation"
+    assert payload["issue_number"] == 24
+    assert payload["test_result"] == "failed"
+    assert payload["next_queue_signal"] == "validation_failed"
+
+
+def test_cli_runner_report_ingest_needs_review_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_report_needs_review_pr.txt", capsys)
+
+    assert payload["status"] == "needs_review"
+    assert payload["issue_number"] == 25
+    assert payload["open_prs"] == ["PR #88"]
+    assert payload["needs_review"] is True
+    assert payload["next_queue_signal"] == "review_required"
+
+
+def test_cli_runner_report_ingest_unsafe_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_report_unsafe_secret_flag.txt", capsys)
+
+    assert payload["status"] == "unsafe_or_policy_violation"
+    assert payload["issue_number"] == 26
+    assert payload["private_data_seen"] is True
+    assert "private_data" in payload["unsafe_flags"]
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False

--- a/tests/skeleton_core/test_runner_report_ingest.py
+++ b/tests/skeleton_core/test_runner_report_ingest.py
@@ -2,8 +2,7 @@ from tools.skeleton_core.runner_report_ingest import ingest_runner_report
 
 
 def test_ingest_green_report() -> None:
-    result = ingest_runner_report(
-        """Agent report for issue #22
+    result = ingest_runner_report("""Agent report for issue #22
 
 issue_number: 22
 branch: bauclock/overnight-baseline
@@ -16,8 +15,7 @@ runtime_code_touched: false
 external_services_called: false
 178 passed
 working tree clean
-"""
-    )
+""")
 
     assert result.status == "green_report"
     assert result.issue_number == 22
@@ -33,13 +31,11 @@ working tree clean
 
 
 def test_ingest_blocked_report() -> None:
-    result = ingest_runner_report(
-        """Blocked report: missing dependency #22 report.
+    result = ingest_runner_report("""Blocked report: missing dependency #22 report.
 issue_number: 23
 blocked_reason: waiting for #22 green baseline validation
 repo_status: clean
-"""
-    )
+""")
 
     assert result.status == "blocked_report"
     assert result.issue_number == 23
@@ -49,16 +45,14 @@ repo_status: clean
 
 
 def test_ingest_failed_validation() -> None:
-    result = ingest_runner_report(
-        """Agent report for issue #24
+    result = ingest_runner_report("""Agent report for issue #24
 issue_number: 24
 commands_run: python -m pytest
 test_result: failed
 repo_status: dirty
 failure_summary: tests failed in test_calendar_service.py
 validation failed: tests failed in test_calendar_service.py
-"""
-    )
+""")
 
     assert result.status == "failed_validation"
     assert result.issue_number == 24
@@ -68,16 +62,14 @@ validation failed: tests failed in test_calendar_service.py
 
 
 def test_ingest_needs_review_pr() -> None:
-    result = ingest_runner_report(
-        """Runner report for issue #25
+    result = ingest_runner_report("""Runner report for issue #25
 issue_number: 25
 commands_run: python -m pytest
 Tests: passed
 repo_status: clean
 open_prs: PR #88
 Draft PR #88 is ready for ChatGPT/Oleksii review.
-"""
-    )
+""")
 
     assert result.status == "needs_review"
     assert result.issue_number == 25
@@ -87,15 +79,13 @@ Draft PR #88 is ready for ChatGPT/Oleksii review.
 
 
 def test_ingest_unsafe_secret_flag() -> None:
-    result = ingest_runner_report(
-        """Runner report for issue #26
+    result = ingest_runner_report("""Runner report for issue #26
 issue_number: 26
 test_result: passed
 repo_status: clean
 private_data_seen: true
 failure_summary: used secret from environment by mistake
-"""
-    )
+""")
 
     assert result.status == "unsafe_or_policy_violation"
     assert result.issue_number == 26

--- a/tests/skeleton_core/test_runner_report_ingest.py
+++ b/tests/skeleton_core/test_runner_report_ingest.py
@@ -1,0 +1,115 @@
+from tools.skeleton_core.runner_report_ingest import ingest_runner_report
+
+
+def test_ingest_green_report() -> None:
+    result = ingest_runner_report(
+        """Agent report for issue #22
+
+issue_number: 22
+branch: bauclock/overnight-baseline
+head_sha: abc123def456
+commands_run: python -m pytest
+test_result: passed
+repo_status: clean
+private_data_seen: false
+runtime_code_touched: false
+external_services_called: false
+178 passed
+working tree clean
+"""
+    )
+
+    assert result.status == "green_report"
+    assert result.issue_number == 22
+    assert result.branch == "bauclock/overnight-baseline"
+    assert result.head_sha == "abc123def456"
+    assert result.commands_run == ["python -m pytest"]
+    assert result.test_result == "passed"
+    assert result.repo_status == "clean"
+    assert result.needs_review is False
+    assert result.next_queue_signal == "dependency_satisfied"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_ingest_blocked_report() -> None:
+    result = ingest_runner_report(
+        """Blocked report: missing dependency #22 report.
+issue_number: 23
+blocked_reason: waiting for #22 green baseline validation
+repo_status: clean
+"""
+    )
+
+    assert result.status == "blocked_report"
+    assert result.issue_number == 23
+    assert result.blocked_reason == "waiting for #22 green baseline validation"
+    assert result.needs_review is True
+    assert result.next_queue_signal == "blocked"
+
+
+def test_ingest_failed_validation() -> None:
+    result = ingest_runner_report(
+        """Agent report for issue #24
+issue_number: 24
+commands_run: python -m pytest
+test_result: failed
+repo_status: dirty
+failure_summary: tests failed in test_calendar_service.py
+validation failed: tests failed in test_calendar_service.py
+"""
+    )
+
+    assert result.status == "failed_validation"
+    assert result.issue_number == 24
+    assert result.test_result == "failed"
+    assert result.failure_summary == "tests failed in test_calendar_service.py"
+    assert result.next_queue_signal == "validation_failed"
+
+
+def test_ingest_needs_review_pr() -> None:
+    result = ingest_runner_report(
+        """Runner report for issue #25
+issue_number: 25
+commands_run: python -m pytest
+Tests: passed
+repo_status: clean
+open_prs: PR #88
+Draft PR #88 is ready for ChatGPT/Oleksii review.
+"""
+    )
+
+    assert result.status == "needs_review"
+    assert result.issue_number == 25
+    assert result.open_prs == ["PR #88"]
+    assert result.needs_review is True
+    assert result.next_queue_signal == "review_required"
+
+
+def test_ingest_unsafe_secret_flag() -> None:
+    result = ingest_runner_report(
+        """Runner report for issue #26
+issue_number: 26
+test_result: passed
+repo_status: clean
+private_data_seen: true
+failure_summary: used secret from environment by mistake
+"""
+    )
+
+    assert result.status == "unsafe_or_policy_violation"
+    assert result.issue_number == 26
+    assert result.private_data_seen is True
+    assert "private_data" in result.unsafe_flags
+    assert "secret" in result.unsafe_flags
+    assert result.needs_review is True
+    assert result.next_queue_signal == "blocked_policy_violation"
+
+
+def test_ingest_unknown_report_requires_review() -> None:
+    result = ingest_runner_report("Issue #30 maybe done, not sure.")
+
+    assert result.status == "unknown_needs_review"
+    assert result.issue_number == 30
+    assert result.needs_review is True
+    assert result.next_queue_signal == "manual_review_required"

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -23,6 +23,7 @@ from tools.skeleton_core.queue_state import QueueStateInput, build_queue_state
 from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.runner_command_pack import RunnerCommandInput, build_runner_command_pack
+from tools.skeleton_core.runner_report_ingest import ingest_runner_report_file_content
 from tools.skeleton_core.state_validator import validate_state
 from tools.skeleton_core.task_lifecycle import build_task_lifecycle_packet
 from tools.skeleton_core.templates import render_runner_issue
@@ -42,6 +43,7 @@ SUBCOMMANDS = {
     "queue-summary",
     "runner-command-pack",
     "runner-report-from-trace",
+    "runner-report-ingest",
     "task-from-text",
     "task-lifecycle",
     "trace-packet",
@@ -310,6 +312,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
     _add_input_arg(runner_command_parser, "Path to public-safe runner command JSON")
 
+    report_ingest_parser = subparsers.add_parser(
+        "runner-report-ingest",
+        help="Normalize public-safe runner report text into status JSON",
+    )
+    _add_input_arg(report_ingest_parser, "Path to public-safe runner report text")
+
     report_parser = subparsers.add_parser(
         "runner-report-from-trace",
         help="Render a short runner report from a TracePacket JSON file",
@@ -478,6 +486,12 @@ def _run_runner_command_pack(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_runner_report_ingest(args: argparse.Namespace) -> int:
+    result = ingest_runner_report_file_content(args.input.read_text(encoding="utf-8"))
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_runner_report_from_trace(args: argparse.Namespace) -> int:
     try:
         packet = load_trace_packet(args.input)
@@ -594,6 +608,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_queue_summary(args)
     if args.command == "runner-command-pack":
         return _run_runner_command_pack(args)
+    if args.command == "runner-report-ingest":
+        return _run_runner_report_ingest(args)
     if args.command == "runner-report-from-trace":
         return _run_runner_report_from_trace(args)
     if args.command == "task-from-text":

--- a/tools/skeleton_core/runner_report_ingest.py
+++ b/tools/skeleton_core/runner_report_ingest.py
@@ -20,9 +20,7 @@ UNSAFE_PATTERNS = {
     "private_data": (
         r"private[_ -]?data[_ -]?seen\s*[:=]\s*true|private data was used|private data seen"
     ),
-    "runtime_code": (
-        r"runtime[_ -]?code[_ -]?touched\s*[:=]\s*true|runtime code touched"
-    ),
+    "runtime_code": (r"runtime[_ -]?code[_ -]?touched\s*[:=]\s*true|runtime code touched"),
     "external_service": (
         r"external[_ -]?services?[_ -]?called\s*[:=]\s*true|external service called|external api called"
     ),
@@ -103,9 +101,7 @@ def _section_items(text: str, *headings: str) -> list[str]:
         if any(heading.startswith(candidate.casefold()) for candidate in headings):
             collecting = True
             continue
-        if collecting and (
-            stripped.startswith("##") or re.match(r"^[A-Za-z_ -]+:\s*$", stripped)
-        ):
+        if collecting and (stripped.startswith("##") or re.match(r"^[A-Za-z_ -]+:\s*$", stripped)):
             break
         if collecting and stripped.startswith("```"):
             continue
@@ -143,9 +139,7 @@ def _failure_summary(text: str) -> str | None:
     value = _field_value(text, "failure_summary", "failure summary")
     if value:
         return value
-    match = re.search(
-        r"(?:failed|failure|error)\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE
-    )
+    match = re.search(r"(?:failed|failure|error)\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE)
     if match:
         return match.group(1).strip()
     return None
@@ -186,9 +180,7 @@ def _open_prs(text: str) -> list[str]:
     explicit = _csv_or_section(text, "open_prs", "open prs", "open pull requests")
     if explicit:
         return explicit
-    return sorted(
-        set(re.findall(r"PR\s*#?\d+|pull request\s*#?\d+", text, flags=re.IGNORECASE))
-    )
+    return sorted(set(re.findall(r"PR\s*#?\d+|pull request\s*#?\d+", text, flags=re.IGNORECASE)))
 
 
 def _status(

--- a/tools/skeleton_core/runner_report_ingest.py
+++ b/tools/skeleton_core/runner_report_ingest.py
@@ -143,7 +143,9 @@ def _failure_summary(text: str) -> str | None:
     value = _field_value(text, "failure_summary", "failure summary")
     if value:
         return value
-    match = re.search(r"(?:failed|failure|error)\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE)
+    match = re.search(
+        r"(?:failed|failure|error)\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE
+    )
     if match:
         return match.group(1).strip()
     return None

--- a/tools/skeleton_core/runner_report_ingest.py
+++ b/tools/skeleton_core/runner_report_ingest.py
@@ -1,0 +1,246 @@
+"""Local offline runner report ingester for Skeleton queue state."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+RunnerReportStatus = Literal[
+    "green_report",
+    "blocked_report",
+    "failed_validation",
+    "needs_review",
+    "unknown_needs_review",
+    "unsafe_or_policy_violation",
+]
+
+UNSAFE_PATTERNS = {
+    "private_data": r"private[_ -]?data[_ -]?seen\s*[:=]\s*true|private data was used|private data seen",
+    "runtime_code": r"runtime[_ -]?code[_ -]?touched\s*[:=]\s*true|runtime code touched",
+    "external_service": r"external[_ -]?services?[_ -]?called\s*[:=]\s*true|external service called|external api called",
+    "secret": r"secret(s)?\s+(used|touched|read|exposed)|used secret|read secret|api key from|token from",
+    "env": r"read\s+\.env|used\s+\.env|\.env\s+(read|used|touched)",
+    "server": r"server ssh used|ssh to server|production server",
+    "production_db": r"production db access|production database access|prod db access",
+}
+
+
+class RunnerReportIngestPacket(BaseModel):
+    """Normalized public-safe runner report status."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: RunnerReportStatus
+    issue_number: int | None = None
+    branch: str | None = None
+    head_sha: str | None = None
+    commands_run: list[str] = Field(default_factory=list)
+    test_result: str | None = None
+    failure_summary: str | None = None
+    open_prs: list[str] = Field(default_factory=list)
+    repo_status: str | None = None
+    changed_files: list[str] = Field(default_factory=list)
+    private_data_seen: bool = False
+    runtime_code_touched: bool = False
+    external_services_called: bool = False
+    blocked_reason: str | None = None
+    needs_review: bool = False
+    unsafe_flags: list[str] = Field(default_factory=list)
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    next_queue_signal: str
+
+
+def _field_value(text: str, *names: str) -> str | None:
+    for name in names:
+        pattern = rf"^\s*{re.escape(name)}\s*[:=]\s*(.+?)\s*$"
+        match = re.search(pattern, text, flags=re.IGNORECASE | re.MULTILINE)
+        if match:
+            return match.group(1).strip().strip("`")
+    return None
+
+
+def _field_bool(text: str, *names: str) -> bool:
+    value = _field_value(text, *names)
+    if value is None:
+        return False
+    return value.casefold() in {"true", "yes", "1", "y"}
+
+
+def _issue_number(text: str) -> int | None:
+    value = _field_value(text, "issue_number", "issue")
+    if value:
+        match = re.search(r"#?(\d+)", value)
+        if match:
+            return int(match.group(1))
+    match = re.search(r"(?:issue|task)\s+#(\d+)|#(\d+)\s+report", text, flags=re.IGNORECASE)
+    if match:
+        return int(next(group for group in match.groups() if group))
+    return None
+
+
+def _section_items(text: str, *headings: str) -> list[str]:
+    lines = text.splitlines()
+    items: list[str] = []
+    collecting = False
+    for line in lines:
+        stripped = line.strip()
+        heading = stripped.strip("#:").strip().casefold()
+        if any(heading.startswith(candidate.casefold()) for candidate in headings):
+            collecting = True
+            continue
+        if collecting and (stripped.startswith("##") or re.match(r"^[A-Za-z_ -]+:\s*$", stripped)):
+            break
+        if collecting and stripped.startswith("```"):
+            continue
+        if collecting and stripped:
+            items.append(stripped.lstrip("-*").strip().strip("`"))
+    return items
+
+
+def _csv_or_section(text: str, field: str, *headings: str) -> list[str]:
+    value = _field_value(text, field)
+    if value:
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return _section_items(text, *headings)
+
+
+def _unsafe_flags(text: str) -> list[str]:
+    flags = []
+    for name, pattern in UNSAFE_PATTERNS.items():
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            flags.append(name)
+    return sorted(set(flags))
+
+
+def _blocked_reason(text: str) -> str | None:
+    value = _field_value(text, "blocked_reason", "blocked reason")
+    if value:
+        return value
+    match = re.search(r"blocked(?: report)?\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _failure_summary(text: str) -> str | None:
+    value = _field_value(text, "failure_summary", "failure summary")
+    if value:
+        return value
+    match = re.search(r"(?:failed|failure|error)\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _test_result(text: str) -> str | None:
+    value = _field_value(text, "test_result", "tests", "validation")
+    if value:
+        lowered = value.casefold()
+        if any(marker in lowered for marker in ("pass", "success", "green")):
+            return "passed"
+        if any(marker in lowered for marker in ("fail", "error", "red")):
+            return "failed"
+        return value
+    lowered_text = text.casefold()
+    if re.search(r"\b\d+\s+passed\b", lowered_text) or "tests passed" in lowered_text:
+        return "passed"
+    if "tests failed" in lowered_text or "validation failed" in lowered_text:
+        return "failed"
+    return None
+
+
+def _repo_status(text: str) -> str | None:
+    value = _field_value(text, "repo_status", "repo status", "working tree")
+    if value:
+        lowered = value.casefold()
+        if "clean" in lowered:
+            return "clean"
+        if "dirty" in lowered or "changed" in lowered:
+            return "dirty"
+        return value
+    if "repo clean" in text.casefold() or "working tree clean" in text.casefold():
+        return "clean"
+    return None
+
+
+def _open_prs(text: str) -> list[str]:
+    explicit = _csv_or_section(text, "open_prs", "open prs", "open pull requests")
+    if explicit:
+        return explicit
+    return sorted(set(re.findall(r"PR\s*#?\d+|pull request\s*#?\d+", text, flags=re.IGNORECASE)))
+
+
+def _status(
+    *,
+    text: str,
+    test_result: str | None,
+    repo_status: str | None,
+    blocked_reason: str | None,
+    open_prs: list[str],
+    unsafe_flags: list[str],
+) -> tuple[RunnerReportStatus, bool, str]:
+    lowered = text.casefold()
+    if unsafe_flags:
+        return "unsafe_or_policy_violation", True, "blocked_policy_violation"
+    if blocked_reason or "blocked report" in lowered:
+        return "blocked_report", True, "blocked"
+    if test_result == "failed" or "validation failed" in lowered:
+        return "failed_validation", True, "validation_failed"
+    if open_prs or "needs review" in lowered or "ready for review" in lowered or "draft pr" in lowered:
+        return "needs_review", True, "review_required"
+    if test_result == "passed" and repo_status == "clean":
+        return "green_report", False, "dependency_satisfied"
+    return "unknown_needs_review", True, "manual_review_required"
+
+
+def ingest_runner_report(text: str) -> RunnerReportIngestPacket:
+    """Parse a public-safe runner report/comment excerpt into structured status."""
+    unsafe_flags = _unsafe_flags(text)
+    private_data_seen = _field_bool(text, "private_data_seen", "private data seen") or "private_data" in unsafe_flags
+    runtime_code_touched = _field_bool(text, "runtime_code_touched", "runtime code touched") or "runtime_code" in unsafe_flags
+    external_services_called = (
+        _field_bool(text, "external_services_called", "external services called")
+        or "external_service" in unsafe_flags
+    )
+    test_result = _test_result(text)
+    repo_status = _repo_status(text)
+    blocked_reason = _blocked_reason(text)
+    open_prs = _open_prs(text)
+    status, needs_review, next_signal = _status(
+        text=text,
+        test_result=test_result,
+        repo_status=repo_status,
+        blocked_reason=blocked_reason,
+        open_prs=open_prs,
+        unsafe_flags=unsafe_flags,
+    )
+
+    return RunnerReportIngestPacket(
+        status=status,
+        issue_number=_issue_number(text),
+        branch=_field_value(text, "branch"),
+        head_sha=_field_value(text, "head_sha", "head sha"),
+        commands_run=_csv_or_section(text, "commands_run", "commands run", "commands"),
+        test_result=test_result,
+        failure_summary=_failure_summary(text),
+        open_prs=open_prs,
+        repo_status=repo_status,
+        changed_files=_csv_or_section(text, "changed_files", "changed files"),
+        private_data_seen=private_data_seen,
+        runtime_code_touched=runtime_code_touched,
+        external_services_called=external_services_called,
+        blocked_reason=blocked_reason,
+        needs_review=needs_review,
+        unsafe_flags=unsafe_flags,
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_queue_signal=next_signal,
+    )
+
+
+def ingest_runner_report_file_content(raw_text: str) -> RunnerReportIngestPacket:
+    """Alias for CLI readability."""
+    return ingest_runner_report(raw_text)

--- a/tools/skeleton_core/runner_report_ingest.py
+++ b/tools/skeleton_core/runner_report_ingest.py
@@ -17,10 +17,18 @@ RunnerReportStatus = Literal[
 ]
 
 UNSAFE_PATTERNS = {
-    "private_data": r"private[_ -]?data[_ -]?seen\s*[:=]\s*true|private data was used|private data seen",
-    "runtime_code": r"runtime[_ -]?code[_ -]?touched\s*[:=]\s*true|runtime code touched",
-    "external_service": r"external[_ -]?services?[_ -]?called\s*[:=]\s*true|external service called|external api called",
-    "secret": r"secret(s)?\s+(used|touched|read|exposed)|used secret|read secret|api key from|token from",
+    "private_data": (
+        r"private[_ -]?data[_ -]?seen\s*[:=]\s*true|private data was used|private data seen"
+    ),
+    "runtime_code": (
+        r"runtime[_ -]?code[_ -]?touched\s*[:=]\s*true|runtime code touched"
+    ),
+    "external_service": (
+        r"external[_ -]?services?[_ -]?called\s*[:=]\s*true|external service called|external api called"
+    ),
+    "secret": (
+        r"secret(s)?\s+(used|touched|read|exposed)|used secret|read secret|api key from|token from"
+    ),
     "env": r"read\s+\.env|used\s+\.env|\.env\s+(read|used|touched)",
     "server": r"server ssh used|ssh to server|production server",
     "production_db": r"production db access|production database access|prod db access",
@@ -75,7 +83,11 @@ def _issue_number(text: str) -> int | None:
         match = re.search(r"#?(\d+)", value)
         if match:
             return int(match.group(1))
-    match = re.search(r"(?:issue|task)\s+#(\d+)|#(\d+)\s+report", text, flags=re.IGNORECASE)
+    match = re.search(
+        r"(?:issue|task)\s+#(\d+)|#(\d+)\s+report",
+        text,
+        flags=re.IGNORECASE,
+    )
     if match:
         return int(next(group for group in match.groups() if group))
     return None
@@ -91,7 +103,9 @@ def _section_items(text: str, *headings: str) -> list[str]:
         if any(heading.startswith(candidate.casefold()) for candidate in headings):
             collecting = True
             continue
-        if collecting and (stripped.startswith("##") or re.match(r"^[A-Za-z_ -]+:\s*$", stripped)):
+        if collecting and (
+            stripped.startswith("##") or re.match(r"^[A-Za-z_ -]+:\s*$", stripped)
+        ):
             break
         if collecting and stripped.startswith("```"):
             continue
@@ -170,7 +184,9 @@ def _open_prs(text: str) -> list[str]:
     explicit = _csv_or_section(text, "open_prs", "open prs", "open pull requests")
     if explicit:
         return explicit
-    return sorted(set(re.findall(r"PR\s*#?\d+|pull request\s*#?\d+", text, flags=re.IGNORECASE)))
+    return sorted(
+        set(re.findall(r"PR\s*#?\d+|pull request\s*#?\d+", text, flags=re.IGNORECASE))
+    )
 
 
 def _status(
@@ -189,7 +205,12 @@ def _status(
         return "blocked_report", True, "blocked"
     if test_result == "failed" or "validation failed" in lowered:
         return "failed_validation", True, "validation_failed"
-    if open_prs or "needs review" in lowered or "ready for review" in lowered or "draft pr" in lowered:
+    if (
+        open_prs
+        or "needs review" in lowered
+        or "ready for review" in lowered
+        or "draft pr" in lowered
+    ):
         return "needs_review", True, "review_required"
     if test_result == "passed" and repo_status == "clean":
         return "green_report", False, "dependency_satisfied"
@@ -199,8 +220,14 @@ def _status(
 def ingest_runner_report(text: str) -> RunnerReportIngestPacket:
     """Parse a public-safe runner report/comment excerpt into structured status."""
     unsafe_flags = _unsafe_flags(text)
-    private_data_seen = _field_bool(text, "private_data_seen", "private data seen") or "private_data" in unsafe_flags
-    runtime_code_touched = _field_bool(text, "runtime_code_touched", "runtime code touched") or "runtime_code" in unsafe_flags
+    private_data_seen = (
+        _field_bool(text, "private_data_seen", "private data seen")
+        or "private_data" in unsafe_flags
+    )
+    runtime_code_touched = (
+        _field_bool(text, "runtime_code_touched", "runtime code touched")
+        or "runtime_code" in unsafe_flags
+    )
     external_services_called = (
         _field_bool(text, "external_services_called", "external services called")
         or "external_service" in unsafe_flags


### PR DESCRIPTION
## Summary

Implements #72 as a local/offline Skeleton Core command:

```text
python -m tools.skeleton_core.cli runner-report-ingest --input tests/fixtures/runner_report_green_22.txt
python -m tools.skeleton_core.cli runner-report-ingest --input tests/fixtures/runner_report_blocked_23.txt
python -m tools.skeleton_core.cli runner-report-ingest --input tests/fixtures/runner_report_failed_tests.txt
python -m tools.skeleton_core.cli runner-report-ingest --input tests/fixtures/runner_report_unsafe_secret_flag.txt
```

The command reads public-safe runner report text and emits structured status:

```text
status
issue_number
commands_run
test_result
repo_status
blocked_reason
needs_review
unsafe_flags
merge_allowed=false
deploy_allowed=false
next_queue_signal
```

## Safety

```text
No Jeeves runtime changes.
No BauClock runtime changes.
No GitHub API calls from the CLI.
No network calls.
No runner/shell execution.
No secrets/private data.
No merge/deploy authority.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Manual fixture commands to verify after checkout:

```bash
python -m tools.skeleton_core.cli runner-report-ingest --input tests/fixtures/runner_report_green_22.txt
python -m tools.skeleton_core.cli runner-report-ingest --input tests/fixtures/runner_report_blocked_23.txt
python -m tools.skeleton_core.cli runner-report-ingest --input tests/fixtures/runner_report_failed_tests.txt
python -m tools.skeleton_core.cli runner-report-ingest --input tests/fixtures/runner_report_unsafe_secret_flag.txt
```

Closes #72.