### PR TITLE
Add Skeleton project-skeleton-profile command

### DIFF
--- a/tests/fixtures/project_profile_bauclock.json
+++ b/tests/fixtures/project_profile_bauclock.json
@@ -1,0 +1,33 @@
+{
+  "project": "BauClock",
+  "type": "application",
+  "default_risk": "YELLOW",
+  "allowed_skeleton_capabilities": [
+    "issue-dispatch",
+    "runner-command-pack",
+    "runner-report-ingest",
+    "queue-state",
+    "pr-review-gate",
+    "branch-recovery"
+  ],
+  "project_needs": [
+    "runner-env-check",
+    "telegram-bot-safe-release-flow",
+    "migration-risk-gate",
+    "role-permission-regression-flow"
+  ],
+  "test_commands": [
+    "python -m pytest -q",
+    "python -m ruff check .",
+    "python -m black --check ."
+  ],
+  "forbidden_by_default": [
+    "deploy",
+    "server ssh",
+    "production db",
+    "secrets",
+    ".env",
+    "automerge"
+  ],
+  "runtime_change_requires_explicit_approval": true
+}

--- a/tests/fixtures/project_profile_skeleton.json
+++ b/tests/fixtures/project_profile_skeleton.json
@@ -1,0 +1,31 @@
+{
+  "project": "Skeleton Core",
+  "type": "skeleton-core",
+  "default_risk": "YELLOW",
+  "allowed_skeleton_capabilities": [
+    "issue-dispatch",
+    "runner-command-pack",
+    "runner-report-ingest",
+    "pr-review-gate",
+    "branch-recovery",
+    "queue-state",
+    "validate-state",
+    "handoff-pack"
+  ],
+  "project_needs": [],
+  "test_commands": [
+    "python -m pytest -q",
+    "python -m ruff check tools/skeleton_core tests/skeleton_core",
+    "python -m black --check tools/skeleton_core tests/skeleton_core",
+    "python -m tools.skeleton_core.cli validate-state"
+  ],
+  "forbidden_by_default": [
+    "deploy",
+    "server ssh",
+    "production db",
+    "secrets",
+    ".env",
+    "automerge"
+  ],
+  "runtime_change_requires_explicit_approval": true
+}

--- a/tests/fixtures/project_profile_unsafe_capability.json
+++ b/tests/fixtures/project_profile_unsafe_capability.json
@@ -1,0 +1,17 @@
+{
+  "project": "Unsafe Example",
+  "type": "application",
+  "default_risk": "YELLOW",
+  "allowed_skeleton_capabilities": [
+    "issue-dispatch",
+    "autonomous-deploy"
+  ],
+  "project_needs": ["runner-env-check"],
+  "test_commands": ["python -m pytest -q"],
+  "forbidden_by_default": [
+    "deploy without approval",
+    "secrets",
+    ".env"
+  ],
+  "runtime_change_requires_explicit_approval": false
+}

--- a/tests/skeleton_core/test_cli_project_skeleton_profile.py
+++ b/tests/skeleton_core/test_cli_project_skeleton_profile.py
@@ -1,0 +1,51 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["project-skeleton-profile", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_bauclock_project_profile_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/project_profile_bauclock.json", capsys)
+
+    assert payload["project"] == "BauClock"
+    assert payload["profile_status"] == "ready"
+    assert payload["development_flow"] == [
+        "issue-dispatch",
+        "runner-command-pack",
+        "runner-report-ingest",
+        "pr-review-gate",
+        "branch-recovery",
+    ]
+    assert payload["recommended_next_gate"] == "pr-review-gate"
+    assert "runner-env-check" in payload["missing_capability_signals"]
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_skeleton_project_profile_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/project_profile_skeleton.json", capsys)
+
+    assert payload["project"] == "Skeleton Core"
+    assert payload["profile_status"] == "ready"
+    assert "validate-state" in payload["development_flow"]
+    assert "handoff-pack" in payload["development_flow"]
+    assert payload["missing_capability_signals"] == []
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_unsafe_project_profile_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/project_profile_unsafe_capability.json", capsys)
+
+    assert payload["profile_status"] == "blocked_unsafe_default"
+    assert payload["development_flow"] == []
+    assert payload["blockers"]
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False

--- a/tests/skeleton_core/test_project_profile.py
+++ b/tests/skeleton_core/test_project_profile.py
@@ -1,0 +1,126 @@
+from tools.skeleton_core.project_profile import (
+    ProjectSkeletonProfileInput,
+    build_project_skeleton_profile,
+)
+
+
+def test_bauclock_profile_ready_with_missing_skill_signals() -> None:
+    result = build_project_skeleton_profile(
+        ProjectSkeletonProfileInput(
+            project="BauClock",
+            type="application",
+            default_risk="YELLOW",
+            allowed_skeleton_capabilities=[
+                "issue-dispatch",
+                "runner-command-pack",
+                "runner-report-ingest",
+                "queue-state",
+                "pr-review-gate",
+                "branch-recovery",
+            ],
+            project_needs=["runner-env-check", "migration-risk-gate"],
+            forbidden_by_default=["deploy", "server ssh", "production db", "secrets", ".env"],
+            runtime_change_requires_explicit_approval=True,
+        )
+    )
+
+    assert result.profile_status == "ready"
+    assert result.project == "BauClock"
+    assert result.risk_level == "YELLOW"
+    assert result.development_flow == [
+        "issue-dispatch",
+        "runner-command-pack",
+        "runner-report-ingest",
+        "pr-review-gate",
+        "branch-recovery",
+    ]
+    assert result.recommended_next_gate == "pr-review-gate"
+    assert "runner-env-check" in result.missing_capability_signals
+    assert "migration-risk-gate" in result.missing_capability_signals
+    assert any("runner-env-check" in item for item in result.recommended_skeleton_skill_backlog)
+    assert result.blockers == []
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_skeleton_core_profile_ready_flow() -> None:
+    result = build_project_skeleton_profile(
+        ProjectSkeletonProfileInput(
+            project="Skeleton Core",
+            type="skeleton-core",
+            default_risk="YELLOW",
+            allowed_skeleton_capabilities=[
+                "issue-dispatch",
+                "runner-command-pack",
+                "runner-report-ingest",
+                "pr-review-gate",
+                "branch-recovery",
+                "queue-state",
+                "validate-state",
+                "handoff-pack",
+            ],
+            forbidden_by_default=["deploy", "server ssh", "production db", "secrets", ".env"],
+        )
+    )
+
+    assert result.profile_status == "ready"
+    assert result.development_flow == [
+        "issue-dispatch",
+        "runner-command-pack",
+        "runner-report-ingest",
+        "pr-review-gate",
+        "branch-recovery",
+        "queue-state",
+        "validate-state",
+        "handoff-pack",
+    ]
+    assert result.missing_capability_signals == []
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_unknown_capability_blocks_profile() -> None:
+    result = build_project_skeleton_profile(
+        ProjectSkeletonProfileInput(
+            project="Unsafe Example",
+            type="application",
+            default_risk="YELLOW",
+            allowed_skeleton_capabilities=["issue-dispatch", "autonomous-deploy"],
+            forbidden_by_default=["deploy", "secrets", ".env"],
+        )
+    )
+
+    assert result.profile_status == "blocked_unknown_capability"
+    assert result.development_flow == []
+    assert any("autonomous-deploy" in blocker for blocker in result.blockers)
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_unsafe_default_blocks_profile() -> None:
+    result = build_project_skeleton_profile(
+        ProjectSkeletonProfileInput(
+            project="Unsafe Example",
+            type="application",
+            default_risk="YELLOW",
+            allowed_skeleton_capabilities=["issue-dispatch"],
+            forbidden_by_default=["deploy without approval", "secrets", ".env"],
+        )
+    )
+
+    assert result.profile_status == "blocked_unsafe_default"
+    assert result.development_flow == []
+    assert any("deploy without approval" in blocker for blocker in result.blockers)
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_missing_profile_fields_needs_review() -> None:
+    result = build_project_skeleton_profile(ProjectSkeletonProfileInput())
+
+    assert result.profile_status == "unknown_needs_review"
+    assert result.development_flow == []
+    assert any("project" in blocker for blocker in result.blockers)
+    assert any("type" in blocker for blocker in result.blockers)
+    assert any("default_risk" in blocker for blocker in result.blockers)
+    assert any("allowed_skeleton_capabilities" in blocker for blocker in result.blockers)

--- a/tools/skeleton_core/capabilities.py
+++ b/tools/skeleton_core/capabilities.py
@@ -86,9 +86,12 @@ SKELETON_CORE_FLOW = [
 ]
 
 DANGEROUS_DEFAULT_MARKERS = {
-    "automerge",
-    "auto merge",
-    "auto-merge",
+    "auto merge allowed",
+    "auto merge without approval",
+    "auto-merge allowed",
+    "auto-merge without approval",
+    "automerge allowed",
+    "automerge without approval",
     "deploy allowed",
     "deploy without approval",
     "merge allowed",

--- a/tools/skeleton_core/capabilities.py
+++ b/tools/skeleton_core/capabilities.py
@@ -1,0 +1,123 @@
+"""Public-safe Skeleton capability registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SkeletonCapability:
+    """Static metadata for a safe Skeleton CLI capability."""
+
+    name: str
+    description: str
+    read_only: bool = True
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+
+
+CAPABILITIES: dict[str, SkeletonCapability] = {
+    "branch-recovery": SkeletonCapability(
+        name="branch-recovery",
+        description="Recover interrupted branch state from a public-safe export.",
+    ),
+    "checkpoint": SkeletonCapability(
+        name="checkpoint",
+        description="Render a compact checkpoint packet from a trace.",
+    ),
+    "handoff-pack": SkeletonCapability(
+        name="handoff-pack",
+        description="Render a compact public-safe Skeleton handoff.",
+    ),
+    "issue-dispatch": SkeletonCapability(
+        name="issue-dispatch",
+        description="Normalize a public-safe issue export into a runner-ready packet.",
+    ),
+    "issue-runner-bridge": SkeletonCapability(
+        name="issue-runner-bridge",
+        description="Build a GREEN/YELLOW runner packet from a public-safe issue export.",
+    ),
+    "job-log-summary": SkeletonCapability(
+        name="job-log-summary",
+        description="Summarize a public-safe CI/job log excerpt.",
+    ),
+    "pr-review-gate": SkeletonCapability(
+        name="pr-review-gate",
+        description="Decide whether a PR export is ready for ChatGPT/Oleksii review.",
+    ),
+    "queue-state": SkeletonCapability(
+        name="queue-state",
+        description="Select next safe runnable item from a public-safe queue export.",
+    ),
+    "runner-command-pack": SkeletonCapability(
+        name="runner-command-pack",
+        description="Build a compact runner instruction from a safe task packet.",
+    ),
+    "runner-report-ingest": SkeletonCapability(
+        name="runner-report-ingest",
+        description="Normalize a public-safe runner report into status JSON.",
+    ),
+    "task-lifecycle": SkeletonCapability(
+        name="task-lifecycle",
+        description="Build a compact lifecycle packet from a public-safe issue export.",
+    ),
+    "validate-state": SkeletonCapability(
+        name="validate-state",
+        description="Validate Skeleton boot and current-state files.",
+    ),
+}
+
+APPLICATION_FLOW = [
+    "issue-dispatch",
+    "runner-command-pack",
+    "runner-report-ingest",
+    "pr-review-gate",
+    "branch-recovery",
+]
+SKELETON_CORE_FLOW = [
+    "issue-dispatch",
+    "runner-command-pack",
+    "runner-report-ingest",
+    "pr-review-gate",
+    "branch-recovery",
+    "queue-state",
+    "validate-state",
+    "handoff-pack",
+]
+
+DANGEROUS_DEFAULT_MARKERS = {
+    "automerge",
+    "auto merge",
+    "auto-merge",
+    "deploy allowed",
+    "deploy without approval",
+    "merge allowed",
+    "merge without approval",
+    "production db write",
+    "read .env",
+    "secrets access",
+    "server ssh allowed",
+}
+
+SAFE_FORBIDDEN_MARKERS = {
+    ".env",
+    "automerge",
+    "deploy",
+    "external credentials",
+    "merge",
+    "production db",
+    "secrets",
+    "server ssh",
+}
+
+
+def known_capability_names() -> set[str]:
+    """Return known safe Skeleton capability names."""
+    return set(CAPABILITIES)
+
+
+def capability_flow(project_type: str, allowed_capabilities: list[str]) -> list[str]:
+    """Return deterministic flow filtered by allowed capabilities."""
+    allowed = set(allowed_capabilities)
+    canonical_flow = SKELETON_CORE_FLOW if project_type == "skeleton-core" else APPLICATION_FLOW
+    return [capability for capability in canonical_flow if capability in allowed]

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -20,6 +20,10 @@ from tools.skeleton_core.job_log_summary import summarize_job_log
 from tools.skeleton_core.models import EvidencePolicy, TaskPacket
 from tools.skeleton_core.pr_review_gate import PRReviewGateInput, build_pr_review_gate
 from tools.skeleton_core.pr_status import PRStatusInput, build_pr_status
+from tools.skeleton_core.project_profile import (
+    ProjectSkeletonProfileInput,
+    build_project_skeleton_profile,
+)
 from tools.skeleton_core.queue_classifier import classify_queue_items
 from tools.skeleton_core.queue_state import QueueStateInput, build_queue_state
 from tools.skeleton_core.report import render_runner_report_from_trace
@@ -43,6 +47,7 @@ SUBCOMMANDS = {
     "job-log-summary",
     "pr-review-gate",
     "pr-status",
+    "project-skeleton-profile",
     "queue-state",
     "queue-summary",
     "runner-command-pack",
@@ -73,6 +78,13 @@ def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
 def load_branch_recovery_input(input_path: Path) -> BranchRecoveryInput:
     """Load public-safe branch recovery input from JSON."""
     return BranchRecoveryInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_project_skeleton_profile_input(input_path: Path) -> ProjectSkeletonProfileInput:
+    """Load public-safe project Skeleton profile input from JSON."""
+    return ProjectSkeletonProfileInput.model_validate_json(
+        input_path.read_text(encoding="utf-8")
+    )
 
 
 def load_queue_items(input_path: Path) -> list[dict[str, Any]]:
@@ -315,6 +327,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
     _add_input_arg(pr_status_parser, "Path to public-safe PR status JSON")
 
+    project_profile_parser = subparsers.add_parser(
+        "project-skeleton-profile",
+        help="Build project development flow and Skeleton skill-growth signals",
+    )
+    _add_input_arg(project_profile_parser, "Path to public-safe project profile JSON")
+
     queue_state_parser = subparsers.add_parser(
         "queue-state",
         help="Determine the next runnable item from public-safe queue state JSON",
@@ -502,6 +520,16 @@ def _run_pr_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_project_skeleton_profile(args: argparse.Namespace) -> int:
+    try:
+        result = build_project_skeleton_profile(load_project_skeleton_profile_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_queue_state(args: argparse.Namespace) -> int:
     try:
         result = build_queue_state(load_queue_state_input(args.input), project=args.project)
@@ -652,6 +680,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_pr_review_gate(args)
     if args.command == "pr-status":
         return _run_pr_status(args)
+    if args.command == "project-skeleton-profile":
+        return _run_project_skeleton_profile(args)
     if args.command == "queue-state":
         return _run_queue_state(args)
     if args.command == "queue-summary":

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -82,9 +82,7 @@ def load_branch_recovery_input(input_path: Path) -> BranchRecoveryInput:
 
 def load_project_skeleton_profile_input(input_path: Path) -> ProjectSkeletonProfileInput:
     """Load public-safe project Skeleton profile input from JSON."""
-    return ProjectSkeletonProfileInput.model_validate_json(
-        input_path.read_text(encoding="utf-8")
-    )
+    return ProjectSkeletonProfileInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_queue_items(input_path: Path) -> list[dict[str, Any]]:

--- a/tools/skeleton_core/project_profile.py
+++ b/tools/skeleton_core/project_profile.py
@@ -1,0 +1,170 @@
+"""Local offline project profile evaluator for Skeleton flow selection."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.capabilities import (
+    DANGEROUS_DEFAULT_MARKERS,
+    SAFE_FORBIDDEN_MARKERS,
+    capability_flow,
+    known_capability_names,
+)
+
+ProfileStatus = Literal[
+    "ready",
+    "blocked_unknown_capability",
+    "blocked_unsafe_default",
+    "unknown_needs_review",
+]
+RiskLevel = Literal["GREEN", "YELLOW", "ORANGE", "RED", "UNKNOWN"]
+
+
+class ProjectSkeletonProfileInput(BaseModel):
+    """Public-safe project profile input."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    project: str = ""
+    type: str = ""
+    default_risk: RiskLevel = "UNKNOWN"
+    allowed_skeleton_capabilities: list[str] = Field(default_factory=list)
+    project_needs: list[str] = Field(default_factory=list)
+    test_commands: list[str] = Field(default_factory=list)
+    forbidden_by_default: list[str] = Field(default_factory=list)
+    runtime_change_requires_explicit_approval: bool = True
+
+
+class ProjectSkeletonProfilePacket(BaseModel):
+    """Deterministic project development-flow packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project: str
+    profile_status: ProfileStatus
+    allowed_skeleton_capabilities: list[str] = Field(default_factory=list)
+    development_flow: list[str] = Field(default_factory=list)
+    recommended_next_gate: str | None = None
+    risk_level: RiskLevel
+    forbidden_by_default: list[str] = Field(default_factory=list)
+    runtime_change_requires_explicit_approval: bool
+    project_needs: list[str] = Field(default_factory=list)
+    missing_capability_signals: list[str] = Field(default_factory=list)
+    recommended_skeleton_skill_backlog: list[str] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+
+
+def _normalized_items(items: list[str]) -> list[str]:
+    return [item.strip() for item in items if item.strip()]
+
+
+def _unknown_capabilities(capabilities: list[str]) -> list[str]:
+    known = known_capability_names()
+    return sorted({capability for capability in capabilities if capability not in known})
+
+
+def _unsafe_defaults(items: list[str]) -> list[str]:
+    unsafe = []
+    for item in items:
+        normalized = item.strip().casefold()
+        if normalized in DANGEROUS_DEFAULT_MARKERS:
+            unsafe.append(item)
+    return sorted(set(unsafe))
+
+
+def _safe_forbidden_items(items: list[str]) -> list[str]:
+    safe = []
+    for item in items:
+        normalized = item.strip().casefold()
+        if normalized in SAFE_FORBIDDEN_MARKERS:
+            safe.append(item)
+    return sorted(set(safe))
+
+
+def _missing_profile_fields(packet: ProjectSkeletonProfileInput) -> list[str]:
+    missing = []
+    if not packet.project.strip():
+        missing.append("project")
+    if not packet.type.strip():
+        missing.append("type")
+    if packet.default_risk == "UNKNOWN":
+        missing.append("default_risk")
+    if not packet.allowed_skeleton_capabilities:
+        missing.append("allowed_skeleton_capabilities")
+    return missing
+
+
+def _missing_capability_signals(packet: ProjectSkeletonProfileInput) -> list[str]:
+    known = known_capability_names()
+    allowed = set(packet.allowed_skeleton_capabilities)
+    signals = []
+    for need in _normalized_items(packet.project_needs):
+        if need not in known and need not in allowed:
+            signals.append(need)
+    return sorted(set(signals))
+
+
+def _backlog(signals: list[str]) -> list[str]:
+    return [f"Add a reviewed Skeleton capability for {signal}" for signal in signals]
+
+
+def _recommended_next_gate(flow: list[str]) -> str | None:
+    if "pr-review-gate" in flow:
+        return "pr-review-gate"
+    if flow:
+        return flow[-1]
+    return None
+
+
+def build_project_skeleton_profile(
+    packet: ProjectSkeletonProfileInput,
+) -> ProjectSkeletonProfilePacket:
+    """Build a local/offline project Skeleton profile packet."""
+    allowed = _normalized_items(packet.allowed_skeleton_capabilities)
+    forbidden = _normalized_items(packet.forbidden_by_default)
+    unknown = _unknown_capabilities(allowed)
+    unsafe_defaults = _unsafe_defaults(forbidden)
+    missing_fields = _missing_profile_fields(packet)
+    signals = _missing_capability_signals(packet)
+    blockers: list[str] = []
+
+    blockers.extend(f"Unknown Skeleton capability: {capability}" for capability in unknown)
+    blockers.extend(f"Unsafe default grants authority: {item}" for item in unsafe_defaults)
+    blockers.extend(f"Missing required profile field: {field}" for field in missing_fields)
+
+    if unsafe_defaults:
+        status: ProfileStatus = "blocked_unsafe_default"
+    elif unknown:
+        status = "blocked_unknown_capability"
+    elif missing_fields:
+        status = "unknown_needs_review"
+    else:
+        status = "ready"
+
+    flow = capability_flow(packet.type, allowed) if status == "ready" else []
+
+    return ProjectSkeletonProfilePacket(
+        project=packet.project,
+        profile_status=status,
+        allowed_skeleton_capabilities=allowed,
+        development_flow=flow,
+        recommended_next_gate=_recommended_next_gate(flow),
+        risk_level=packet.default_risk,
+        forbidden_by_default=_safe_forbidden_items(forbidden),
+        runtime_change_requires_explicit_approval=packet.runtime_change_requires_explicit_approval,
+        project_needs=_normalized_items(packet.project_needs),
+        missing_capability_signals=signals,
+        recommended_skeleton_skill_backlog=_backlog(signals),
+        blockers=sorted(set(blockers)),
+        merge_allowed=False,
+        deploy_allowed=False,
+    )
+
+
+def build_project_skeleton_profile_from_json(raw_json: str) -> ProjectSkeletonProfilePacket:
+    """Validate local JSON text and build a project Skeleton profile packet."""
+    return build_project_skeleton_profile(ProjectSkeletonProfileInput.model_validate_json(raw_json))


### PR DESCRIPTION
## Summary

Implements #82 as a local/offline Skeleton Core command:

```text
python -m tools.skeleton_core.cli project-skeleton-profile --input tests/fixtures/project_profile_bauclock.json
python -m tools.skeleton_core.cli project-skeleton-profile --input tests/fixtures/project_profile_skeleton.json
python -m tools.skeleton_core.cli project-skeleton-profile --input tests/fixtures/project_profile_unsafe_capability.json
```

The command reads public-safe project profile JSON and emits:

```text
project
profile_status
allowed_skeleton_capabilities
development_flow
recommended_next_gate
risk_level
forbidden_by_default
runtime_change_requires_explicit_approval
project_needs
missing_capability_signals
recommended_skeleton_skill_backlog
blockers
merge_allowed=false
deploy_allowed=false
```

It supports both directions:

```text
project adapts its development flow to available Skeleton capabilities
Skeleton skill growth adapts to recurring project needs via reviewable missing-capability signals
```

Example: BauClock fixture now emits `runner-env-check` as a missing-capability signal/backlog candidate for #83.

## Safety

```text
No Jeeves runtime changes.
No BauClock runtime changes.
No GitHub API calls from the CLI.
No network calls.
No runner/shell execution.
No secrets/private data.
No merge/deploy authority.
No automatic creation of new Skeleton skill PRs from project_needs.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Manual fixture commands to verify after checkout:

```bash
python -m tools.skeleton_core.cli project-skeleton-profile --input tests/fixtures/project_profile_bauclock.json
python -m tools.skeleton_core.cli project-skeleton-profile --input tests/fixtures/project_profile_skeleton.json
python -m tools.skeleton_core.cli project-skeleton-profile --input tests/fixtures/project_profile_unsafe_capability.json
```

Closes #82.