### PR TITLE
Add Skeleton capability-request-broker command

### DIFF
--- a/tests/fixtures/capability_request_bauclock_actions_runner_control.json
+++ b/tests/fixtures/capability_request_bauclock_actions_runner_control.json
@@ -1,0 +1,23 @@
+{
+  "project": "bauclock",
+  "repository": "alanua/bauclock",
+  "source_issue": 22,
+  "blocker_or_need": "Need to run baseline validation with less manual work using GitHub Actions results.",
+  "manual_steps_repeated": [
+    "Start workflow manually",
+    "Read Actions run status",
+    "Read job result",
+    "Write #22 report"
+  ],
+  "desired_capability": "github-actions-runner-control",
+  "safety_constraints": [
+    "no merge",
+    "no deploy",
+    "no secrets",
+    "no runtime changes"
+  ],
+  "evidence": [
+    "BauClock #22 baseline validation is blocked/manual",
+    "BauClock #45 adds workflow_dispatch"
+  ]
+}

--- a/tests/fixtures/capability_request_bauclock_runner_env_check.json
+++ b/tests/fixtures/capability_request_bauclock_runner_env_check.json
@@ -1,0 +1,23 @@
+{
+  "project": "bauclock",
+  "repository": "alanua/bauclock",
+  "source_issue": 22,
+  "blocker_or_need": "Need to detect whether the runner environment is ready before attempting BauClock validation.",
+  "manual_steps_repeated": [
+    "Check python availability",
+    "Check git availability",
+    "Check writable workdir",
+    "Report blocked state manually"
+  ],
+  "desired_capability": "runner-env-check",
+  "safety_constraints": [
+    "no merge",
+    "no deploy",
+    "no secrets",
+    "no runtime changes"
+  ],
+  "evidence": [
+    "BauClock #22 validation was blocked by environment readiness uncertainty",
+    "Skeleton #83 introduced runner-env-check"
+  ]
+}

--- a/tests/fixtures/capability_request_existing_capability.json
+++ b/tests/fixtures/capability_request_existing_capability.json
@@ -1,0 +1,11 @@
+{
+  "project": "bauclock",
+  "repository": "alanua/bauclock",
+  "source_issue": 22,
+  "blocker_or_need": "Need to use existing runner-env-check before validation.",
+  "manual_steps_repeated": ["Check runner environment manually"],
+  "desired_capability": "runner-env-check",
+  "existing_capabilities": ["runner-env-check", "queue-state"],
+  "safety_constraints": ["no merge", "no deploy"],
+  "evidence": ["runner-env-check already exists in Skeleton"]
+}

--- a/tests/fixtures/capability_request_unknown_needs_review.json
+++ b/tests/fixtures/capability_request_unknown_needs_review.json
@@ -1,0 +1,10 @@
+{
+  "project": "bauclock",
+  "repository": "alanua/bauclock",
+  "source_issue": 22,
+  "blocker_or_need": "Need some automation.",
+  "desired_capability": "",
+  "manual_steps_repeated": [],
+  "safety_constraints": ["no merge"],
+  "evidence": []
+}

--- a/tests/fixtures/capability_request_unsafe_live_executor.json
+++ b/tests/fixtures/capability_request_unsafe_live_executor.json
@@ -1,0 +1,10 @@
+{
+  "project": "bauclock",
+  "repository": "alanua/bauclock",
+  "source_issue": 22,
+  "blocker_or_need": "Need a live executor that can merge, deploy, read .env tokens, and SSH into production server automatically.",
+  "manual_steps_repeated": ["Manual deploy", "Manual server SSH"],
+  "desired_capability": "live-executor",
+  "safety_constraints": [],
+  "evidence": ["unsafe request fixture"]
+}

--- a/tests/skeleton_core/test_capability_request_broker.py
+++ b/tests/skeleton_core/test_capability_request_broker.py
@@ -1,0 +1,85 @@
+from tools.skeleton_core.capability_request_broker import (
+    CapabilityRequestInput,
+    build_capability_request,
+)
+
+
+def test_ready_capability_request() -> None:
+    result = build_capability_request(
+        CapabilityRequestInput(
+            project="bauclock",
+            repository="alanua/bauclock",
+            source_issue=22,
+            blocker_or_need="Need to reduce manual GitHub Actions report work.",
+            manual_steps_repeated=["Read Actions run", "Write issue report"],
+            desired_capability="github-actions-runner-control",
+            safety_constraints=["no merge", "no deploy", "no secrets"],
+            evidence=["BauClock #22", "BauClock #45"],
+        )
+    )
+
+    assert result.status == "capability_request_ready"
+    assert result.capability_name == "github-actions-runner-control"
+    assert result.risk_level == "YELLOW"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert "github-actions-runner-control" in result.recommended_skeleton_issue_title
+    assert "No GitHub writes from CLI in v1" in result.recommended_skeleton_issue_body
+
+
+def test_existing_capability_request() -> None:
+    result = build_capability_request(
+        CapabilityRequestInput(
+            project="bauclock",
+            repository="alanua/bauclock",
+            source_issue=22,
+            blocker_or_need="Need to use existing runner-env-check.",
+            manual_steps_repeated=["Check runner manually"],
+            desired_capability="runner-env-check",
+            existing_capabilities=["runner-env-check"],
+            evidence=["Capability already merged"],
+        )
+    )
+
+    assert result.status == "capability_already_exists"
+    assert result.next_safe_step == "Update the project workflow to use the existing Skeleton capability."
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_unsafe_capability_request_blocks() -> None:
+    result = build_capability_request(
+        CapabilityRequestInput(
+            project="bauclock",
+            repository="alanua/bauclock",
+            source_issue=22,
+            blocker_or_need="Need live executor that can merge deploy and read .env token.",
+            manual_steps_repeated=["Manual deploy"],
+            desired_capability="live-executor",
+            evidence=["unsafe fixture"],
+        )
+    )
+
+    assert result.status == "blocked_unsafe_capability"
+    assert result.risk_level == "RED"
+    assert result.allowed_scope == []
+    assert result.acceptance_criteria == []
+    assert result.recommended_skeleton_issue_body == ""
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+    assert result.blockers
+
+
+def test_unknown_capability_request_needs_review() -> None:
+    result = build_capability_request(
+        CapabilityRequestInput(
+            project="bauclock",
+            blocker_or_need="Need some automation.",
+            desired_capability="",
+        )
+    )
+
+    assert result.status == "unknown_needs_review"
+    assert result.risk_level == "UNKNOWN"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False

--- a/tests/skeleton_core/test_capability_request_broker.py
+++ b/tests/skeleton_core/test_capability_request_broker.py
@@ -42,7 +42,10 @@ def test_existing_capability_request() -> None:
     )
 
     assert result.status == "capability_already_exists"
-    assert result.next_safe_step == "Update the project workflow to use the existing Skeleton capability."
+    assert (
+        result.next_safe_step
+        == "Update the project workflow to use the existing Skeleton capability."
+    )
     assert result.merge_allowed is False
     assert result.deploy_allowed is False
 

--- a/tests/skeleton_core/test_cli_capability_request_broker.py
+++ b/tests/skeleton_core/test_cli_capability_request_broker.py
@@ -41,7 +41,10 @@ def test_cli_capability_request_existing(capsys) -> None:
     )
 
     assert payload["status"] == "capability_already_exists"
-    assert payload["next_safe_step"] == "Update the project workflow to use the existing Skeleton capability."
+    assert (
+        payload["next_safe_step"]
+        == "Update the project workflow to use the existing Skeleton capability."
+    )
 
 
 def test_cli_capability_request_unsafe(capsys) -> None:

--- a/tests/skeleton_core/test_cli_capability_request_broker.py
+++ b/tests/skeleton_core/test_cli_capability_request_broker.py
@@ -1,0 +1,67 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["capability-request-broker", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_capability_request_runner_env_ready(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/capability_request_bauclock_runner_env_check.json",
+        capsys,
+    )
+
+    assert payload["status"] == "capability_request_ready"
+    assert payload["capability_name"] == "runner-env-check"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_capability_request_actions_ready(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/capability_request_bauclock_actions_runner_control.json",
+        capsys,
+    )
+
+    assert payload["status"] == "capability_request_ready"
+    assert payload["capability_name"] == "github-actions-runner-control"
+    assert "github-actions-runner-control" in payload["recommended_skeleton_issue_title"]
+
+
+def test_cli_capability_request_existing(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/capability_request_existing_capability.json",
+        capsys,
+    )
+
+    assert payload["status"] == "capability_already_exists"
+    assert payload["next_safe_step"] == "Update the project workflow to use the existing Skeleton capability."
+
+
+def test_cli_capability_request_unsafe(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/capability_request_unsafe_live_executor.json",
+        capsys,
+    )
+
+    assert payload["status"] == "blocked_unsafe_capability"
+    assert payload["risk_level"] == "RED"
+    assert payload["recommended_skeleton_issue_body"] == ""
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_capability_request_unknown(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/capability_request_unknown_needs_review.json",
+        capsys,
+    )
+
+    assert payload["status"] == "unknown_needs_review"
+    assert payload["risk_level"] == "UNKNOWN"

--- a/tools/skeleton_core/capability_request_broker.py
+++ b/tools/skeleton_core/capability_request_broker.py
@@ -227,7 +227,9 @@ def build_capability_request(packet: CapabilityRequestInput) -> CapabilityReques
         risk_level = "YELLOW"
 
     title = _issue_title(capability_name) if capability_name else ""
-    issue_body = "" if status == "blocked_unsafe_capability" else _issue_body(packet, capability_name)
+    issue_body = (
+        "" if status == "blocked_unsafe_capability" else _issue_body(packet, capability_name)
+    )
     return CapabilityRequestPacket(
         status=status,
         capability_name=capability_name,
@@ -238,9 +240,13 @@ def build_capability_request(packet: CapabilityRequestInput) -> CapabilityReques
         risk_level=risk_level,
         recommended_skeleton_issue_title=title,
         recommended_skeleton_issue_body=issue_body,
-        allowed_scope=[] if status == "blocked_unsafe_capability" else _allowed_scope(capability_name),
+        allowed_scope=(
+            [] if status == "blocked_unsafe_capability" else _allowed_scope(capability_name)
+        ),
         forbidden_scope=_forbidden_scope(),
-        acceptance_criteria=[] if status == "blocked_unsafe_capability" else _acceptance_criteria(capability_name),
+        acceptance_criteria=(
+            [] if status == "blocked_unsafe_capability" else _acceptance_criteria(capability_name)
+        ),
         links_or_references=_clean_items(packet.evidence),
         blockers=blockers,
         merge_allowed=False,

--- a/tools/skeleton_core/capability_request_broker.py
+++ b/tools/skeleton_core/capability_request_broker.py
@@ -1,0 +1,254 @@
+"""Local/offline broker for converting project blockers into Skeleton skill requests."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CapabilityRequestStatus = Literal[
+    "capability_request_ready",
+    "capability_already_exists",
+    "blocked_unsafe_capability",
+    "unknown_needs_review",
+]
+RiskLevel = Literal["YELLOW", "RED", "UNKNOWN"]
+
+UNSAFE_PATTERNS = {
+    "live_executor": r"live executor|autonomous executor|execute live",
+    "merge": r"\bmerge\b|auto-merge",
+    "deploy": r"\bdeploy\b|deployment|release",
+    "server": r"server ssh|\bssh\b|production server",
+    "production_db": r"production db|production database|prod db",
+    "secret": r"\.env|\bsecret\b|\bsecrets\b|\btoken\b|api key|apikey|credential|password",
+    "runtime_change": r"runtime change|change runtime|modify runtime",
+}
+
+
+class CapabilityRequestInput(BaseModel):
+    """Public-safe project capability request input."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    project: str = ""
+    repository: str = ""
+    source_issue: int | None = None
+    blocker_or_need: str = ""
+    manual_steps_repeated: list[str] = Field(default_factory=list)
+    desired_capability: str = ""
+    safety_constraints: list[str] = Field(default_factory=list)
+    evidence: list[str] = Field(default_factory=list)
+    existing_capabilities: list[str] = Field(default_factory=list)
+
+
+class CapabilityRequestPacket(BaseModel):
+    """Structured Skeleton skill request packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: CapabilityRequestStatus
+    capability_name: str = ""
+    source_project: str = ""
+    source_repository: str = ""
+    source_issue: int | None = None
+    need_summary: str = ""
+    risk_level: RiskLevel = "UNKNOWN"
+    recommended_skeleton_issue_title: str = ""
+    recommended_skeleton_issue_body: str = ""
+    allowed_scope: list[str] = Field(default_factory=list)
+    forbidden_scope: list[str] = Field(default_factory=list)
+    acceptance_criteria: list[str] = Field(default_factory=list)
+    links_or_references: list[str] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    next_safe_step: str
+
+
+def _clean(value: str) -> str:
+    return " ".join(value.strip().split())
+
+
+def _clean_items(items: list[str]) -> list[str]:
+    return [_clean(item) for item in items if _clean(item)]
+
+
+def _slug(value: str) -> str:
+    lowered = value.strip().casefold().replace("_", "-")
+    return re.sub(r"[^a-z0-9-]+", "-", lowered).strip("-")
+
+
+def _combined_text(packet: CapabilityRequestInput) -> str:
+    parts = [
+        packet.project,
+        packet.repository,
+        packet.blocker_or_need,
+        packet.desired_capability,
+        "\n".join(packet.manual_steps_repeated),
+        "\n".join(packet.safety_constraints),
+        "\n".join(packet.evidence),
+    ]
+    return "\n".join(parts)
+
+
+def _unsafe_blockers(packet: CapabilityRequestInput) -> list[str]:
+    text = _combined_text(packet)
+    blockers = []
+    for name, pattern in UNSAFE_PATTERNS.items():
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            blockers.append(f"Unsafe capability request detected: {name}")
+    return sorted(set(blockers))
+
+
+def _has_enough_evidence(packet: CapabilityRequestInput) -> bool:
+    return bool(
+        _clean(packet.project)
+        and _clean(packet.blocker_or_need)
+        and _clean(packet.desired_capability)
+        and (_clean_items(packet.manual_steps_repeated) or _clean_items(packet.evidence))
+    )
+
+
+def _existing_capability(packet: CapabilityRequestInput) -> bool:
+    desired = _slug(packet.desired_capability)
+    existing = {_slug(item) for item in packet.existing_capabilities}
+    return bool(desired and desired in existing)
+
+
+def _issue_title(capability_name: str) -> str:
+    return f"[agent-task-yellow] Add Skeleton {capability_name} command"
+
+
+def _allowed_scope(capability_name: str) -> list[str]:
+    return [
+        f"Add local/offline {capability_name} packet builder.",
+        "Read public-safe JSON input only.",
+        "Emit reviewable Skeleton issue title/body and status packet.",
+        "Add tests and fixtures.",
+    ]
+
+
+def _forbidden_scope() -> list[str]:
+    return [
+        "No GitHub issue creation from CLI in v1.",
+        "No live GitHub API calls from CLI in v1.",
+        "No runner execution.",
+        "No shell execution.",
+        "No merge/deploy authority.",
+        "No server SSH or production DB access.",
+        "No .env reads or writes.",
+        "No secrets or private data in outputs.",
+        "No runtime code changes.",
+    ]
+
+
+def _acceptance_criteria(capability_name: str) -> list[str]:
+    return [
+        f"{capability_name} emits deterministic ready/blocked/unknown statuses.",
+        "Unsafe live/merge/deploy/server/secrets requests are blocked.",
+        "Unknown or under-evidenced requests require review.",
+        "Output always has merge_allowed=false and deploy_allowed=false.",
+        "CLI is local/offline/read-only.",
+        "Tests and CI pass.",
+    ]
+
+
+def _issue_body(packet: CapabilityRequestInput, capability_name: str) -> str:
+    manual_steps = _clean_items(packet.manual_steps_repeated)
+    evidence = _clean_items(packet.evidence)
+    constraints = _clean_items(packet.safety_constraints)
+    lines = [
+        f"# YELLOW — Add Skeleton {capability_name} command",
+        "",
+        "## Source project need",
+        "",
+        f"Project: {packet.project or 'unknown'}",
+        f"Repository: {packet.repository or 'unknown'}",
+        f"Source issue: {packet.source_issue if packet.source_issue is not None else 'unknown'}",
+        "",
+        "## Need summary",
+        "",
+        _clean(packet.blocker_or_need) or "Unknown need.",
+        "",
+        "## Repeated manual steps",
+        "",
+    ]
+    lines.extend([f"- {item}" for item in manual_steps] or ["- unknown"])
+    lines.extend(["", "## Evidence", ""])
+    lines.extend([f"- {item}" for item in evidence] or ["- needs review"])
+    lines.extend(["", "## Safety constraints", ""])
+    lines.extend([f"- {item}" for item in constraints] or ["- local/offline/public-safe v1"])
+    lines.extend(
+        [
+            "",
+            "## Required safety",
+            "",
+            "```text",
+            "Local/offline/public-safe JSON only.",
+            "No GitHub writes from CLI in v1.",
+            "No live API calls.",
+            "No runner execution.",
+            "No .env reads.",
+            "No secrets.",
+            "No merge/deploy authority.",
+            "No runtime changes.",
+            "```",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _next_safe_step(status: CapabilityRequestStatus) -> str:
+    if status == "capability_request_ready":
+        return "Review and post this as a Skeleton issue if still needed."
+    if status == "capability_already_exists":
+        return "Update the project workflow to use the existing Skeleton capability."
+    if status == "blocked_unsafe_capability":
+        return "Stop and redesign the request into a safe local/offline capability, if possible."
+    return "Add evidence or narrow the capability request before creating a Skeleton issue."
+
+
+def build_capability_request(packet: CapabilityRequestInput) -> CapabilityRequestPacket:
+    """Build a deterministic capability request packet from a project need."""
+    capability_name = _slug(packet.desired_capability)
+    blockers = _unsafe_blockers(packet)
+    if blockers:
+        status: CapabilityRequestStatus = "blocked_unsafe_capability"
+        risk_level: RiskLevel = "RED"
+    elif _existing_capability(packet):
+        status = "capability_already_exists"
+        risk_level = "YELLOW"
+    elif not _has_enough_evidence(packet):
+        status = "unknown_needs_review"
+        risk_level = "UNKNOWN"
+    else:
+        status = "capability_request_ready"
+        risk_level = "YELLOW"
+
+    title = _issue_title(capability_name) if capability_name else ""
+    issue_body = "" if status == "blocked_unsafe_capability" else _issue_body(packet, capability_name)
+    return CapabilityRequestPacket(
+        status=status,
+        capability_name=capability_name,
+        source_project=_clean(packet.project),
+        source_repository=_clean(packet.repository),
+        source_issue=packet.source_issue,
+        need_summary=_clean(packet.blocker_or_need),
+        risk_level=risk_level,
+        recommended_skeleton_issue_title=title,
+        recommended_skeleton_issue_body=issue_body,
+        allowed_scope=[] if status == "blocked_unsafe_capability" else _allowed_scope(capability_name),
+        forbidden_scope=_forbidden_scope(),
+        acceptance_criteria=[] if status == "blocked_unsafe_capability" else _acceptance_criteria(capability_name),
+        links_or_references=_clean_items(packet.evidence),
+        blockers=blockers,
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_safe_step=_next_safe_step(status),
+    )
+
+
+def build_capability_request_from_json(raw_json: str) -> CapabilityRequestPacket:
+    """Validate local JSON text and build a capability request packet."""
+    return build_capability_request(CapabilityRequestInput.model_validate_json(raw_json))

--- a/tools/skeleton_core/capability_request_broker.py
+++ b/tools/skeleton_core/capability_request_broker.py
@@ -79,21 +79,21 @@ def _slug(value: str) -> str:
     return re.sub(r"[^a-z0-9-]+", "-", lowered).strip("-")
 
 
-def _combined_text(packet: CapabilityRequestInput) -> str:
+def _unsafe_text(packet: CapabilityRequestInput) -> str:
+    """Text that represents requested capability, excluding safety constraints."""
     parts = [
         packet.project,
         packet.repository,
         packet.blocker_or_need,
         packet.desired_capability,
         "\n".join(packet.manual_steps_repeated),
-        "\n".join(packet.safety_constraints),
         "\n".join(packet.evidence),
     ]
     return "\n".join(parts)
 
 
 def _unsafe_blockers(packet: CapabilityRequestInput) -> list[str]:
-    text = _combined_text(packet)
+    text = _unsafe_text(packet)
     blockers = []
     for name, pattern in UNSAFE_PATTERNS.items():
         if re.search(pattern, text, flags=re.IGNORECASE):

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -11,6 +11,10 @@ from typing import Any
 from pydantic import ValidationError
 
 from tools.skeleton_core.branch_recovery import BranchRecoveryInput, build_branch_recovery
+from tools.skeleton_core.capability_request_broker import (
+    CapabilityRequestInput,
+    build_capability_request,
+)
 from tools.skeleton_core.checkpoint import render_checkpoint
 from tools.skeleton_core.format_preflight import (
     FormatPreflightInput,
@@ -52,6 +56,7 @@ from tools.skeleton_core.work_packet import render_work_packet
 
 SUBCOMMANDS = {
     "branch-recovery",
+    "capability-request-broker",
     "checkpoint",
     "classify-queue",
     "decide",
@@ -95,6 +100,11 @@ def build_decision_payload(packet: TaskPacket) -> dict[str, Any]:
 def load_branch_recovery_input(input_path: Path) -> BranchRecoveryInput:
     """Load public-safe branch recovery input from JSON."""
     return BranchRecoveryInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_capability_request_input(input_path: Path) -> CapabilityRequestInput:
+    """Load public-safe capability request input from JSON."""
+    return CapabilityRequestInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_format_preflight_input(input_path: Path) -> FormatPreflightInput:
@@ -284,6 +294,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Build a recovery packet for interrupted Skeleton branch work",
     )
     _add_input_arg(branch_recovery_parser, "Path to public-safe branch recovery JSON")
+
+    capability_parser = subparsers.add_parser(
+        "capability-request-broker",
+        help="Build a Skeleton skill request packet from a project need JSON",
+    )
+    _add_input_arg(capability_parser, "Path to public-safe capability request JSON")
 
     checkpoint_parser = subparsers.add_parser(
         "checkpoint",
@@ -517,6 +533,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def _run_branch_recovery(args: argparse.Namespace) -> int:
     try:
         result = build_branch_recovery(load_branch_recovery_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
+def _run_capability_request_broker(args: argparse.Namespace) -> int:
+    try:
+        result = build_capability_request(load_capability_request_input(args.input))
     except ValidationError as exc:
         print(exc.json(), flush=True)
         return 2
@@ -810,6 +836,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.command == "branch-recovery":
         return _run_branch_recovery(args)
+    if args.command == "capability-request-broker":
+        return _run_capability_request_broker(args)
     if args.command == "checkpoint":
         return _run_checkpoint(args)
     if args.command == "classify-queue":


### PR DESCRIPTION
## Summary

Implements #90 as a local/offline capability request broker:

```text
python -m tools.skeleton_core.cli capability-request-broker --input tests/fixtures/capability_request_bauclock_runner_env_check.json
python -m tools.skeleton_core.cli capability-request-broker --input tests/fixtures/capability_request_bauclock_actions_runner_control.json
python -m tools.skeleton_core.cli capability-request-broker --input tests/fixtures/capability_request_unsafe_live_executor.json
```

It converts a public-safe project blocker/manual repetition into a reviewable Skeleton skill request packet/body.

## Statuses

```text
capability_request_ready
capability_already_exists
blocked_unsafe_capability
unknown_needs_review
```

## Safety

```text
Local/offline/public-safe JSON only.
No GitHub issue creation from CLI in v1.
No live GitHub API calls from CLI in v1.
No runner execution.
No shell execution.
No .env reads.
No secrets.
No merge/deploy authority.
No runtime changes.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Closes #90.