### PR TITLE
Add Skeleton pr-review-gate command

### DIFF
--- a/tests/fixtures/pr_review_gate_bauclock_test_only_green.json
+++ b/tests/fixtures/pr_review_gate_bauclock_test_only_green.json
@@ -1,0 +1,21 @@
+{
+  "repository": "alanua/bauclock",
+  "pr_number": 101,
+  "title": "test: add calendar access-control regressions",
+  "draft": true,
+  "source_issue": {
+    "issue_number": 23,
+    "risk_level": "YELLOW",
+    "allowed_files": [
+      "tests/test_calendar_service.py",
+      "tests/test_legal_hardening.py"
+    ],
+    "test_only": true
+  },
+  "changed_files": ["tests/test_calendar_service.py"],
+  "ci": {
+    "status": "completed",
+    "conclusion": "success"
+  },
+  "body": "Public-safe test-only PR body. No merge. No deploy."
+}

--- a/tests/fixtures/pr_review_gate_bauclock_test_only_green.json
+++ b/tests/fixtures/pr_review_gate_bauclock_test_only_green.json
@@ -17,5 +17,5 @@
     "status": "completed",
     "conclusion": "success"
   },
-  "body": "Public-safe test-only PR body. No merge. No deploy."
+  "body": "Public-safe test-only PR body for ChatGPT review."
 }

--- a/tests/fixtures/pr_review_gate_disallowed_file.json
+++ b/tests/fixtures/pr_review_gate_disallowed_file.json
@@ -1,0 +1,21 @@
+{
+  "repository": "alanua/bauclock",
+  "pr_number": 102,
+  "title": "test: add calendar access-control regressions",
+  "draft": true,
+  "source_issue": {
+    "issue_number": 23,
+    "risk_level": "YELLOW",
+    "allowed_files": ["tests/test_calendar_service.py"],
+    "test_only": true
+  },
+  "changed_files": [
+    "tests/test_calendar_service.py",
+    "app/services/calendar_service.py"
+  ],
+  "ci": {
+    "status": "completed",
+    "conclusion": "success"
+  },
+  "body": "Public-safe test-only PR body."
+}

--- a/tests/fixtures/pr_review_gate_disallowed_file.json
+++ b/tests/fixtures/pr_review_gate_disallowed_file.json
@@ -11,7 +11,7 @@
   },
   "changed_files": [
     "tests/test_calendar_service.py",
-    "app/services/calendar_service.py"
+    "docs/calendar_access_control_notes.md"
   ],
   "ci": {
     "status": "completed",

--- a/tests/fixtures/pr_review_gate_failed_ci.json
+++ b/tests/fixtures/pr_review_gate_failed_ci.json
@@ -1,0 +1,18 @@
+{
+  "repository": "alanua/bauclock",
+  "pr_number": 103,
+  "title": "test: add calendar access-control regressions",
+  "draft": true,
+  "source_issue": {
+    "issue_number": 23,
+    "risk_level": "YELLOW",
+    "allowed_files": ["tests/test_calendar_service.py"],
+    "test_only": true
+  },
+  "changed_files": ["tests/test_calendar_service.py"],
+  "ci": {
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  "body": "Public-safe test-only PR body."
+}

--- a/tests/fixtures/pr_review_gate_runtime_change_blocked.json
+++ b/tests/fixtures/pr_review_gate_runtime_change_blocked.json
@@ -1,0 +1,21 @@
+{
+  "repository": "alanua/bauclock",
+  "pr_number": 104,
+  "title": "test: add calendar access-control regressions",
+  "draft": true,
+  "source_issue": {
+    "issue_number": 23,
+    "risk_level": "YELLOW",
+    "allowed_files": [
+      "tests/test_calendar_service.py",
+      "app/services/calendar_service.py"
+    ],
+    "test_only": true
+  },
+  "changed_files": ["app/services/calendar_service.py"],
+  "ci": {
+    "status": "completed",
+    "conclusion": "success"
+  },
+  "body": "Public-safe test-only PR body."
+}

--- a/tests/fixtures/pr_review_gate_unsafe_text_blocked.json
+++ b/tests/fixtures/pr_review_gate_unsafe_text_blocked.json
@@ -1,0 +1,18 @@
+{
+  "repository": "alanua/bauclock",
+  "pr_number": 105,
+  "title": "test: deploy calendar access-control regressions",
+  "draft": true,
+  "source_issue": {
+    "issue_number": 23,
+    "risk_level": "YELLOW",
+    "allowed_files": ["tests/test_calendar_service.py"],
+    "test_only": true
+  },
+  "changed_files": ["tests/test_calendar_service.py"],
+  "ci": {
+    "status": "completed",
+    "conclusion": "success"
+  },
+  "body": "This PR mentions deploy and production DB in public-safe text."
+}

--- a/tests/skeleton_core/test_cli_pr_review_gate.py
+++ b/tests/skeleton_core/test_cli_pr_review_gate.py
@@ -1,0 +1,62 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["pr-review-gate", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_pr_review_gate_ready_fixture(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/pr_review_gate_bauclock_test_only_green.json",
+        capsys,
+    )
+
+    assert payload["status"] == "blocked_unsafe_text"
+    assert payload["repository"] == "alanua/bauclock"
+    assert payload["pr_number"] == 101
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_pr_review_gate_disallowed_file_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/pr_review_gate_disallowed_file.json", capsys)
+
+    assert payload["status"] == "blocked_runtime_change"
+    assert payload["changed_files_ok"] is False
+    assert payload["scope_ok"] is False
+    assert payload["blockers"]
+
+
+def test_cli_pr_review_gate_failed_ci_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/pr_review_gate_failed_ci.json", capsys)
+
+    assert payload["status"] == "blocked_failed_ci"
+    assert payload["ci_ok"] is False
+    assert payload["blockers"]
+
+
+def test_cli_pr_review_gate_runtime_change_fixture(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/pr_review_gate_runtime_change_blocked.json",
+        capsys,
+    )
+
+    assert payload["status"] == "blocked_runtime_change"
+    assert payload["changed_files_ok"] is True
+    assert payload["scope_ok"] is False
+    assert payload["blockers"]
+
+
+def test_cli_pr_review_gate_unsafe_text_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/pr_review_gate_unsafe_text_blocked.json", capsys)
+
+    assert payload["status"] == "blocked_unsafe_text"
+    assert payload["ci_ok"] is True
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False

--- a/tests/skeleton_core/test_cli_pr_review_gate.py
+++ b/tests/skeleton_core/test_cli_pr_review_gate.py
@@ -17,9 +17,12 @@ def test_cli_pr_review_gate_ready_fixture(capsys) -> None:
         capsys,
     )
 
-    assert payload["status"] == "blocked_unsafe_text"
+    assert payload["status"] == "ready_for_chatgpt_review"
     assert payload["repository"] == "alanua/bauclock"
     assert payload["pr_number"] == 101
+    assert payload["changed_files_ok"] is True
+    assert payload["ci_ok"] is True
+    assert payload["scope_ok"] is True
     assert payload["merge_allowed"] is False
     assert payload["deploy_allowed"] is False
 

--- a/tests/skeleton_core/test_cli_pr_review_gate.py
+++ b/tests/skeleton_core/test_cli_pr_review_gate.py
@@ -30,7 +30,7 @@ def test_cli_pr_review_gate_ready_fixture(capsys) -> None:
 def test_cli_pr_review_gate_disallowed_file_fixture(capsys) -> None:
     payload = _run_fixture("tests/fixtures/pr_review_gate_disallowed_file.json", capsys)
 
-    assert payload["status"] == "blocked_runtime_change"
+    assert payload["status"] == "blocked_disallowed_files"
     assert payload["changed_files_ok"] is False
     assert payload["scope_ok"] is False
     assert payload["blockers"]

--- a/tests/skeleton_core/test_pr_review_gate.py
+++ b/tests/skeleton_core/test_pr_review_gate.py
@@ -1,0 +1,109 @@
+from tools.skeleton_core.pr_review_gate import (
+    CIStatus,
+    PRReviewGateInput,
+    SourceIssuePacket,
+    build_pr_review_gate,
+)
+
+
+def _base_packet(**overrides) -> PRReviewGateInput:
+    data = {
+        "repository": "alanua/bauclock",
+        "pr_number": 101,
+        "title": "test: add calendar access-control regressions",
+        "draft": True,
+        "source_issue": SourceIssuePacket(
+            issue_number=23,
+            risk_level="YELLOW",
+            allowed_files=[
+                "tests/test_calendar_service.py",
+                "tests/test_legal_hardening.py",
+            ],
+            test_only=True,
+        ),
+        "changed_files": ["tests/test_calendar_service.py"],
+        "ci": CIStatus(status="completed", conclusion="success"),
+        "body": "Public-safe test-only PR body.",
+    }
+    data.update(overrides)
+    return PRReviewGateInput(**data)
+
+
+def test_pr_review_gate_ready_for_chatgpt_review() -> None:
+    result = build_pr_review_gate(_base_packet())
+
+    assert result.status == "ready_for_chatgpt_review"
+    assert result.repository == "alanua/bauclock"
+    assert result.pr_number == 101
+    assert result.source_issue == 23
+    assert result.changed_files_ok is True
+    assert result.ci_ok is True
+    assert result.scope_ok is True
+    assert result.blockers == []
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_pr_review_gate_blocks_disallowed_files() -> None:
+    result = build_pr_review_gate(
+        _base_packet(
+            changed_files=[
+                "tests/test_calendar_service.py",
+                "app/services/calendar_service.py",
+            ]
+        )
+    )
+
+    assert result.status == "blocked_runtime_change"
+    assert result.changed_files_ok is False
+    assert result.scope_ok is False
+    assert any("File outside allowed scope" in blocker for blocker in result.blockers)
+
+
+def test_pr_review_gate_blocks_failed_ci() -> None:
+    result = build_pr_review_gate(
+        _base_packet(ci=CIStatus(status="completed", conclusion="failure"))
+    )
+
+    assert result.status == "blocked_failed_ci"
+    assert result.ci_ok is False
+    assert any("Required CI" in blocker for blocker in result.blockers)
+
+
+def test_pr_review_gate_blocks_runtime_change_in_test_only_task() -> None:
+    result = build_pr_review_gate(
+        _base_packet(
+            source_issue=SourceIssuePacket(
+                issue_number=23,
+                risk_level="YELLOW",
+                allowed_files=["app/services/calendar_service.py"],
+                test_only=True,
+            ),
+            changed_files=["app/services/calendar_service.py"],
+        )
+    )
+
+    assert result.status == "blocked_runtime_change"
+    assert result.changed_files_ok is True
+    assert result.scope_ok is False
+    assert any("Runtime/app file" in blocker for blocker in result.blockers)
+
+
+def test_pr_review_gate_blocks_unsafe_text() -> None:
+    result = build_pr_review_gate(
+        _base_packet(title="test: deploy calendar regressions", body="Mentions production DB.")
+    )
+
+    assert result.status == "blocked_unsafe_text"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert any("Unsafe PR text" in blocker for blocker in result.blockers)
+
+
+def test_pr_review_gate_unknown_when_source_issue_missing() -> None:
+    result = build_pr_review_gate(_base_packet(source_issue=None))
+
+    assert result.status == "unknown_needs_review"
+    assert result.source_issue is None
+    assert result.scope_ok is False
+    assert any("source issue" in blocker for blocker in result.blockers)

--- a/tests/skeleton_core/test_pr_review_gate.py
+++ b/tests/skeleton_core/test_pr_review_gate.py
@@ -49,12 +49,12 @@ def test_pr_review_gate_blocks_disallowed_files() -> None:
         _base_packet(
             changed_files=[
                 "tests/test_calendar_service.py",
-                "app/services/calendar_service.py",
+                "docs/calendar_access_control_notes.md",
             ]
         )
     )
 
-    assert result.status == "blocked_runtime_change"
+    assert result.status == "blocked_disallowed_files"
     assert result.changed_files_ok is False
     assert result.scope_ok is False
     assert any("File outside allowed scope" in blocker for blocker in result.blockers)

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -17,6 +17,7 @@ from tools.skeleton_core.issue_dispatch import IssueDispatchInput, build_issue_d
 from tools.skeleton_core.issue_runner_bridge import IssueRunnerInput, build_issue_runner_packet
 from tools.skeleton_core.job_log_summary import summarize_job_log
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
+from tools.skeleton_core.pr_review_gate import PRReviewGateInput, build_pr_review_gate
 from tools.skeleton_core.pr_status import PRStatusInput, build_pr_status
 from tools.skeleton_core.queue_classifier import classify_queue_items
 from tools.skeleton_core.queue_state import QueueStateInput, build_queue_state
@@ -38,6 +39,7 @@ SUBCOMMANDS = {
     "issue-dispatch",
     "issue-runner-bridge",
     "job-log-summary",
+    "pr-review-gate",
     "pr-status",
     "queue-state",
     "queue-summary",
@@ -77,6 +79,11 @@ def load_queue_items(input_path: Path) -> list[dict[str, Any]]:
 def load_queue_state_input(input_path: Path) -> QueueStateInput:
     """Load public-safe queue-state input from JSON."""
     return QueueStateInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_pr_review_gate_input(input_path: Path) -> PRReviewGateInput:
+    """Load public-safe PR review gate input from JSON."""
+    return PRReviewGateInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_pr_status_input(input_path: Path) -> PRStatusInput:
@@ -283,6 +290,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
     _add_input_arg(job_log_parser, "Path to public-safe job log text")
 
+    pr_review_parser = subparsers.add_parser(
+        "pr-review-gate",
+        help="Decide whether a public-safe PR export is ready for ChatGPT review",
+    )
+    _add_input_arg(pr_review_parser, "Path to public-safe PR review gate JSON")
+
     pr_status_parser = subparsers.add_parser(
         "pr-status",
         help="Build a deterministic PR status packet from public-safe JSON",
@@ -446,6 +459,16 @@ def _run_job_log_summary(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_pr_review_gate(args: argparse.Namespace) -> int:
+    try:
+        result = build_pr_review_gate(load_pr_review_gate_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_pr_status(args: argparse.Namespace) -> int:
     try:
         result = build_pr_status(load_pr_status_input(args.input))
@@ -600,6 +623,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_issue_runner_bridge(args)
     if args.command == "job-log-summary":
         return _run_job_log_summary(args)
+    if args.command == "pr-review-gate":
+        return _run_pr_review_gate(args)
     if args.command == "pr-status":
         return _run_pr_status(args)
     if args.command == "queue-state":

--- a/tools/skeleton_core/pr_review_gate.py
+++ b/tools/skeleton_core/pr_review_gate.py
@@ -1,0 +1,201 @@
+"""Local offline PR review gate for Skeleton controller flow."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PRReviewGateStatus = Literal[
+    "ready_for_chatgpt_review",
+    "blocked_disallowed_files",
+    "blocked_failed_ci",
+    "blocked_scope_mismatch",
+    "blocked_runtime_change",
+    "blocked_unsafe_text",
+    "unknown_needs_review",
+]
+RiskLevel = Literal["GREEN", "YELLOW", "ORANGE", "RED", "UNKNOWN"]
+
+UNSAFE_TEXT_PATTERNS = {
+    "merge": r"\bmerge\b|auto-merge",
+    "deploy": r"\bdeploy\b|deployment|release",
+    "server": r"server ssh|\bssh\b|production server",
+    "production_db": r"production db|production database|prod db",
+    "env": r"\.env|environment secret|env file",
+    "secret": r"\bsecret\b|\bsecrets\b|\btoken\b|api key|credential|password",
+    "network": r"live network|external service|external api|http[s]?://",
+}
+RUNTIME_PREFIXES = (
+    "app/",
+    "alembic/",
+    "db/",
+    "migrations/",
+    "scripts/",
+)
+RUNTIME_FILENAMES = (
+    "docker-compose.yml",
+    "Dockerfile",
+    ".env",
+)
+
+
+class SourceIssuePacket(BaseModel):
+    """Public-safe source issue constraints."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    issue_number: int
+    risk_level: RiskLevel = "UNKNOWN"
+    allowed_files: list[str] = Field(default_factory=list)
+    test_only: bool = True
+
+
+class CIStatus(BaseModel):
+    """Public-safe CI status."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    status: str | None = None
+    conclusion: str | None = None
+
+
+class PRReviewGateInput(BaseModel):
+    """Public-safe PR review export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    repository: str
+    pr_number: int
+    title: str
+    draft: bool = True
+    source_issue: SourceIssuePacket | None = None
+    changed_files: list[str] = Field(default_factory=list)
+    ci: CIStatus | None = None
+    body: str = ""
+
+
+class PRReviewGatePacket(BaseModel):
+    """Deterministic PR review gate decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: PRReviewGateStatus
+    repository: str
+    pr_number: int
+    source_issue: int | None = None
+    changed_files_ok: bool
+    ci_ok: bool
+    scope_ok: bool
+    blockers: list[str] = Field(default_factory=list)
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    next_safe_step: str
+
+
+def _unsafe_text_blockers(packet: PRReviewGateInput) -> list[str]:
+    text = "\n".join([packet.title, packet.body])
+    blockers = []
+    for name, pattern in UNSAFE_TEXT_PATTERNS.items():
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            blockers.append(f"Unsafe PR text detected: {name}")
+    return sorted(set(blockers))
+
+
+def _runtime_files(files: list[str]) -> list[str]:
+    runtime_files = []
+    for path in files:
+        normalized = path.strip()
+        if normalized in RUNTIME_FILENAMES or normalized.startswith(RUNTIME_PREFIXES):
+            runtime_files.append(normalized)
+    return sorted(set(runtime_files))
+
+
+def _disallowed_files(packet: PRReviewGateInput) -> list[str]:
+    if packet.source_issue is None or not packet.source_issue.allowed_files:
+        return []
+    allowed = set(packet.source_issue.allowed_files)
+    return sorted(path for path in packet.changed_files if path not in allowed)
+
+
+def _ci_ok(packet: PRReviewGateInput) -> bool:
+    if packet.ci is None:
+        return False
+    return packet.ci.status == "completed" and packet.ci.conclusion == "success"
+
+
+def _source_issue_ambiguous(packet: PRReviewGateInput) -> bool:
+    if packet.source_issue is None:
+        return True
+    return packet.source_issue.risk_level not in {"GREEN", "YELLOW"}
+
+
+def _next_step(status: PRReviewGateStatus) -> str:
+    if status == "ready_for_chatgpt_review":
+        return "ChatGPT review PR diff before any merge decision."
+    if status == "blocked_failed_ci":
+        return "Fix or rerun CI before ChatGPT review."
+    if status == "blocked_disallowed_files":
+        return "Restrict PR to source issue allowed files before review."
+    if status == "blocked_runtime_change":
+        return "Remove runtime/app changes or create a separately approved higher-risk task."
+    if status == "blocked_unsafe_text":
+        return "Stop and review safety blockers before continuing."
+    if status == "blocked_scope_mismatch":
+        return "Align PR scope with source issue before review."
+    return "Manual review required before any merge decision."
+
+
+def build_pr_review_gate(packet: PRReviewGateInput) -> PRReviewGatePacket:
+    """Build a local/offline PR review gate decision."""
+    blockers: list[str] = []
+    unsafe_blockers = _unsafe_text_blockers(packet)
+    runtime_files = _runtime_files(packet.changed_files)
+    disallowed_files = _disallowed_files(packet)
+    ci_ok = _ci_ok(packet)
+
+    if _source_issue_ambiguous(packet):
+        blockers.append("Missing or unsupported source issue risk level")
+    if disallowed_files:
+        blockers.extend(f"File outside allowed scope: {path}" for path in disallowed_files)
+    if not ci_ok:
+        blockers.append("Required CI is not completed successfully")
+    if packet.source_issue and packet.source_issue.test_only and runtime_files:
+        blockers.extend(f"Runtime/app file changed in test-only task: {path}" for path in runtime_files)
+    blockers.extend(unsafe_blockers)
+
+    if unsafe_blockers:
+        status: PRReviewGateStatus = "blocked_unsafe_text"
+    elif packet.source_issue and packet.source_issue.test_only and runtime_files:
+        status = "blocked_runtime_change"
+    elif disallowed_files:
+        status = "blocked_disallowed_files"
+    elif not ci_ok:
+        status = "blocked_failed_ci" if packet.ci is not None else "unknown_needs_review"
+    elif _source_issue_ambiguous(packet):
+        status = "unknown_needs_review"
+    elif not packet.changed_files:
+        status = "unknown_needs_review"
+        blockers.append("No changed files provided")
+    else:
+        status = "ready_for_chatgpt_review"
+
+    return PRReviewGatePacket(
+        status=status,
+        repository=packet.repository,
+        pr_number=packet.pr_number,
+        source_issue=packet.source_issue.issue_number if packet.source_issue else None,
+        changed_files_ok=not disallowed_files and bool(packet.changed_files),
+        ci_ok=ci_ok,
+        scope_ok=not runtime_files and not disallowed_files and not _source_issue_ambiguous(packet),
+        blockers=sorted(set(blockers)),
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_safe_step=_next_step(status),
+    )
+
+
+def build_pr_review_gate_from_json(raw_json: str) -> PRReviewGatePacket:
+    """Validate local JSON text and build a PR review gate packet."""
+    return build_pr_review_gate(PRReviewGateInput.model_validate_json(raw_json))

--- a/tools/skeleton_core/pr_review_gate.py
+++ b/tools/skeleton_core/pr_review_gate.py
@@ -162,7 +162,9 @@ def build_pr_review_gate(packet: PRReviewGateInput) -> PRReviewGatePacket:
     if not ci_ok:
         blockers.append("Required CI is not completed successfully")
     if packet.source_issue and packet.source_issue.test_only and runtime_files:
-        blockers.extend(f"Runtime/app file changed in test-only task: {path}" for path in runtime_files)
+        blockers.extend(
+            f"Runtime/app file changed in test-only task: {path}" for path in runtime_files
+        )
     blockers.extend(unsafe_blockers)
 
     if unsafe_blockers:


### PR DESCRIPTION
## Summary

Implements #74 as a local/offline Skeleton Core command:

```text
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_bauclock_test_only_green.json
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_disallowed_file.json
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_failed_ci.json
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_runtime_change_blocked.json
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_unsafe_text_blocked.json
```

The command reads public-safe PR review JSON and emits a deterministic gate decision:

```text
ready_for_chatgpt_review
blocked_disallowed_files
blocked_failed_ci
blocked_scope_mismatch
blocked_runtime_change
blocked_unsafe_text
unknown_needs_review
```

Output always keeps:

```text
merge_allowed=false
deploy_allowed=false
```

## Safety

```text
No Jeeves runtime changes.
No BauClock runtime changes.
No GitHub API calls from the CLI.
No network calls.
No runner/shell execution.
No secrets/private data.
No merge/deploy authority.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Manual fixture commands to verify after checkout:

```bash
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_bauclock_test_only_green.json
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_disallowed_file.json
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_failed_ci.json
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_runtime_change_blocked.json
python -m tools.skeleton_core.cli pr-review-gate --input tests/fixtures/pr_review_gate_unsafe_text_blocked.json
```

Closes #74.