### PR TITLE
Add Skeleton github-actions-runner-control command

### DIFF
--- a/tests/fixtures/actions_run_bauclock_tests_cancelled.json
+++ b/tests/fixtures/actions_run_bauclock_tests_cancelled.json
@@ -1,0 +1,20 @@
+{
+  "repository": "alanua/bauclock",
+  "workflow": "Tests",
+  "workflow_file": "tests.yml",
+  "ref": "main",
+  "head_sha": "abc123cancelled",
+  "run_id": 1003,
+  "run_status": "completed",
+  "run_conclusion": "cancelled",
+  "commands_inferred": ["pytest"],
+  "logs_summary": ["Workflow was cancelled."],
+  "jobs": [
+    {
+      "name": "tests",
+      "status": "completed",
+      "conclusion": "cancelled",
+      "steps": []
+    }
+  ]
+}

--- a/tests/fixtures/actions_run_bauclock_tests_failed.json
+++ b/tests/fixtures/actions_run_bauclock_tests_failed.json
@@ -1,0 +1,27 @@
+{
+  "repository": "alanua/bauclock",
+  "workflow": "Tests",
+  "workflow_file": "tests.yml",
+  "ref": "main",
+  "head_sha": "abc123failed",
+  "run_id": 1002,
+  "run_status": "completed",
+  "run_conclusion": "failure",
+  "commands_inferred": ["pytest"],
+  "logs_summary": ["pytest failed in test_dashboard.py"],
+  "jobs": [
+    {
+      "name": "tests",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "Run tests",
+          "status": "completed",
+          "conclusion": "failure",
+          "summary": "1 failed"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/actions_run_bauclock_tests_success.json
+++ b/tests/fixtures/actions_run_bauclock_tests_success.json
@@ -1,0 +1,27 @@
+{
+  "repository": "alanua/bauclock",
+  "workflow": "Tests",
+  "workflow_file": "tests.yml",
+  "ref": "main",
+  "head_sha": "abc123success",
+  "run_id": 1001,
+  "run_status": "completed",
+  "run_conclusion": "success",
+  "commands_inferred": ["pytest"],
+  "logs_summary": ["All tests passed."],
+  "jobs": [
+    {
+      "name": "tests",
+      "status": "completed",
+      "conclusion": "success",
+      "steps": [
+        {
+          "name": "Run tests",
+          "status": "completed",
+          "conclusion": "success",
+          "summary": "228 passed"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/actions_run_secret_like_log_blocked.json
+++ b/tests/fixtures/actions_run_secret_like_log_blocked.json
@@ -1,0 +1,27 @@
+{
+  "repository": "alanua/bauclock",
+  "workflow": "Tests",
+  "workflow_file": "tests.yml",
+  "ref": "main",
+  "head_sha": "abc123secret",
+  "run_id": 1004,
+  "run_status": "completed",
+  "run_conclusion": "failure",
+  "commands_inferred": ["pytest"],
+  "logs_summary": ["token=<redacted-fixture-value> appeared in log summary"],
+  "jobs": [
+    {
+      "name": "tests",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "Run tests",
+          "status": "completed",
+          "conclusion": "failure",
+          "summary": "secret-like output blocked"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/skeleton_core/test_cli_github_actions_runner_control.py
+++ b/tests/skeleton_core/test_cli_github_actions_runner_control.py
@@ -1,0 +1,46 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["github-actions-runner-control", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_actions_success_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/actions_run_bauclock_tests_success.json", capsys)
+
+    assert payload["status"] == "workflow_success_report"
+    assert payload["test_result"] == "passed"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+    assert "BauClock #22" in payload["issue_report_text"]
+
+
+def test_cli_actions_failed_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/actions_run_bauclock_tests_failed.json", capsys)
+
+    assert payload["status"] == "workflow_failed_report"
+    assert payload["test_result"] == "failed"
+    assert payload["failed_steps"] == ["tests: Run tests"]
+
+
+def test_cli_actions_cancelled_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/actions_run_bauclock_tests_cancelled.json", capsys)
+
+    assert payload["status"] == "workflow_cancelled_report"
+    assert payload["test_result"] == "cancelled"
+
+
+def test_cli_actions_secret_like_fixture(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/actions_run_secret_like_log_blocked.json", capsys)
+
+    assert payload["status"] == "unsafe_or_policy_violation"
+    assert payload["test_result"] == "blocked"
+    assert "token=" not in json.dumps(payload)
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False

--- a/tests/skeleton_core/test_github_actions_runner_control.py
+++ b/tests/skeleton_core/test_github_actions_runner_control.py
@@ -1,0 +1,112 @@
+from tools.skeleton_core.github_actions_runner_control import (
+    ActionsJob,
+    ActionsStep,
+    GithubActionsRunnerInput,
+    build_github_actions_runner_control,
+)
+
+
+def _base_packet(**overrides) -> GithubActionsRunnerInput:
+    data = {
+        "repository": "alanua/bauclock",
+        "workflow": "Tests",
+        "workflow_file": "tests.yml",
+        "ref": "main",
+        "head_sha": "abc123",
+        "run_id": 1001,
+        "run_status": "completed",
+        "run_conclusion": "success",
+        "commands_inferred": ["pytest"],
+        "logs_summary": ["All tests passed."],
+        "jobs": [
+            ActionsJob(
+                name="tests",
+                status="completed",
+                conclusion="success",
+                steps=[
+                    ActionsStep(
+                        name="Run tests",
+                        status="completed",
+                        conclusion="success",
+                        summary="228 passed",
+                    )
+                ],
+            )
+        ],
+    }
+    data.update(overrides)
+    return GithubActionsRunnerInput(**data)
+
+
+def test_actions_success_report() -> None:
+    result = build_github_actions_runner_control(_base_packet())
+
+    assert result.status == "workflow_success_report"
+    assert result.test_result == "passed"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert "BauClock #22" in result.issue_report_text
+    assert "queue-state may unlock" in result.issue_report_text
+
+
+def test_actions_failed_report_includes_failed_step() -> None:
+    result = build_github_actions_runner_control(
+        _base_packet(
+            run_conclusion="failure",
+            logs_summary=["pytest failed"],
+            jobs=[
+                ActionsJob(
+                    name="tests",
+                    status="completed",
+                    conclusion="failure",
+                    steps=[
+                        ActionsStep(
+                            name="Run tests",
+                            status="completed",
+                            conclusion="failure",
+                            summary="1 failed",
+                        )
+                    ],
+                )
+            ],
+        )
+    )
+
+    assert result.status == "workflow_failed_report"
+    assert result.test_result == "failed"
+    assert result.failed_steps == ["tests: Run tests"]
+    assert result.failure_summary == "Failed steps: tests: Run tests"
+
+
+def test_actions_cancelled_report() -> None:
+    result = build_github_actions_runner_control(
+        _base_packet(run_conclusion="cancelled", jobs=[], logs_summary=[])
+    )
+
+    assert result.status == "workflow_cancelled_report"
+    assert result.test_result == "cancelled"
+    assert result.failure_summary == "Workflow run was cancelled."
+
+
+def test_actions_secret_like_log_is_blocked_and_redacted() -> None:
+    result = build_github_actions_runner_control(
+        _base_packet(
+            run_conclusion="failure",
+            logs_summary=["token=<redacted-fixture-value> appeared"],
+        )
+    )
+
+    assert result.status == "unsafe_or_policy_violation"
+    assert result.test_result == "blocked"
+    assert result.failure_summary is not None
+    assert "Secret-like content" in result.failure_summary
+    assert "token=" not in result.failure_summary
+
+
+def test_actions_unknown_needs_review() -> None:
+    result = build_github_actions_runner_control(_base_packet(run_conclusion="", jobs=[]))
+
+    assert result.status == "workflow_unknown_needs_review"
+    assert result.test_result == "unknown"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -17,6 +17,10 @@ from tools.skeleton_core.format_preflight import (
     build_format_preflight,
     live_format_preflight,
 )
+from tools.skeleton_core.github_actions_runner_control import (
+    GithubActionsRunnerInput,
+    build_github_actions_runner_control,
+)
 from tools.skeleton_core.github_queue import normalize_issue, normalize_pr, summarize_queue
 from tools.skeleton_core.handoff_pack import render_handoff_pack
 from tools.skeleton_core.issue_dispatch import IssueDispatchInput, build_issue_dispatch_packet
@@ -52,6 +56,7 @@ SUBCOMMANDS = {
     "classify-queue",
     "decide",
     "format-preflight",
+    "github-actions-runner-control",
     "handoff-pack",
     "issue-dispatch",
     "issue-runner-bridge",
@@ -95,6 +100,11 @@ def load_branch_recovery_input(input_path: Path) -> BranchRecoveryInput:
 def load_format_preflight_input(input_path: Path) -> FormatPreflightInput:
     """Load public-safe format preflight input from JSON."""
     return FormatPreflightInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_github_actions_runner_input(input_path: Path) -> GithubActionsRunnerInput:
+    """Load public-safe GitHub Actions runner input from JSON."""
+    return GithubActionsRunnerInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_project_skeleton_profile_input(input_path: Path) -> ProjectSkeletonProfileInput:
@@ -312,6 +322,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Compatibility flag; live mode is always check-only",
     )
+
+    actions_parser = subparsers.add_parser(
+        "github-actions-runner-control",
+        help="Build a report from public-safe GitHub Actions run/job JSON",
+    )
+    _add_input_arg(actions_parser, "Path to public-safe GitHub Actions run/job JSON")
 
     handoff_pack_parser = subparsers.add_parser(
         "handoff-pack",
@@ -557,6 +573,16 @@ def _run_format_preflight(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_github_actions_runner_control(args: argparse.Namespace) -> int:
+    try:
+        result = build_github_actions_runner_control(load_github_actions_runner_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_handoff_pack(args: argparse.Namespace) -> int:
     print(render_handoff_pack(args.root), flush=True)
     return 0
@@ -790,6 +816,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_classify_queue(args)
     if args.command == "format-preflight":
         return _run_format_preflight(args)
+    if args.command == "github-actions-runner-control":
+        return _run_github_actions_runner_control(args)
     if args.command == "handoff-pack":
         return _run_handoff_pack(args)
     if args.command == "issue-dispatch":

--- a/tools/skeleton_core/github_actions_runner_control.py
+++ b/tools/skeleton_core/github_actions_runner_control.py
@@ -1,0 +1,231 @@
+"""Offline GitHub Actions run report normalizer for Skeleton."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ActionsRunnerStatus = Literal[
+    "workflow_success_report",
+    "workflow_failed_report",
+    "workflow_cancelled_report",
+    "workflow_unknown_needs_review",
+    "unsafe_or_policy_violation",
+]
+StepConclusion = Literal["success", "failure", "cancelled", "skipped", "neutral", "timed_out", "unknown"]
+
+SECRET_MARKERS = (
+    "api_key",
+    "apikey",
+    "authorization:",
+    "bearer ",
+    "client_secret",
+    "ghp_",
+    "password=",
+    "private_key",
+    "secret=",
+    "token=",
+)
+
+
+class ActionsStep(BaseModel):
+    """Public-safe GitHub Actions step export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = ""
+    status: str = ""
+    conclusion: StepConclusion = "unknown"
+    summary: str = ""
+
+
+class ActionsJob(BaseModel):
+    """Public-safe GitHub Actions job export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = ""
+    status: str = ""
+    conclusion: str = ""
+    steps: list[ActionsStep] = Field(default_factory=list)
+
+
+class GithubActionsRunnerInput(BaseModel):
+    """Public-safe GitHub Actions run/job export."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    repository: str = ""
+    workflow: str = ""
+    workflow_file: str = ""
+    ref: str = ""
+    head_sha: str = ""
+    run_id: int | None = None
+    run_status: str = ""
+    run_conclusion: str = ""
+    jobs: list[ActionsJob] = Field(default_factory=list)
+    commands_inferred: list[str] = Field(default_factory=list)
+    logs_summary: list[str] = Field(default_factory=list)
+
+
+class GithubActionsRunnerPacket(BaseModel):
+    """Structured report packet for Actions-based validation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: ActionsRunnerStatus
+    repository: str = ""
+    workflow: str = ""
+    workflow_file: str = ""
+    ref: str = ""
+    head_sha: str = ""
+    run_id: int | None = None
+    run_status: str = ""
+    run_conclusion: str = ""
+    job_names: list[str] = Field(default_factory=list)
+    failed_steps: list[str] = Field(default_factory=list)
+    commands_inferred: list[str] = Field(default_factory=list)
+    test_result: str = "unknown"
+    failure_summary: str | None = None
+    issue_report_text: str
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+
+
+def _clean_items(items: list[str]) -> list[str]:
+    return [item.strip() for item in items if item.strip()]
+
+
+def _has_secret_like_text(values: list[str]) -> bool:
+    joined = "\n".join(values).casefold()
+    return any(marker in joined for marker in SECRET_MARKERS)
+
+
+def _redacted(value: str) -> str:
+    lowered = value.casefold()
+    if any(marker in lowered for marker in SECRET_MARKERS):
+        return "<redacted-secret-like-log-line>"
+    return value
+
+
+def _failed_steps(jobs: list[ActionsJob]) -> list[str]:
+    failed = []
+    for job in jobs:
+        for step in job.steps:
+            if step.conclusion in {"failure", "timed_out"}:
+                name = step.name or "unnamed step"
+                failed.append(f"{job.name}: {name}" if job.name else name)
+    return _clean_items(failed)
+
+
+def _status(packet: GithubActionsRunnerInput) -> ActionsRunnerStatus:
+    if _has_secret_like_text(packet.logs_summary):
+        return "unsafe_or_policy_violation"
+    if packet.run_conclusion == "success":
+        return "workflow_success_report"
+    if packet.run_conclusion in {"failure", "timed_out"}:
+        return "workflow_failed_report"
+    if packet.run_conclusion == "cancelled":
+        return "workflow_cancelled_report"
+    return "workflow_unknown_needs_review"
+
+
+def _test_result(status: ActionsRunnerStatus) -> str:
+    if status == "workflow_success_report":
+        return "passed"
+    if status == "workflow_failed_report":
+        return "failed"
+    if status == "workflow_cancelled_report":
+        return "cancelled"
+    if status == "unsafe_or_policy_violation":
+        return "blocked"
+    return "unknown"
+
+
+def _failure_summary(
+    status: ActionsRunnerStatus,
+    failed_steps: list[str],
+    logs_summary: list[str],
+) -> str | None:
+    if status == "workflow_success_report":
+        return None
+    if status == "unsafe_or_policy_violation":
+        return "Secret-like content was detected in the Actions export/log summary. Output was redacted."
+    if failed_steps:
+        return "Failed steps: " + "; ".join(failed_steps)
+    redacted_logs = [_redacted(item) for item in logs_summary]
+    if redacted_logs:
+        return "Logs summary: " + "; ".join(redacted_logs[:3])
+    if status == "workflow_cancelled_report":
+        return "Workflow run was cancelled."
+    return "Workflow result needs manual review."
+
+
+def _report_text(
+    *,
+    packet: GithubActionsRunnerInput,
+    status: ActionsRunnerStatus,
+    test_result: str,
+    failure_summary: str | None,
+    failed_steps: list[str],
+) -> str:
+    lines = [
+        "Agent report for BauClock #22",
+        "",
+        f"Repository: {packet.repository or 'unknown'}",
+        f"Workflow: {packet.workflow or 'unknown'}",
+        f"Ref: {packet.ref or 'unknown'}",
+        f"Head SHA: {packet.head_sha or 'unknown'}",
+        f"Run ID: {packet.run_id if packet.run_id is not None else 'unknown'}",
+        f"Result: {test_result}",
+    ]
+    if failure_summary:
+        lines.extend(["", f"Failure summary: {failure_summary}"])
+    if failed_steps:
+        lines.extend(["", "Failed steps:", *[f"- {step}" for step in failed_steps]])
+    if status == "workflow_success_report":
+        lines.extend(["", "Next safe step: queue-state may unlock the next BauClock task."])
+    else:
+        lines.extend(["", "Next safe step: review or fix the workflow result before unlocking the queue."])
+    return "\n".join(lines)
+
+
+def build_github_actions_runner_control(
+    packet: GithubActionsRunnerInput,
+) -> GithubActionsRunnerPacket:
+    """Build a deterministic Actions validation report packet."""
+    status = _status(packet)
+    failed_steps = _failed_steps(packet.jobs)
+    test_result = _test_result(status)
+    failure_summary = _failure_summary(status, failed_steps, packet.logs_summary)
+    return GithubActionsRunnerPacket(
+        status=status,
+        repository=packet.repository,
+        workflow=packet.workflow,
+        workflow_file=packet.workflow_file,
+        ref=packet.ref,
+        head_sha=packet.head_sha,
+        run_id=packet.run_id,
+        run_status=packet.run_status,
+        run_conclusion=packet.run_conclusion,
+        job_names=_clean_items([job.name for job in packet.jobs]),
+        failed_steps=failed_steps,
+        commands_inferred=_clean_items(packet.commands_inferred),
+        test_result=test_result,
+        failure_summary=failure_summary,
+        issue_report_text=_report_text(
+            packet=packet,
+            status=status,
+            test_result=test_result,
+            failure_summary=failure_summary,
+            failed_steps=failed_steps,
+        ),
+        merge_allowed=False,
+        deploy_allowed=False,
+    )
+
+
+def build_github_actions_runner_control_from_json(raw_json: str) -> GithubActionsRunnerPacket:
+    """Validate local JSON text and build an Actions report packet."""
+    return build_github_actions_runner_control(GithubActionsRunnerInput.model_validate_json(raw_json))

--- a/tools/skeleton_core/github_actions_runner_control.py
+++ b/tools/skeleton_core/github_actions_runner_control.py
@@ -199,8 +199,7 @@ def _report_text(
         lines.extend(["", "Next safe step: queue-state may unlock the next BauClock task."])
     else:
         next_step = (
-            "Next safe step: review or fix the workflow result "
-            "before unlocking the queue."
+            "Next safe step: review or fix the workflow result " "before unlocking the queue."
         )
         lines.extend(["", next_step])
     return "\n".join(lines)

--- a/tools/skeleton_core/github_actions_runner_control.py
+++ b/tools/skeleton_core/github_actions_runner_control.py
@@ -13,7 +13,15 @@ ActionsRunnerStatus = Literal[
     "workflow_unknown_needs_review",
     "unsafe_or_policy_violation",
 ]
-StepConclusion = Literal["success", "failure", "cancelled", "skipped", "neutral", "timed_out", "unknown"]
+StepConclusion = Literal[
+    "success",
+    "failure",
+    "cancelled",
+    "skipped",
+    "neutral",
+    "timed_out",
+    "unknown",
+]
 
 SECRET_MARKERS = (
     "api_key",
@@ -151,7 +159,10 @@ def _failure_summary(
     if status == "workflow_success_report":
         return None
     if status == "unsafe_or_policy_violation":
-        return "Secret-like content was detected in the Actions export/log summary. Output was redacted."
+        return (
+            "Secret-like content was detected in the Actions export/log summary. "
+            "Output was redacted."
+        )
     if failed_steps:
         return "Failed steps: " + "; ".join(failed_steps)
     redacted_logs = [_redacted(item) for item in logs_summary]
@@ -185,9 +196,16 @@ def _report_text(
     if failed_steps:
         lines.extend(["", "Failed steps:", *[f"- {step}" for step in failed_steps]])
     if status == "workflow_success_report":
-        lines.extend(["", "Next safe step: queue-state may unlock the next BauClock task."])
+        lines.extend(
+            ["", "Next safe step: queue-state may unlock the next BauClock task."]
+        )
     else:
-        lines.extend(["", "Next safe step: review or fix the workflow result before unlocking the queue."])
+        lines.extend(
+            [
+                "",
+                "Next safe step: review or fix the workflow result before unlocking the queue.",
+            ]
+        )
     return "\n".join(lines)
 
 

--- a/tools/skeleton_core/github_actions_runner_control.py
+++ b/tools/skeleton_core/github_actions_runner_control.py
@@ -196,9 +196,7 @@ def _report_text(
     if failed_steps:
         lines.extend(["", "Failed steps:", *[f"- {step}" for step in failed_steps]])
     if status == "workflow_success_report":
-        lines.extend(
-            ["", "Next safe step: queue-state may unlock the next BauClock task."]
-        )
+        lines.extend(["", "Next safe step: queue-state may unlock the next BauClock task."])
     else:
         next_step = (
             "Next safe step: review or fix the workflow result "

--- a/tools/skeleton_core/github_actions_runner_control.py
+++ b/tools/skeleton_core/github_actions_runner_control.py
@@ -200,12 +200,11 @@ def _report_text(
             ["", "Next safe step: queue-state may unlock the next BauClock task."]
         )
     else:
-        lines.extend(
-            [
-                "",
-                "Next safe step: review or fix the workflow result before unlocking the queue.",
-            ]
+        next_step = (
+            "Next safe step: review or fix the workflow result "
+            "before unlocking the queue."
         )
+        lines.extend(["", next_step])
     return "\n".join(lines)
 
 
@@ -244,6 +243,9 @@ def build_github_actions_runner_control(
     )
 
 
-def build_github_actions_runner_control_from_json(raw_json: str) -> GithubActionsRunnerPacket:
+def build_github_actions_runner_control_from_json(
+    raw_json: str,
+) -> GithubActionsRunnerPacket:
     """Validate local JSON text and build an Actions report packet."""
-    return build_github_actions_runner_control(GithubActionsRunnerInput.model_validate_json(raw_json))
+    packet = GithubActionsRunnerInput.model_validate_json(raw_json)
+    return build_github_actions_runner_control(packet)


### PR DESCRIPTION
## Summary

Implements #88 offline/public-safe report mode:

```text
python -m tools.skeleton_core.cli github-actions-runner-control --input tests/fixtures/actions_run_bauclock_tests_success.json
python -m tools.skeleton_core.cli github-actions-runner-control --input tests/fixtures/actions_run_bauclock_tests_failed.json
python -m tools.skeleton_core.cli github-actions-runner-control --input tests/fixtures/actions_run_bauclock_tests_cancelled.json
python -m tools.skeleton_core.cli github-actions-runner-control --input tests/fixtures/actions_run_secret_like_log_blocked.json
```

Emits:

```text
workflow_success_report
workflow_failed_report
workflow_cancelled_report
workflow_unknown_needs_review
unsafe_or_policy_violation
```

## Safety

```text
Offline/public-safe input only.
No live GitHub Actions dispatch.
No network.
No .env reads.
No secrets printed.
No merge/deploy authority.
No Jeeves/BauClock runtime changes.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Closes #88.