### PR TITLE
Add Skeleton branch-recovery command

### DIFF
--- a/tests/fixtures/branch_recovery_merged.json
+++ b/tests/fixtures/branch_recovery_merged.json
@@ -1,0 +1,12 @@
+{
+  "branch_name": "skeleton/example-merged",
+  "issue_number": 68,
+  "pr_number": 70,
+  "pr_state": "closed",
+  "merged": true,
+  "merged_sha": "abc123def456",
+  "changed_files": ["tools/skeleton_core/example.py"],
+  "ci_status": "success",
+  "ci_blockers": [],
+  "checkpoint_result": "completed"
+}

--- a/tests/fixtures/branch_recovery_missing_ci.json
+++ b/tests/fixtures/branch_recovery_missing_ci.json
@@ -1,0 +1,12 @@
+{
+  "branch_name": "skeleton/example-missing-ci",
+  "issue_number": 68,
+  "pr_number": 71,
+  "pr_state": "open",
+  "merged": false,
+  "merged_sha": "",
+  "changed_files": ["tools/skeleton_core/example.py"],
+  "ci_status": "missing",
+  "ci_blockers": [],
+  "checkpoint_result": "queued"
+}

--- a/tests/fixtures/branch_recovery_open_failed.json
+++ b/tests/fixtures/branch_recovery_open_failed.json
@@ -1,0 +1,12 @@
+{
+  "branch_name": "skeleton/example-failed",
+  "issue_number": 68,
+  "pr_number": 69,
+  "pr_state": "open",
+  "merged": false,
+  "merged_sha": "",
+  "changed_files": ["tools/skeleton_core/example.py"],
+  "ci_status": "failed",
+  "ci_blockers": ["black"],
+  "checkpoint_result": "queued"
+}

--- a/tests/skeleton_core/test_branch_recovery.py
+++ b/tests/skeleton_core/test_branch_recovery.py
@@ -1,0 +1,92 @@
+from tools.skeleton_core.branch_recovery import BranchRecoveryInput, build_branch_recovery
+
+
+def test_branch_recovery_completed_for_merged_pr() -> None:
+    result = build_branch_recovery(
+        BranchRecoveryInput(
+            branch_name="skeleton/example-merged",
+            issue_number=68,
+            pr_number=70,
+            pr_state="closed",
+            merged=True,
+            merged_sha="abc123def456",
+            changed_files=["tools/skeleton_core/example.py"],
+            ci_status="success",
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.merged_sha == "abc123def456"
+    assert result.blockers == []
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.next_safe_action == "checkpoint state and continue next task"
+
+
+def test_branch_recovery_needs_fix_for_open_failed_ci() -> None:
+    result = build_branch_recovery(
+        BranchRecoveryInput(
+            branch_name="skeleton/example-failed",
+            issue_number=68,
+            pr_number=69,
+            pr_state="open",
+            merged=False,
+            changed_files=["tools/skeleton_core/example.py"],
+            ci_status="failed",
+            ci_blockers=["black"],
+        )
+    )
+
+    assert result.status == "needs_fix"
+    assert result.ci_status == "failed"
+    assert result.blockers == ["black"]
+    assert result.next_safe_action == "read job log summary, fix blocker, rerun CI"
+
+
+def test_branch_recovery_waits_for_missing_ci() -> None:
+    result = build_branch_recovery(
+        BranchRecoveryInput(
+            branch_name="skeleton/example-missing-ci",
+            issue_number=68,
+            pr_number=71,
+            pr_state="open",
+            changed_files=["tools/skeleton_core/example.py"],
+            ci_status="missing",
+        )
+    )
+
+    assert result.status == "wait_for_ci_or_fetch_status"
+    assert result.next_safe_action == "wait for CI or fetch public-safe PR status export"
+
+
+def test_branch_recovery_suggests_create_pr_when_branch_has_changes() -> None:
+    result = build_branch_recovery(
+        BranchRecoveryInput(
+            branch_name="skeleton/example-no-pr",
+            issue_number=68,
+            changed_files=["tools/skeleton_core/example.py"],
+            ci_status="unknown",
+        )
+    )
+
+    assert result.status == "create_pr_if_branch_ready"
+    assert result.pr_number is None
+    assert result.next_safe_action == "create draft PR if branch diff is still needed and public-safe"
+
+
+def test_branch_recovery_unknown_for_merged_without_sha() -> None:
+    result = build_branch_recovery(
+        BranchRecoveryInput(
+            branch_name="skeleton/example-bad-merge",
+            issue_number=68,
+            pr_number=70,
+            pr_state="closed",
+            merged=True,
+            merged_sha="",
+            changed_files=["tools/skeleton_core/example.py"],
+            ci_status="success",
+        )
+    )
+
+    assert result.status == "unknown_needs_review"
+    assert "Merged PR has no merged_sha in export" in result.blockers

--- a/tests/skeleton_core/test_branch_recovery.py
+++ b/tests/skeleton_core/test_branch_recovery.py
@@ -69,12 +69,10 @@ def test_branch_recovery_suggests_create_pr_when_branch_has_changes() -> None:
         )
     )
 
+    expected_action = "create draft PR if branch diff is still needed and public-safe"
     assert result.status == "create_pr_if_branch_ready"
     assert result.pr_number is None
-    assert (
-        result.next_safe_action
-        == "create draft PR if branch diff is still needed and public-safe"
-    )
+    assert result.next_safe_action == expected_action
 
 
 def test_branch_recovery_unknown_for_merged_without_sha() -> None:

--- a/tests/skeleton_core/test_branch_recovery.py
+++ b/tests/skeleton_core/test_branch_recovery.py
@@ -71,7 +71,10 @@ def test_branch_recovery_suggests_create_pr_when_branch_has_changes() -> None:
 
     assert result.status == "create_pr_if_branch_ready"
     assert result.pr_number is None
-    assert result.next_safe_action == "create draft PR if branch diff is still needed and public-safe"
+    assert (
+        result.next_safe_action
+        == "create draft PR if branch diff is still needed and public-safe"
+    )
 
 
 def test_branch_recovery_unknown_for_merged_without_sha() -> None:

--- a/tests/skeleton_core/test_cli_branch_recovery.py
+++ b/tests/skeleton_core/test_cli_branch_recovery.py
@@ -1,0 +1,44 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["branch-recovery", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_branch_recovery_failed_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/branch_recovery_open_failed.json", capsys)
+
+    assert payload["branch_name"] == "skeleton/example-failed"
+    assert payload["issue_number"] == 68
+    assert payload["pr_number"] == 69
+    assert payload["status"] == "needs_fix"
+    assert payload["ci_status"] == "failed"
+    assert payload["blockers"] == ["black"]
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_branch_recovery_merged_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/branch_recovery_merged.json", capsys)
+
+    assert payload["status"] == "completed"
+    assert payload["merged_sha"] == "abc123def456"
+    assert payload["next_safe_action"] == "checkpoint state and continue next task"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_branch_recovery_missing_ci_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/branch_recovery_missing_ci.json", capsys)
+
+    assert payload["status"] == "wait_for_ci_or_fetch_status"
+    assert payload["ci_status"] == "missing"
+    assert payload["next_safe_action"] == "wait for CI or fetch public-safe PR status export"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False

--- a/tools/skeleton_core/branch_recovery.py
+++ b/tools/skeleton_core/branch_recovery.py
@@ -1,0 +1,123 @@
+"""Local offline recovery packet builder for interrupted Skeleton branches."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+BranchRecoveryStatus = Literal[
+    "completed",
+    "needs_fix",
+    "wait_for_ci_or_fetch_status",
+    "create_pr_if_branch_ready",
+    "unknown_needs_review",
+]
+CIStatus = Literal["success", "failed", "pending", "missing", "unknown"]
+
+
+class BranchRecoveryInput(BaseModel):
+    """Public-safe interrupted branch export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    branch_name: str
+    issue_number: int | None = None
+    pr_number: int | None = None
+    pr_state: str | None = None
+    merged: bool = False
+    merged_sha: str = ""
+    changed_files: list[str] = Field(default_factory=list)
+    ci_status: CIStatus = "unknown"
+    ci_blockers: list[str] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    checkpoint_result: str | None = None
+
+
+class BranchRecoveryPacket(BaseModel):
+    """Deterministic branch recovery output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    branch_name: str
+    issue_number: int | None = None
+    pr_number: int | None = None
+    status: BranchRecoveryStatus
+    merged_sha: str = ""
+    changed_files: list[str] = Field(default_factory=list)
+    ci_status: CIStatus
+    blockers: list[str] = Field(default_factory=list)
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    next_safe_action: str
+
+
+def _combined_blockers(packet: BranchRecoveryInput) -> list[str]:
+    blockers = [*packet.blockers, *packet.ci_blockers]
+    if packet.pr_state and packet.pr_state.casefold() not in {"open", "closed", "merged"}:
+        blockers.append(f"Unknown PR state: {packet.pr_state}")
+    return sorted(set(item for item in blockers if item))
+
+
+def _has_open_pr(packet: BranchRecoveryInput) -> bool:
+    return packet.pr_number is not None and (packet.pr_state or "open").casefold() == "open"
+
+
+def _has_any_pr(packet: BranchRecoveryInput) -> bool:
+    return packet.pr_number is not None
+
+
+def _next_action(status: BranchRecoveryStatus) -> str:
+    if status == "completed":
+        return "checkpoint state and continue next task"
+    if status == "needs_fix":
+        return "read job log summary, fix blocker, rerun CI"
+    if status == "wait_for_ci_or_fetch_status":
+        return "wait for CI or fetch public-safe PR status export"
+    if status == "create_pr_if_branch_ready":
+        return "create draft PR if branch diff is still needed and public-safe"
+    return "manual review required before continuing"
+
+
+def build_branch_recovery(packet: BranchRecoveryInput) -> BranchRecoveryPacket:
+    """Build a local/offline recovery packet for an interrupted branch."""
+    blockers = _combined_blockers(packet)
+
+    if packet.merged:
+        status: BranchRecoveryStatus = "completed"
+    elif _has_open_pr(packet) and packet.ci_status == "failed":
+        status = "needs_fix"
+    elif _has_open_pr(packet) and packet.ci_status in {"missing", "pending", "unknown"}:
+        status = "wait_for_ci_or_fetch_status"
+    elif not _has_any_pr(packet) and packet.changed_files:
+        status = "create_pr_if_branch_ready"
+    else:
+        status = "unknown_needs_review"
+
+    if packet.merged and not packet.merged_sha:
+        blockers.append("Merged PR has no merged_sha in export")
+        status = "unknown_needs_review"
+    if status == "needs_fix" and not blockers:
+        blockers.append("CI failed without blocker details")
+    if not packet.branch_name.strip():
+        blockers.append("Missing branch_name")
+        status = "unknown_needs_review"
+
+    return BranchRecoveryPacket(
+        branch_name=packet.branch_name,
+        issue_number=packet.issue_number,
+        pr_number=packet.pr_number,
+        status=status,
+        merged_sha=packet.merged_sha,
+        changed_files=packet.changed_files,
+        ci_status=packet.ci_status,
+        blockers=sorted(set(blockers)),
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_safe_action=_next_action(status),
+    )
+
+
+def build_branch_recovery_from_json(raw_json: str) -> BranchRecoveryPacket:
+    """Validate local JSON text and build a branch recovery packet."""
+    return build_branch_recovery(BranchRecoveryInput.model_validate_json(raw_json))

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from tools.skeleton_core.branch_recovery import BranchRecoveryInput, build_branch_recovery
 from tools.skeleton_core.checkpoint import render_checkpoint
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.handoff_pack import render_handoff_pack
@@ -32,6 +33,7 @@ from tools.skeleton_core.trace import TracePacket
 from tools.skeleton_core.work_packet import render_work_packet
 
 SUBCOMMANDS = {
+    "branch-recovery",
     "checkpoint",
     "classify-queue",
     "decide",
@@ -66,6 +68,11 @@ def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
         "blocked_reason": decision.blocked_reason,
         "runner_issue_body": render_runner_issue(packet, decision),
     }
+
+
+def load_branch_recovery_input(input_path: Path) -> BranchRecoveryInput:
+    """Load public-safe branch recovery input from JSON."""
+    return BranchRecoveryInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_queue_items(input_path: Path) -> list[dict[str, Any]]:
@@ -230,6 +237,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Skeleton Externalizer CLI.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    branch_recovery_parser = subparsers.add_parser(
+        "branch-recovery",
+        help="Build a recovery packet for interrupted Skeleton branch work",
+    )
+    _add_input_arg(branch_recovery_parser, "Path to public-safe branch recovery JSON")
+
     checkpoint_parser = subparsers.add_parser(
         "checkpoint",
         help="Build a Skeleton checkpoint bundle",
@@ -385,6 +398,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args = _legacy_decide_parser().parse_args(effective_argv)
     args.command = "decide"
     return args
+
+
+def _run_branch_recovery(args: argparse.Namespace) -> int:
+    try:
+        result = build_branch_recovery(load_branch_recovery_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
 
 
 def _run_decide(args: argparse.Namespace) -> int:
@@ -611,6 +634,8 @@ def _run_work_packet(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.command == "branch-recovery":
+        return _run_branch_recovery(args)
     if args.command == "checkpoint":
         return _run_checkpoint(args)
     if args.command == "classify-queue":


### PR DESCRIPTION
## Summary

Implements #68 as a local/offline Skeleton Core command:

```text
python -m tools.skeleton_core.cli branch-recovery --input tests/fixtures/branch_recovery_open_failed.json
python -m tools.skeleton_core.cli branch-recovery --input tests/fixtures/branch_recovery_merged.json
python -m tools.skeleton_core.cli branch-recovery --input tests/fixtures/branch_recovery_missing_ci.json
```

The command reads public-safe interrupted branch JSON and emits a deterministic recovery packet:

```text
completed
needs_fix
wait_for_ci_or_fetch_status
create_pr_if_branch_ready
unknown_needs_review
```

Output always keeps:

```text
merge_allowed=false
deploy_allowed=false
```

## Safety

```text
No Jeeves runtime changes.
No BauClock runtime changes.
No GitHub API calls from the CLI.
No network calls.
No runner/shell execution.
No secrets/private data.
No merge/deploy authority.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Manual fixture commands to verify after checkout:

```bash
python -m tools.skeleton_core.cli branch-recovery --input tests/fixtures/branch_recovery_open_failed.json
python -m tools.skeleton_core.cli branch-recovery --input tests/fixtures/branch_recovery_merged.json
python -m tools.skeleton_core.cli branch-recovery --input tests/fixtures/branch_recovery_missing_ci.json
```

Closes #68.