### PR TITLE
Add Skeleton format-preflight command

### DIFF
--- a/tests/fixtures/format_preflight_clean.json
+++ b/tests/fixtures/format_preflight_clean.json
@@ -1,0 +1,7 @@
+{
+  "formatter": "black",
+  "checked_paths": ["tools/skeleton_core", "tests/skeleton_core"],
+  "files_needing_format": [],
+  "black_available": "ok",
+  "blocked_reason": ""
+}

--- a/tests/fixtures/format_preflight_missing_black.json
+++ b/tests/fixtures/format_preflight_missing_black.json
@@ -1,0 +1,7 @@
+{
+  "formatter": "black",
+  "checked_paths": ["tools/skeleton_core", "tests/skeleton_core"],
+  "files_needing_format": [],
+  "black_available": "missing",
+  "blocked_reason": ""
+}

--- a/tests/fixtures/format_preflight_needs_black.json
+++ b/tests/fixtures/format_preflight_needs_black.json
@@ -1,0 +1,7 @@
+{
+  "formatter": "black",
+  "checked_paths": ["tools/skeleton_core/cli.py"],
+  "files_needing_format": ["tools/skeleton_core/cli.py"],
+  "black_available": "ok",
+  "blocked_reason": ""
+}

--- a/tests/skeleton_core/test_cli_format_preflight.py
+++ b/tests/skeleton_core/test_cli_format_preflight.py
@@ -1,0 +1,45 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["format-preflight", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_format_preflight_clean_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/format_preflight_clean.json", capsys)
+
+    assert payload["status"] == "format_ready"
+    assert payload["safe_to_continue_ci"] is True
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_format_preflight_needs_black_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/format_preflight_needs_black.json", capsys)
+
+    assert payload["status"] == "needs_black_format"
+    assert payload["safe_to_continue_ci"] is False
+    assert payload["files_needing_format"] == ["tools/skeleton_core/cli.py"]
+
+
+def test_cli_format_preflight_missing_black_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/format_preflight_missing_black.json", capsys)
+
+    assert payload["status"] == "blocked_missing_black"
+    assert payload["safe_to_continue_ci"] is False
+
+
+def test_cli_format_preflight_missing_args(capsys) -> None:
+    exit_code = main(["format-preflight"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["status"] == "unknown_needs_review"
+    assert payload["safe_to_continue_ci"] is False

--- a/tests/skeleton_core/test_format_preflight.py
+++ b/tests/skeleton_core/test_format_preflight.py
@@ -1,0 +1,51 @@
+from tools.skeleton_core.format_preflight import FormatPreflightInput, build_format_preflight
+
+
+def test_format_preflight_clean_ready() -> None:
+    result = build_format_preflight(
+        FormatPreflightInput(
+            checked_paths=["tools/skeleton_core", "tests/skeleton_core"],
+            files_needing_format=[],
+            black_available="ok",
+        )
+    )
+
+    assert result.status == "format_ready"
+    assert result.safe_to_continue_ci is True
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_format_preflight_needs_black() -> None:
+    result = build_format_preflight(
+        FormatPreflightInput(
+            checked_paths=["tools/skeleton_core/cli.py"],
+            files_needing_format=["tools/skeleton_core/cli.py"],
+            black_available="ok",
+        )
+    )
+
+    assert result.status == "needs_black_format"
+    assert result.safe_to_continue_ci is False
+    assert result.files_needing_format == ["tools/skeleton_core/cli.py"]
+    assert "python -m black tools/skeleton_core/cli.py" in result.commands_recommended
+
+
+def test_format_preflight_missing_black() -> None:
+    result = build_format_preflight(
+        FormatPreflightInput(
+            checked_paths=["tools/skeleton_core"],
+            black_available="missing",
+        )
+    )
+
+    assert result.status == "blocked_missing_black"
+    assert result.safe_to_continue_ci is False
+    assert result.next_safe_step == "Install dev dependencies with Black before formatting checks."
+
+
+def test_format_preflight_unknown_without_paths() -> None:
+    result = build_format_preflight(FormatPreflightInput())
+
+    assert result.status == "unknown_needs_review"
+    assert result.safe_to_continue_ci is False

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -12,6 +12,11 @@ from pydantic import ValidationError
 
 from tools.skeleton_core.branch_recovery import BranchRecoveryInput, build_branch_recovery
 from tools.skeleton_core.checkpoint import render_checkpoint
+from tools.skeleton_core.format_preflight import (
+    FormatPreflightInput,
+    build_format_preflight,
+    live_format_preflight,
+)
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.handoff_pack import render_handoff_pack
 from tools.skeleton_core.issue_dispatch import IssueDispatchInput, build_issue_dispatch_packet
@@ -46,6 +51,7 @@ SUBCOMMANDS = {
     "checkpoint",
     "classify-queue",
     "decide",
+    "format-preflight",
     "handoff-pack",
     "issue-dispatch",
     "issue-runner-bridge",
@@ -84,6 +90,11 @@ def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
 def load_branch_recovery_input(input_path: Path) -> BranchRecoveryInput:
     """Load public-safe branch recovery input from JSON."""
     return BranchRecoveryInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_format_preflight_input(input_path: Path) -> FormatPreflightInput:
+    """Load public-safe format preflight input from JSON."""
+    return FormatPreflightInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_project_skeleton_profile_input(input_path: Path) -> ProjectSkeletonProfileInput:
@@ -278,6 +289,18 @@ def _subcommand_parser() -> argparse.ArgumentParser:
 
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
+
+    format_parser = subparsers.add_parser(
+        "format-preflight",
+        help="Check Black formatting readiness before CI",
+    )
+    format_parser.add_argument("--input", type=Path, default=None, help="Path to offline fixture JSON")
+    format_parser.add_argument("--paths", nargs="*", type=Path, default=None, help="Paths for live check-only mode")
+    format_parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Compatibility flag; live mode is always check-only",
+    )
 
     handoff_pack_parser = subparsers.add_parser(
         "handoff-pack",
@@ -504,6 +527,21 @@ def _run_checkpoint(args: argparse.Namespace) -> int:
 
 def _run_classify_queue(args: argparse.Namespace) -> int:
     result = classify_queue_items(load_queue_items(args.input))
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
+def _run_format_preflight(args: argparse.Namespace) -> int:
+    try:
+        if args.input is not None:
+            result = build_format_preflight(load_format_preflight_input(args.input))
+        elif args.paths:
+            result = live_format_preflight(args.paths)
+        else:
+            result = build_format_preflight(FormatPreflightInput())
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
     print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
     return 0
 
@@ -739,6 +777,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_checkpoint(args)
     if args.command == "classify-queue":
         return _run_classify_queue(args)
+    if args.command == "format-preflight":
+        return _run_format_preflight(args)
     if args.command == "handoff-pack":
         return _run_handoff_pack(args)
     if args.command == "issue-dispatch":

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -294,8 +294,19 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         "format-preflight",
         help="Check Black formatting readiness before CI",
     )
-    format_parser.add_argument("--input", type=Path, default=None, help="Path to offline fixture JSON")
-    format_parser.add_argument("--paths", nargs="*", type=Path, default=None, help="Paths for live check-only mode")
+    format_parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Path to offline fixture JSON",
+    )
+    format_parser.add_argument(
+        "--paths",
+        nargs="*",
+        type=Path,
+        default=None,
+        help="Paths for live check-only mode",
+    )
     format_parser.add_argument(
         "--check-only",
         action="store_true",

--- a/tools/skeleton_core/format_preflight.py
+++ b/tools/skeleton_core/format_preflight.py
@@ -1,0 +1,155 @@
+"""Local/offline formatter preflight for Skeleton changes."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+FormatPreflightStatus = Literal[
+    "format_ready",
+    "needs_black_format",
+    "blocked_missing_black",
+    "unknown_needs_review",
+]
+BlackAvailability = Literal["ok", "missing", "not_checked"]
+
+
+class FormatPreflightInput(BaseModel):
+    """Public-safe formatter preflight export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    formatter: str = "black"
+    checked_paths: list[str] = Field(default_factory=list)
+    files_needing_format: list[str] = Field(default_factory=list)
+    black_available: BlackAvailability = "not_checked"
+    blocked_reason: str = ""
+
+
+class FormatPreflightPacket(BaseModel):
+    """Structured formatter readiness packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: FormatPreflightStatus
+    formatter: str = "black"
+    checked_paths: list[str] = Field(default_factory=list)
+    files_needing_format: list[str] = Field(default_factory=list)
+    commands_recommended: list[str] = Field(default_factory=list)
+    safe_to_continue_ci: bool = False
+    blocked_reason: str = ""
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    next_safe_step: str
+
+
+def _clean_items(items: list[str]) -> list[str]:
+    return sorted({item.strip() for item in items if item.strip()})
+
+
+def _commands(status: FormatPreflightStatus, checked_paths: list[str]) -> list[str]:
+    paths = " ".join(checked_paths) if checked_paths else "tools/skeleton_core tests/skeleton_core"
+    if status == "needs_black_format":
+        return [f"python -m black {paths}", f"python -m black --check {paths}"]
+    if status == "blocked_missing_black":
+        return ["pip install -e .[dev]", f"python -m black --check {paths}"]
+    if status == "format_ready":
+        return [f"python -m black --check {paths}"]
+    return []
+
+
+def _next_step(status: FormatPreflightStatus) -> str:
+    if status == "format_ready":
+        return "Continue to CI or PR review."
+    if status == "needs_black_format":
+        return "Run Black on listed files before pushing or re-running CI."
+    if status == "blocked_missing_black":
+        return "Install dev dependencies with Black before formatting checks."
+    return "Manual review required before continuing."
+
+
+def _blocked_reason(status: FormatPreflightStatus, packet: FormatPreflightInput) -> str:
+    if packet.blocked_reason:
+        return packet.blocked_reason
+    if status == "needs_black_format":
+        return "Black would reformat one or more checked files."
+    if status == "blocked_missing_black":
+        return "Black is not available in this environment."
+    if status == "unknown_needs_review":
+        return "Formatter readiness could not be determined."
+    return ""
+
+
+def build_format_preflight(packet: FormatPreflightInput) -> FormatPreflightPacket:
+    """Build a formatter preflight packet from public-safe input."""
+    checked_paths = _clean_items(packet.checked_paths)
+    files_needing_format = _clean_items(packet.files_needing_format)
+
+    if packet.black_available == "missing":
+        status: FormatPreflightStatus = "blocked_missing_black"
+    elif files_needing_format:
+        status = "needs_black_format"
+    elif checked_paths and packet.black_available in {"ok", "not_checked"}:
+        status = "format_ready"
+    else:
+        status = "unknown_needs_review"
+
+    return FormatPreflightPacket(
+        status=status,
+        formatter=packet.formatter or "black",
+        checked_paths=checked_paths,
+        files_needing_format=files_needing_format,
+        commands_recommended=_commands(status, checked_paths),
+        safe_to_continue_ci=status == "format_ready",
+        blocked_reason=_blocked_reason(status, packet),
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_safe_step=_next_step(status),
+    )
+
+
+def build_format_preflight_from_json(raw_json: str) -> FormatPreflightPacket:
+    """Validate local JSON text and build a formatter preflight packet."""
+    return build_format_preflight(FormatPreflightInput.model_validate_json(raw_json))
+
+
+def _parse_black_files(output: str) -> list[str]:
+    files = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("would reformat "):
+            files.append(stripped.removeprefix("would reformat ").strip())
+    return _clean_items(files)
+
+
+def live_format_preflight(paths: list[Path]) -> FormatPreflightPacket:
+    """Run Black in check-only mode. This does not modify files."""
+    checked_paths = [str(path) for path in paths]
+    if importlib.util.find_spec("black") is None:
+        return build_format_preflight(
+            FormatPreflightInput(
+                checked_paths=checked_paths,
+                black_available="missing",
+            )
+        )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "black", "--check", *checked_paths],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    files = _parse_black_files(result.stdout + "\n" + result.stderr)
+    return build_format_preflight(
+        FormatPreflightInput(
+            checked_paths=checked_paths,
+            files_needing_format=files,
+            black_available="ok",
+        )
+    )


### PR DESCRIPTION
## Summary

Implements #86 as a local/offline Skeleton Core command:

```text
python -m tools.skeleton_core.cli format-preflight --input tests/fixtures/format_preflight_clean.json
python -m tools.skeleton_core.cli format-preflight --input tests/fixtures/format_preflight_needs_black.json
python -m tools.skeleton_core.cli format-preflight --input tests/fixtures/format_preflight_missing_black.json
```

It emits:

```text
format_ready
needs_black_format
blocked_missing_black
unknown_needs_review
```

Live mode is check-only:

```bash
python -m tools.skeleton_core.cli format-preflight --paths tools/skeleton_core tests/skeleton_core --check-only
```

## Safety

```text
No runtime changes.
No network.
No secrets.
No .env reads.
No merge/deploy authority.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Closes #86.