### PR TITLE
Add Skeleton runner-env-check command

### DIFF
--- a/tests/fixtures/runner_env_check_clone_failed.json
+++ b/tests/fixtures/runner_env_check_clone_failed.json
@@ -1,0 +1,19 @@
+{
+  "repository": "alanua/bauclock",
+  "repo_url_checked": "https://github.com/alanua/bauclock.git",
+  "checks": {
+    "python": "ok",
+    "git": "ok",
+    "workdir": "ok",
+    "dns_github": "ok",
+    "clone": "failed",
+    "pytest": "ok"
+  },
+  "commands_run": [
+    "python --version",
+    "git --version",
+    "git clone --depth 1 <redacted-repo-url> /tmp/bauclock_preflight/repo"
+  ],
+  "blocked_reason": "Shallow clone failed.",
+  "policy_violation": false
+}

--- a/tests/fixtures/runner_env_check_dns_failure.json
+++ b/tests/fixtures/runner_env_check_dns_failure.json
@@ -1,0 +1,19 @@
+{
+  "repository": "alanua/bauclock",
+  "repo_url_checked": "https://github.com/alanua/bauclock.git",
+  "checks": {
+    "python": "ok",
+    "git": "ok",
+    "workdir": "ok",
+    "dns_github": "failed",
+    "clone": "not_run_or_failed",
+    "pytest": "not_checked"
+  },
+  "commands_run": [
+    "python --version",
+    "git --version",
+    "git clone --depth 1 <redacted-repo-url> /tmp/bauclock_preflight/repo"
+  ],
+  "blocked_reason": "Could not resolve host: github.com",
+  "policy_violation": false
+}

--- a/tests/fixtures/runner_env_check_no_git.json
+++ b/tests/fixtures/runner_env_check_no_git.json
@@ -1,0 +1,18 @@
+{
+  "repository": "alanua/bauclock",
+  "repo_url_checked": "https://github.com/alanua/bauclock.git",
+  "checks": {
+    "python": "ok",
+    "git": "missing",
+    "workdir": "ok",
+    "dns_github": "not_checked",
+    "clone": "not_checked",
+    "pytest": "ok"
+  },
+  "commands_run": [
+    "python --version",
+    "git --version"
+  ],
+  "blocked_reason": "Git is not installed in this runner.",
+  "policy_violation": false
+}

--- a/tests/fixtures/runner_env_check_policy_violation.json
+++ b/tests/fixtures/runner_env_check_policy_violation.json
@@ -1,0 +1,15 @@
+{
+  "repository": "alanua/bauclock",
+  "repo_url_checked": "https://token@example.com/alanua/bauclock.git",
+  "checks": {
+    "python": "ok",
+    "git": "ok",
+    "workdir": "ok",
+    "dns_github": "not_checked",
+    "clone": "not_checked",
+    "pytest": "ok"
+  },
+  "commands_run": [],
+  "blocked_reason": "Repository URL contains credentials and was redacted.",
+  "policy_violation": true
+}

--- a/tests/fixtures/runner_env_check_ready.json
+++ b/tests/fixtures/runner_env_check_ready.json
@@ -1,0 +1,18 @@
+{
+  "repository": "alanua/bauclock",
+  "repo_url_checked": "https://github.com/alanua/bauclock.git",
+  "checks": {
+    "python": "ok",
+    "git": "ok",
+    "workdir": "ok",
+    "dns_github": "not_checked",
+    "clone": "not_checked",
+    "pytest": "ok"
+  },
+  "commands_run": [
+    "python --version",
+    "git --version"
+  ],
+  "blocked_reason": "",
+  "policy_violation": false
+}

--- a/tests/skeleton_core/test_cli_runner_env_check.py
+++ b/tests/skeleton_core/test_cli_runner_env_check.py
@@ -1,0 +1,64 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["runner-env-check", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_runner_env_check_ready_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_env_check_ready.json", capsys)
+
+    assert payload["status"] == "ready_for_read_only_validation"
+    assert payload["safe_for_runner"] is True
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_runner_env_check_dns_failure_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_env_check_dns_failure.json", capsys)
+
+    assert payload["status"] == "blocked_dns_or_network"
+    assert payload["safe_for_runner"] is False
+    assert payload["blocked_reason"] == "Could not resolve host: github.com"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_runner_env_check_no_git_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_env_check_no_git.json", capsys)
+
+    assert payload["status"] == "blocked_no_git"
+    assert payload["safe_for_runner"] is False
+
+
+def test_cli_runner_env_check_clone_failed_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_env_check_clone_failed.json", capsys)
+
+    assert payload["status"] == "blocked_clone_failed"
+    assert payload["safe_for_runner"] is False
+
+
+def test_cli_runner_env_check_policy_violation_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/runner_env_check_policy_violation.json", capsys)
+
+    assert payload["status"] == "unsafe_or_policy_violation"
+    assert payload["repo_url_checked"] == "<redacted-repo-url>"
+    assert "token" not in json.dumps(payload)
+    assert payload["safe_for_runner"] is False
+
+
+def test_cli_runner_env_check_missing_args(capsys) -> None:
+    exit_code = main(["runner-env-check"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["status"] == "unknown_needs_review"
+    assert payload["safe_for_runner"] is False
+    assert "Provide --input" in payload["blocked_reason"]

--- a/tests/skeleton_core/test_runner_env_check.py
+++ b/tests/skeleton_core/test_runner_env_check.py
@@ -1,0 +1,104 @@
+from tools.skeleton_core.runner_env_check import RunnerEnvCheckInput, build_runner_env_check
+
+
+def _base_packet(**overrides) -> RunnerEnvCheckInput:
+    data = {
+        "repository": "alanua/bauclock",
+        "repo_url_checked": "https://github.com/alanua/bauclock.git",
+        "checks": {
+            "python": "ok",
+            "git": "ok",
+            "workdir": "ok",
+            "dns_github": "not_checked",
+            "clone": "not_checked",
+            "pytest": "ok",
+        },
+        "commands_run": ["python --version", "git --version"],
+        "blocked_reason": "",
+        "policy_violation": False,
+    }
+    data.update(overrides)
+    return RunnerEnvCheckInput(**data)
+
+
+def test_runner_env_check_ready() -> None:
+    result = build_runner_env_check(_base_packet())
+
+    assert result.status == "ready_for_read_only_validation"
+    assert result.repository == "alanua/bauclock"
+    assert result.safe_for_runner is True
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.next_safe_step == "Continue to runner-command-pack for read-only validation work."
+
+
+def test_runner_env_check_blocks_dns_failure() -> None:
+    result = build_runner_env_check(
+        _base_packet(
+            checks={
+                "python": "ok",
+                "git": "ok",
+                "workdir": "ok",
+                "dns_github": "failed",
+                "clone": "not_run_or_failed",
+                "pytest": "not_checked",
+            },
+            blocked_reason="Could not resolve host: github.com",
+        )
+    )
+
+    assert result.status == "blocked_dns_or_network"
+    assert result.safe_for_runner is False
+    assert result.blocked_reason == "Could not resolve host: github.com"
+
+
+def test_runner_env_check_blocks_no_git() -> None:
+    result = build_runner_env_check(
+        _base_packet(checks={"python": "ok", "git": "missing", "workdir": "ok"})
+    )
+
+    assert result.status == "blocked_no_git"
+    assert result.safe_for_runner is False
+    assert result.blocked_reason == "Git is not available in the runner."
+
+
+def test_runner_env_check_blocks_clone_failed() -> None:
+    result = build_runner_env_check(
+        _base_packet(
+            checks={
+                "python": "ok",
+                "git": "ok",
+                "workdir": "ok",
+                "dns_github": "ok",
+                "clone": "failed",
+                "pytest": "ok",
+            }
+        )
+    )
+
+    assert result.status == "blocked_clone_failed"
+    assert result.safe_for_runner is False
+
+
+def test_runner_env_check_blocks_pytest_missing() -> None:
+    result = build_runner_env_check(
+        _base_packet(checks={"python": "ok", "git": "ok", "workdir": "ok", "pytest": "missing"})
+    )
+
+    assert result.status == "blocked_pytest_unavailable"
+    assert result.safe_for_runner is False
+
+
+def test_runner_env_check_redacts_credential_url() -> None:
+    result = build_runner_env_check(
+        _base_packet(
+            repo_url_checked="https://token@example.com/alanua/bauclock.git",
+            policy_violation=True,
+            blocked_reason="Repository URL contains credentials and was redacted.",
+        )
+    )
+
+    assert result.status == "unsafe_or_policy_violation"
+    assert result.repo_url_checked == "<redacted-repo-url>"
+    assert "token" not in result.model_dump_json()
+    assert result.safe_for_runner is False

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -346,9 +346,23 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         "runner-env-check",
         help="Check runner environment readiness before assigning validation work",
     )
-    runner_env_parser.add_argument("--input", type=Path, default=None, help="Path to offline fixture JSON")
-    runner_env_parser.add_argument("--repo-url", default=None, help="Repository URL for live preflight")
-    runner_env_parser.add_argument("--workdir", type=Path, default=None, help="Disposable workdir")
+    runner_env_parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Path to offline fixture JSON",
+    )
+    runner_env_parser.add_argument(
+        "--repo-url",
+        default=None,
+        help="Repository URL for live preflight",
+    )
+    runner_env_parser.add_argument(
+        "--workdir",
+        type=Path,
+        default=None,
+        help="Disposable workdir",
+    )
     runner_env_parser.add_argument(
         "--allow-network-check",
         action="store_true",

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -29,6 +29,11 @@ from tools.skeleton_core.queue_state import QueueStateInput, build_queue_state
 from tools.skeleton_core.report import render_runner_report_from_trace
 from tools.skeleton_core.router import route_task
 from tools.skeleton_core.runner_command_pack import RunnerCommandInput, build_runner_command_pack
+from tools.skeleton_core.runner_env_check import (
+    RunnerEnvCheckInput,
+    build_runner_env_check,
+    live_runner_env_check,
+)
 from tools.skeleton_core.runner_report_ingest import ingest_runner_report_file_content
 from tools.skeleton_core.state_validator import validate_state
 from tools.skeleton_core.task_lifecycle import build_task_lifecycle_packet
@@ -51,6 +56,7 @@ SUBCOMMANDS = {
     "queue-state",
     "queue-summary",
     "runner-command-pack",
+    "runner-env-check",
     "runner-report-from-trace",
     "runner-report-ingest",
     "task-from-text",
@@ -83,6 +89,11 @@ def load_branch_recovery_input(input_path: Path) -> BranchRecoveryInput:
 def load_project_skeleton_profile_input(input_path: Path) -> ProjectSkeletonProfileInput:
     """Load public-safe project Skeleton profile input from JSON."""
     return ProjectSkeletonProfileInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_runner_env_check_input(input_path: Path) -> RunnerEnvCheckInput:
+    """Load public-safe runner environment check input from JSON."""
+    return RunnerEnvCheckInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_queue_items(input_path: Path) -> list[dict[str, Any]]:
@@ -331,6 +342,29 @@ def _subcommand_parser() -> argparse.ArgumentParser:
     )
     _add_input_arg(project_profile_parser, "Path to public-safe project profile JSON")
 
+    runner_env_parser = subparsers.add_parser(
+        "runner-env-check",
+        help="Check runner environment readiness before assigning validation work",
+    )
+    runner_env_parser.add_argument("--input", type=Path, default=None, help="Path to offline fixture JSON")
+    runner_env_parser.add_argument("--repo-url", default=None, help="Repository URL for live preflight")
+    runner_env_parser.add_argument("--workdir", type=Path, default=None, help="Disposable workdir")
+    runner_env_parser.add_argument(
+        "--allow-network-check",
+        action="store_true",
+        help="Explicitly allow DNS/network/clone checks",
+    )
+    runner_env_parser.add_argument(
+        "--skip-clone-check",
+        action="store_true",
+        help="Skip clone even when network check is allowed",
+    )
+    runner_env_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Compatibility flag; output is always JSON",
+    )
+
     queue_state_parser = subparsers.add_parser(
         "queue-state",
         help="Determine the next runnable item from public-safe queue state JSON",
@@ -528,6 +562,31 @@ def _run_project_skeleton_profile(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_runner_env_check(args: argparse.Namespace) -> int:
+    try:
+        if args.input is not None:
+            result = build_runner_env_check(load_runner_env_check_input(args.input))
+        elif args.repo_url and args.workdir:
+            result = live_runner_env_check(
+                repo_url=args.repo_url,
+                workdir=args.workdir,
+                allow_network_check=args.allow_network_check,
+                skip_clone_check=args.skip_clone_check,
+            )
+        else:
+            result = build_runner_env_check(
+                RunnerEnvCheckInput(
+                    checks={},
+                    blocked_reason="Provide --input or both --repo-url and --workdir.",
+                )
+            )
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_queue_state(args: argparse.Namespace) -> int:
     try:
         result = build_queue_state(load_queue_state_input(args.input), project=args.project)
@@ -686,6 +745,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_queue_summary(args)
     if args.command == "runner-command-pack":
         return _run_runner_command_pack(args)
+    if args.command == "runner-env-check":
+        return _run_runner_env_check(args)
     if args.command == "runner-report-ingest":
         return _run_runner_report_ingest(args)
     if args.command == "runner-report-from-trace":

--- a/tools/skeleton_core/runner_env_check.py
+++ b/tools/skeleton_core/runner_env_check.py
@@ -1,0 +1,288 @@
+"""Safe runner environment preflight for Skeleton tasks."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Literal
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field
+
+RunnerEnvCheckStatus = Literal[
+    "ready_for_read_only_validation",
+    "blocked_no_git",
+    "blocked_no_python",
+    "blocked_no_workdir",
+    "blocked_dns_or_network",
+    "blocked_clone_failed",
+    "blocked_pytest_unavailable",
+    "unsafe_or_policy_violation",
+    "unknown_needs_review",
+]
+CheckState = Literal[
+    "ok",
+    "failed",
+    "missing",
+    "not_checked",
+    "not_run",
+    "not_run_or_failed",
+]
+
+REDACTED_REPO_URL = "<redacted-repo-url>"
+DEFAULT_NEXT_SAFE_STEP = (
+    "Run the task in another ready runner, or fix this runner before assigning work."
+)
+STATUS_NEXT_STEPS = {
+    "ready_for_read_only_validation": "Continue to runner-command-pack for read-only validation work.",
+    "blocked_no_git": "Install git or select another runner with git available.",
+    "blocked_no_python": "Install Python or select another runner with Python available.",
+    "blocked_no_workdir": "Use a writable disposable workdir before assigning work.",
+    "blocked_dns_or_network": (
+        "Run the task in another runner with GitHub network access, or fix DNS/network in this runner."
+    ),
+    "blocked_clone_failed": "Fix clone access or select another runner before assigning work.",
+    "blocked_pytest_unavailable": "Install pytest or select another runner with project validation dependencies.",
+    "unsafe_or_policy_violation": "Stop and review runner preflight safety blockers before continuing.",
+    "unknown_needs_review": "Manual review required before assigning work to this runner.",
+}
+
+
+class RunnerEnvCheckInput(BaseModel):
+    """Public-safe offline runner environment export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    repository: str = ""
+    repo_url_checked: str = ""
+    checks: dict[str, CheckState] = Field(default_factory=dict)
+    commands_run: list[str] = Field(default_factory=list)
+    blocked_reason: str = ""
+    policy_violation: bool = False
+
+
+class RunnerEnvCheckPacket(BaseModel):
+    """Structured runner environment readiness packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: RunnerEnvCheckStatus
+    repository: str = ""
+    repo_url_checked: str = ""
+    checks: dict[str, CheckState] = Field(default_factory=dict)
+    commands_run: list[str] = Field(default_factory=list)
+    blocked_reason: str = ""
+    safe_for_runner: bool = False
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    next_safe_step: str
+
+
+def _redact_repo_url(repo_url: str) -> str:
+    parsed = urlparse(repo_url)
+    if parsed.scheme in {"http", "https"} and parsed.netloc and "@" in parsed.netloc:
+        return REDACTED_REPO_URL
+    if "token" in repo_url.casefold() or "password" in repo_url.casefold():
+        return REDACTED_REPO_URL
+    return repo_url
+
+
+def _repo_url_has_credentials(repo_url: str) -> bool:
+    parsed = urlparse(repo_url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc and "@" in parsed.netloc)
+
+
+def _redacted_clone_command(workdir: str) -> str:
+    return f"git clone --depth 1 {REDACTED_REPO_URL} {workdir}/repo"
+
+
+def _infer_repository(repo_url: str) -> str:
+    if not repo_url:
+        return ""
+    cleaned = repo_url.removesuffix(".git")
+    if cleaned.startswith("git@github.com:"):
+        return cleaned.split(":", 1)[1]
+    parsed = urlparse(cleaned)
+    if parsed.netloc.endswith("github.com"):
+        return parsed.path.strip("/")
+    return ""
+
+
+def _status_from_checks(packet: RunnerEnvCheckInput) -> RunnerEnvCheckStatus:
+    checks = packet.checks
+    if packet.policy_violation or _repo_url_has_credentials(packet.repo_url_checked):
+        return "unsafe_or_policy_violation"
+    if checks.get("python") in {"missing", "failed"}:
+        return "blocked_no_python"
+    if checks.get("git") in {"missing", "failed"}:
+        return "blocked_no_git"
+    if checks.get("workdir") in {"missing", "failed"}:
+        return "blocked_no_workdir"
+    if checks.get("dns_github") == "failed":
+        return "blocked_dns_or_network"
+    if checks.get("clone") in {"failed", "not_run_or_failed"}:
+        return "blocked_clone_failed"
+    if checks.get("pytest") in {"missing", "failed"}:
+        return "blocked_pytest_unavailable"
+    required = [checks.get("python"), checks.get("git"), checks.get("workdir")]
+    if all(value == "ok" for value in required):
+        return "ready_for_read_only_validation"
+    return "unknown_needs_review"
+
+
+def _blocked_reason(status: RunnerEnvCheckStatus, packet: RunnerEnvCheckInput) -> str:
+    if packet.blocked_reason:
+        return packet.blocked_reason
+    if status == "blocked_no_python":
+        return "Python is not available in the runner."
+    if status == "blocked_no_git":
+        return "Git is not available in the runner."
+    if status == "blocked_no_workdir":
+        return "Workdir is not writable or not available."
+    if status == "blocked_dns_or_network":
+        return "GitHub DNS/network check failed."
+    if status == "blocked_clone_failed":
+        return "Repository shallow clone failed."
+    if status == "blocked_pytest_unavailable":
+        return "Pytest is not available in the runner."
+    if status == "unsafe_or_policy_violation":
+        return "Unsafe runner preflight input or credential-like repository URL."
+    if status == "unknown_needs_review":
+        return "Runner readiness could not be determined from the provided checks."
+    return ""
+
+
+def build_runner_env_check(packet: RunnerEnvCheckInput) -> RunnerEnvCheckPacket:
+    """Build a runner preflight packet from public-safe offline input."""
+    status = _status_from_checks(packet)
+    safe = status == "ready_for_read_only_validation"
+    repo_url = _redact_repo_url(packet.repo_url_checked)
+    repository = packet.repository or _infer_repository(packet.repo_url_checked)
+
+    return RunnerEnvCheckPacket(
+        status=status,
+        repository=repository,
+        repo_url_checked=repo_url,
+        checks=packet.checks,
+        commands_run=packet.commands_run,
+        blocked_reason=_blocked_reason(status, packet),
+        safe_for_runner=safe,
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_safe_step=STATUS_NEXT_STEPS.get(status, DEFAULT_NEXT_SAFE_STEP),
+    )
+
+
+def build_runner_env_check_from_json(raw_json: str) -> RunnerEnvCheckPacket:
+    """Validate local JSON text and build a runner environment packet."""
+    return build_runner_env_check(RunnerEnvCheckInput.model_validate_json(raw_json))
+
+
+def _check_workdir(workdir: Path) -> CheckState:
+    try:
+        workdir.mkdir(parents=True, exist_ok=True)
+        probe = workdir / ".skeleton_write_probe"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+    except OSError:
+        return "failed"
+    return "ok"
+
+
+def _run_version_command(command: list[str]) -> CheckState:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "failed"
+    return "ok" if result.returncode == 0 else "failed"
+
+
+def _check_dns_github() -> CheckState:
+    try:
+        socket.gethostbyname("github.com")
+    except OSError:
+        return "failed"
+    return "ok"
+
+
+def _check_clone(repo_url: str, workdir: Path) -> CheckState:
+    target = workdir / "repo"
+    if target.exists():
+        shutil.rmtree(target)
+    try:
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", repo_url, str(target)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "failed"
+    return "ok" if result.returncode == 0 else "failed"
+
+
+def live_runner_env_check(
+    *,
+    repo_url: str,
+    workdir: Path,
+    allow_network_check: bool = False,
+    skip_clone_check: bool = False,
+) -> RunnerEnvCheckPacket:
+    """Run a bounded local preflight. Network/clone only run with explicit opt-in."""
+    checks: dict[str, CheckState] = {}
+    commands_run: list[str] = []
+
+    if _repo_url_has_credentials(repo_url):
+        return build_runner_env_check(
+            RunnerEnvCheckInput(
+                repo_url_checked=repo_url,
+                policy_violation=True,
+                blocked_reason="Repository URL contains credentials and was redacted.",
+            )
+        )
+
+    if shutil.which(sys.executable):
+        checks["python"] = _run_version_command([sys.executable, "--version"])
+    else:
+        checks["python"] = "missing"
+    commands_run.append("python --version")
+
+    if shutil.which("git"):
+        checks["git"] = _run_version_command(["git", "--version"])
+    else:
+        checks["git"] = "missing"
+    commands_run.append("git --version")
+
+    checks["workdir"] = _check_workdir(workdir)
+    checks["pytest"] = "ok" if importlib.util.find_spec("pytest") else "missing"
+
+    if allow_network_check:
+        checks["dns_github"] = _check_dns_github()
+        if not skip_clone_check and checks["dns_github"] == "ok" and checks["git"] == "ok":
+            checks["clone"] = _check_clone(repo_url, workdir)
+            commands_run.append(_redacted_clone_command(str(workdir)))
+        else:
+            checks["clone"] = "not_run"
+    else:
+        checks["dns_github"] = "not_checked"
+        checks["clone"] = "not_checked"
+
+    return build_runner_env_check(
+        RunnerEnvCheckInput(
+            repository=_infer_repository(repo_url),
+            repo_url_checked=repo_url,
+            checks=checks,
+            commands_run=commands_run,
+        )
+    )


### PR DESCRIPTION
## Summary

Implements #83 as a local/offline-first Skeleton Core command:

```text
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_ready.json
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_dns_failure.json
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_no_git.json
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_clone_failed.json
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_policy_violation.json
```

The command emits:

```text
ready_for_read_only_validation
blocked_no_git
blocked_no_python
blocked_no_workdir
blocked_dns_or_network
blocked_clone_failed
blocked_pytest_unavailable
unsafe_or_policy_violation
unknown_needs_review
```

Live preflight is supported only when the operator explicitly passes repo/workdir, and DNS/clone require explicit `--allow-network-check`:

```bash
python -m tools.skeleton_core.cli runner-env-check --repo-url https://github.com/alanua/bauclock.git --workdir /tmp/bauclock_preflight --allow-network-check
```

## Safety

```text
Fixture mode is fully offline.
No project tests are run by default.
No .env reads.
No GitHub issue/PR API calls from the CLI.
No server SSH.
No production DB.
No secrets/private data printed.
Credential-like repo URLs are redacted and blocked.
No merge/deploy authority.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Manual fixture commands to verify after checkout:

```bash
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_ready.json
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_dns_failure.json
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_no_git.json
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_clone_failed.json
python -m tools.skeleton_core.cli runner-env-check --input tests/fixtures/runner_env_check_policy_violation.json
```

Closes #83.