### PR TITLE
Add Skeleton workflow-gate command v2

### DIFF
--- a/tests/fixtures/workflow_gate_actions_report_unsafe.json
+++ b/tests/fixtures/workflow_gate_actions_report_unsafe.json
@@ -1,0 +1,9 @@
+{
+  "action": "actions_report",
+  "repository": "alanua/jeeves",
+  "branch": "main",
+  "preflights": {
+    "github_actions_runner_control": "unsafe_or_policy_violation"
+  },
+  "requested_next_action": "use_actions_report"
+}

--- a/tests/fixtures/workflow_gate_pr_ready_missing_review_gate.json
+++ b/tests/fixtures/workflow_gate_pr_ready_missing_review_gate.json
@@ -1,0 +1,10 @@
+{
+  "action": "ready_for_review",
+  "repository": "alanua/jeeves",
+  "branch": "skeleton/workflow-gate-v2",
+  "changed_files": ["tools/skeleton_core/workflow_gate.py"],
+  "preflights": {
+    "ci_status": "success"
+  },
+  "requested_next_action": "ready_for_review"
+}

--- a/tests/fixtures/workflow_gate_python_update_missing_format.json
+++ b/tests/fixtures/workflow_gate_python_update_missing_format.json
@@ -1,0 +1,13 @@
+{
+  "action": "github_update_file",
+  "repository": "alanua/jeeves",
+  "branch": "skeleton/workflow-gate-v2",
+  "changed_files": ["tools/skeleton_core/workflow_gate.py"],
+  "python_files_changed": true,
+  "preflights": {
+    "local_black_applied": "missing",
+    "format_preflight": "unknown",
+    "head_sha_verified": "ok"
+  },
+  "requested_next_action": "update_file"
+}

--- a/tests/fixtures/workflow_gate_python_update_ready.json
+++ b/tests/fixtures/workflow_gate_python_update_ready.json
@@ -1,0 +1,13 @@
+{
+  "action": "github_update_file",
+  "repository": "alanua/jeeves",
+  "branch": "skeleton/workflow-gate-v2",
+  "changed_files": ["tools/skeleton_core/workflow_gate.py"],
+  "python_files_changed": true,
+  "preflights": {
+    "local_black_applied": "ok",
+    "format_preflight": "format_ready",
+    "head_sha_verified": "ok"
+  },
+  "requested_next_action": "update_file"
+}

--- a/tests/fixtures/workflow_gate_queue_advance_missing_report.json
+++ b/tests/fixtures/workflow_gate_queue_advance_missing_report.json
@@ -1,0 +1,10 @@
+{
+  "action": "queue_advance",
+  "repository": "alanua/jeeves",
+  "branch": "main",
+  "preflights": {
+    "queue_state": "has_next_runnable_issue"
+  },
+  "queue_next_runnable_issue": 90,
+  "requested_next_action": "start_next_issue"
+}

--- a/tests/fixtures/workflow_gate_runner_missing_env_check.json
+++ b/tests/fixtures/workflow_gate_runner_missing_env_check.json
@@ -1,0 +1,9 @@
+{
+  "action": "runner_dispatch",
+  "repository": "alanua/jeeves",
+  "branch": "main",
+  "preflights": {
+    "runner_command_pack": "ready"
+  },
+  "requested_next_action": "runner_dispatch"
+}

--- a/tests/skeleton_core/test_cli_workflow_gate.py
+++ b/tests/skeleton_core/test_cli_workflow_gate.py
@@ -1,0 +1,74 @@
+import json
+
+from tools.skeleton_core.cli import main
+
+
+def _run_fixture(path: str, capsys) -> dict:
+    exit_code = main(["workflow-gate", "--input", path])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    return payload
+
+
+def test_cli_workflow_gate_python_update_ready(capsys) -> None:
+    payload = _run_fixture("tests/fixtures/workflow_gate_python_update_ready.json", capsys)
+
+    assert payload["status"] == "action_ready"
+    assert payload["allowed_to_continue"] is True
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_cli_workflow_gate_python_update_missing_format(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/workflow_gate_python_update_missing_format.json",
+        capsys,
+    )
+
+    assert payload["status"] == "blocked_missing_required_skill"
+    assert payload["allowed_to_continue"] is False
+    assert "local_black_applied" in payload["missing_or_failed_skills"]
+    assert "format_preflight" in payload["missing_or_failed_skills"]
+
+
+def test_cli_workflow_gate_pr_ready_missing_review_gate(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/workflow_gate_pr_ready_missing_review_gate.json",
+        capsys,
+    )
+
+    assert payload["status"] == "blocked_missing_required_skill"
+    assert payload["missing_or_failed_skills"] == ["pr_review_gate"]
+
+
+def test_cli_workflow_gate_runner_missing_env_check(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/workflow_gate_runner_missing_env_check.json",
+        capsys,
+    )
+
+    assert payload["status"] == "blocked_missing_required_skill"
+    assert "runner_env_check" in payload["missing_or_failed_skills"]
+
+
+def test_cli_workflow_gate_queue_advance_missing_report(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/workflow_gate_queue_advance_missing_report.json",
+        capsys,
+    )
+
+    assert payload["status"] == "blocked_missing_required_skill"
+    assert "runner_report_ingest" in payload["missing_or_failed_skills"]
+
+
+def test_cli_workflow_gate_actions_report_unsafe(capsys) -> None:
+    payload = _run_fixture(
+        "tests/fixtures/workflow_gate_actions_report_unsafe.json",
+        capsys,
+    )
+
+    assert payload["status"] == "blocked_failed_required_skill"
+    assert payload["missing_or_failed_skills"] == [
+        "github_actions_runner_control=unsafe_or_policy_violation"
+    ]

--- a/tests/skeleton_core/test_workflow_gate.py
+++ b/tests/skeleton_core/test_workflow_gate.py
@@ -1,0 +1,107 @@
+from tools.skeleton_core.workflow_gate import WorkflowGateInput, build_workflow_gate
+
+
+def test_python_update_ready() -> None:
+    result = build_workflow_gate(
+        WorkflowGateInput(
+            action="github_update_file",
+            python_files_changed=True,
+            preflights={
+                "local_black_applied": "ok",
+                "format_preflight": "format_ready",
+                "head_sha_verified": "ok",
+            },
+            requested_next_action="update_file",
+        )
+    )
+
+    assert result.status == "action_ready"
+    assert result.allowed_to_continue is True
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_python_update_missing_format_blocks() -> None:
+    result = build_workflow_gate(
+        WorkflowGateInput(
+            action="github_update_file",
+            python_files_changed=True,
+            preflights={
+                "local_black_applied": "missing",
+                "format_preflight": "unknown",
+                "head_sha_verified": "ok",
+            },
+            requested_next_action="update_file",
+        )
+    )
+
+    assert result.status == "blocked_missing_required_skill"
+    assert result.allowed_to_continue is False
+    assert "local_black_applied" in result.missing_or_failed_skills
+    assert "format_preflight" in result.missing_or_failed_skills
+
+
+def test_pr_ready_missing_review_gate_blocks() -> None:
+    result = build_workflow_gate(
+        WorkflowGateInput(
+            action="ready_for_review",
+            preflights={"ci_status": "success"},
+            requested_next_action="ready_for_review",
+        )
+    )
+
+    assert result.status == "blocked_missing_required_skill"
+    assert result.allowed_to_continue is False
+    assert result.required_skills == ["ci_status", "pr_review_gate"]
+    assert result.missing_or_failed_skills == ["pr_review_gate"]
+
+
+def test_runner_dispatch_missing_env_check_blocks() -> None:
+    result = build_workflow_gate(
+        WorkflowGateInput(
+            action="runner_dispatch",
+            preflights={"runner_command_pack": "ready"},
+            requested_next_action="runner_dispatch",
+        )
+    )
+
+    assert result.status == "blocked_missing_required_skill"
+    assert "runner_env_check" in result.missing_or_failed_skills
+
+
+def test_queue_advance_missing_previous_report_blocks() -> None:
+    result = build_workflow_gate(
+        WorkflowGateInput(
+            action="queue_advance",
+            queue_next_runnable_issue=90,
+            preflights={"queue_state": "has_next_runnable_issue"},
+            requested_next_action="start_next_issue",
+        )
+    )
+
+    assert result.status == "blocked_missing_required_skill"
+    assert result.allowed_to_continue is False
+    assert "runner_report_ingest" in result.missing_or_failed_skills
+
+
+def test_actions_report_unsafe_blocks() -> None:
+    result = build_workflow_gate(
+        WorkflowGateInput(
+            action="actions_report",
+            preflights={"github_actions_runner_control": "unsafe_or_policy_violation"},
+            requested_next_action="use_actions_report",
+        )
+    )
+
+    assert result.status == "blocked_failed_required_skill"
+    assert result.allowed_to_continue is False
+    assert result.missing_or_failed_skills == [
+        "github_actions_runner_control=unsafe_or_policy_violation"
+    ]
+
+
+def test_unknown_without_matching_gate_needs_review() -> None:
+    result = build_workflow_gate(WorkflowGateInput(action="unknown"))
+
+    assert result.status == "unknown_needs_review"
+    assert result.allowed_to_continue is False

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -53,6 +53,7 @@ from tools.skeleton_core.task_lifecycle import build_task_lifecycle_packet
 from tools.skeleton_core.templates import render_runner_issue
 from tools.skeleton_core.trace import TracePacket
 from tools.skeleton_core.work_packet import render_work_packet
+from tools.skeleton_core.workflow_gate import WorkflowGateInput, build_workflow_gate
 
 SUBCOMMANDS = {
     "branch-recovery",
@@ -79,6 +80,7 @@ SUBCOMMANDS = {
     "task-lifecycle",
     "trace-packet",
     "validate-state",
+    "workflow-gate",
     "work-packet",
 }
 MAX_AUTO_TITLE_LENGTH = 80
@@ -125,6 +127,11 @@ def load_project_skeleton_profile_input(input_path: Path) -> ProjectSkeletonProf
 def load_runner_env_check_input(input_path: Path) -> RunnerEnvCheckInput:
     """Load public-safe runner environment check input from JSON."""
     return RunnerEnvCheckInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_workflow_gate_input(input_path: Path) -> WorkflowGateInput:
+    """Load public-safe workflow gate input from JSON."""
+    return WorkflowGateInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_queue_items(input_path: Path) -> list[dict[str, Any]]:
@@ -506,6 +513,12 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Repository root to validate",
     )
 
+    workflow_gate_parser = subparsers.add_parser(
+        "workflow-gate",
+        help="Enforce ready Skeleton skills before workflow actions",
+    )
+    _add_input_arg(workflow_gate_parser, "Path to public-safe workflow gate JSON")
+
     work_packet_parser = subparsers.add_parser(
         "work-packet",
         help="Render a public-safe work packet from free-form task text",
@@ -760,6 +773,16 @@ def _run_task_lifecycle(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_workflow_gate(args: argparse.Namespace) -> int:
+    try:
+        result = build_workflow_gate(load_workflow_gate_input(args.input))
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _trace_packet_from_args(args: argparse.Namespace) -> TracePacket:
     return TracePacket(
         task_id=args.task_id,
@@ -880,6 +903,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_trace_packet(args)
     if args.command == "validate-state":
         return _run_validate_state(args)
+    if args.command == "workflow-gate":
+        return _run_workflow_gate(args)
     if args.command == "work-packet":
         return _run_work_packet(args)
     return _run_decide(args)

--- a/tools/skeleton_core/workflow_gate.py
+++ b/tools/skeleton_core/workflow_gate.py
@@ -1,0 +1,269 @@
+"""Local/offline workflow gate that enforces ready Skeleton skills."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+WorkflowGateStatus = Literal[
+    "action_ready",
+    "blocked_missing_required_skill",
+    "blocked_failed_required_skill",
+    "blocked_unsafe_or_policy_violation",
+    "unknown_needs_review",
+]
+
+UNSAFE_PATTERNS = {
+    "merge": r"\bmerge\b|auto-merge",
+    "deploy": r"\bdeploy\b|deployment|release",
+    "server": r"server ssh|\bssh\b|production server",
+    "production_db": r"production db|production database|prod db",
+    "secret": r"\.env|\bsecret\b|\bsecrets\b|\btoken\b|api key|apikey|credential|password",
+}
+
+PYTHON_UPDATE_REQUIREMENTS = {
+    "local_black_applied": {"ok"},
+    "format_preflight": {"format_ready"},
+    "head_sha_verified": {"ok"},
+}
+PR_REVIEW_REQUIREMENTS = {
+    "pr_review_gate": {"ready_for_chatgpt_review"},
+    "ci_status": {"success"},
+}
+RUNNER_REQUIREMENTS = {
+    "runner_env_check": {"ready_for_read_only_validation"},
+    "runner_command_pack": {"ready"},
+}
+QUEUE_REQUIREMENTS = {
+    "queue_state": {"has_next_runnable_issue", "next_runnable_issue"},
+    "runner_report_ingest": {"green_report", "approved_equivalent"},
+}
+ACTIONS_REQUIREMENTS = {
+    "github_actions_runner_control": {
+        "workflow_success_report",
+        "workflow_failed_report",
+        "workflow_cancelled_report",
+    },
+}
+
+
+class WorkflowGateInput(BaseModel):
+    """Public-safe workflow action packet."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    action: str = ""
+    repository: str = ""
+    branch: str = ""
+    changed_files: list[str] = Field(default_factory=list)
+    python_files_changed: bool = False
+    preflights: dict[str, str] = Field(default_factory=dict)
+    requested_next_action: str = ""
+    queue_next_runnable_issue: int | None = None
+    human_override: bool = False
+
+
+class WorkflowGatePacket(BaseModel):
+    """Deterministic workflow gate decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: WorkflowGateStatus
+    requested_next_action: str
+    required_skills: list[str] = Field(default_factory=list)
+    missing_or_failed_skills: list[str] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    allowed_to_continue: bool = False
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    next_safe_step: str
+
+
+def _normalized(value: str | None) -> str:
+    return (value or "").strip().casefold().replace("-", "_")
+
+
+def _combined_text(packet: WorkflowGateInput) -> str:
+    parts = [
+        packet.action,
+        packet.requested_next_action,
+        packet.repository,
+        packet.branch,
+        "\n".join(packet.changed_files),
+        "\n".join(f"{key}={value}" for key, value in packet.preflights.items()),
+    ]
+    return "\n".join(parts)
+
+
+def _unsafe_blockers(packet: WorkflowGateInput) -> list[str]:
+    text = _combined_text(packet)
+    blockers = []
+    for name, pattern in UNSAFE_PATTERNS.items():
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            blockers.append(f"Unsafe workflow action detected: {name}")
+    if _normalized(packet.requested_next_action) in {"merge", "deploy", "release"}:
+        blockers.append("Requested next action is not allowed for Skeleton workflow-gate")
+    return sorted(set(blockers))
+
+
+def _is_python_update(packet: WorkflowGateInput) -> bool:
+    action = _normalized(packet.action)
+    requested = _normalized(packet.requested_next_action)
+    return (
+        packet.python_files_changed
+        or action in {"github_update_file", "update_file"}
+        or requested == "update_file"
+    )
+
+
+def _is_pr_review(packet: WorkflowGateInput) -> bool:
+    action = _normalized(packet.action)
+    requested = _normalized(packet.requested_next_action)
+    return action in {"pr_ready", "ready_for_review", "pr_review"} or requested in {
+        "ready_for_review",
+        "mark_ready_for_review",
+    }
+
+
+def _is_runner_dispatch(packet: WorkflowGateInput) -> bool:
+    action = _normalized(packet.action)
+    requested = _normalized(packet.requested_next_action)
+    return action in {"runner_dispatch", "runner_task"} or requested == "runner_dispatch"
+
+
+def _is_queue_advance(packet: WorkflowGateInput) -> bool:
+    action = _normalized(packet.action)
+    requested = _normalized(packet.requested_next_action)
+    return action in {
+        "queue_advance",
+        "start_next_issue",
+        "open_next_issue",
+    } or requested in {
+        "queue_advance",
+        "start_next_issue",
+        "open_next_issue",
+    }
+
+
+def _is_actions_report(packet: WorkflowGateInput) -> bool:
+    action = _normalized(packet.action)
+    requested = _normalized(packet.requested_next_action)
+    return action in {"actions_report", "use_actions_report"} or requested in {
+        "actions_report",
+        "use_actions_report",
+    }
+
+
+def _requirements(packet: WorkflowGateInput) -> dict[str, set[str]]:
+    requirements: dict[str, set[str]] = {}
+    if _is_python_update(packet):
+        requirements.update(PYTHON_UPDATE_REQUIREMENTS)
+    if _is_pr_review(packet):
+        requirements.update(PR_REVIEW_REQUIREMENTS)
+    if _is_runner_dispatch(packet):
+        requirements.update(RUNNER_REQUIREMENTS)
+    if _is_queue_advance(packet):
+        requirements.update(QUEUE_REQUIREMENTS)
+    if _is_actions_report(packet):
+        requirements.update(ACTIONS_REQUIREMENTS)
+    return requirements
+
+
+def _missing_or_failed(
+    packet: WorkflowGateInput,
+    requirements: dict[str, set[str]],
+) -> tuple[list[str], list[str]]:
+    missing: list[str] = []
+    failed: list[str] = []
+    preflights = {_normalized(key): _normalized(value) for key, value in packet.preflights.items()}
+    for skill, allowed_values in requirements.items():
+        value = preflights.get(_normalized(skill))
+        normalized_allowed = {_normalized(item) for item in allowed_values}
+        if value in {None, "", "missing", "not_checked", "unknown"}:
+            missing.append(skill)
+        elif value not in normalized_allowed:
+            failed.append(f"{skill}={value}")
+    if "queue_state" in requirements and packet.queue_next_runnable_issue is not None:
+        missing = [item for item in missing if item != "queue_state"]
+        failed = [item for item in failed if not item.startswith("queue_state=")]
+    return sorted(missing), sorted(failed)
+
+
+def _next_step(status: WorkflowGateStatus, missing_or_failed: list[str]) -> str:
+    if status == "action_ready":
+        return "Continue with the requested action, then verify the resulting state."
+    if status == "blocked_unsafe_or_policy_violation":
+        return "Stop and review unsafe workflow scope before continuing."
+    if (
+        any(item.startswith("local_black_applied") for item in missing_or_failed)
+        or "local_black_applied" in missing_or_failed
+    ):
+        return "Run real local Black on outgoing Python content before update_file."
+    if (
+        any(item.startswith("format_preflight") for item in missing_or_failed)
+        or "format_preflight" in missing_or_failed
+    ):
+        return "Run format-preflight and require format_ready before continuing."
+    if (
+        any(item.startswith("pr_review_gate") for item in missing_or_failed)
+        or "pr_review_gate" in missing_or_failed
+    ):
+        return "Run pr-review-gate and require ready_for_chatgpt_review."
+    if (
+        any(item.startswith("runner_env_check") for item in missing_or_failed)
+        or "runner_env_check" in missing_or_failed
+    ):
+        return "Run runner-env-check before dispatching runner work."
+    if (
+        any(item.startswith("runner_report_ingest") for item in missing_or_failed)
+        or "runner_report_ingest" in missing_or_failed
+    ):
+        return "Ingest the previous runner report before advancing the queue."
+    if (
+        any(item.startswith("github_actions_runner_control") for item in missing_or_failed)
+        or "github_actions_runner_control" in missing_or_failed
+    ):
+        return "Build a safe GitHub Actions runner-control report before using Actions as evidence."
+    if status == "unknown_needs_review":
+        return "Manual review required; no matching workflow gate was selected."
+    return "Satisfy the missing or failed required Skeleton skill before continuing."
+
+
+def build_workflow_gate(packet: WorkflowGateInput) -> WorkflowGatePacket:
+    """Enforce ready Skeleton skills before the requested workflow action."""
+    unsafe_blockers = _unsafe_blockers(packet)
+    requirements = _requirements(packet)
+    required_skills = sorted(requirements)
+    missing, failed = _missing_or_failed(packet, requirements)
+    missing_or_failed = [*missing, *failed]
+
+    if unsafe_blockers:
+        status: WorkflowGateStatus = "blocked_unsafe_or_policy_violation"
+    elif failed:
+        status = "blocked_failed_required_skill"
+    elif missing:
+        status = "blocked_missing_required_skill"
+    elif requirements or packet.human_override:
+        status = "action_ready"
+    else:
+        status = "unknown_needs_review"
+
+    allowed = status == "action_ready"
+    return WorkflowGatePacket(
+        status=status,
+        requested_next_action=packet.requested_next_action or packet.action or "unknown",
+        required_skills=required_skills,
+        missing_or_failed_skills=missing_or_failed,
+        blockers=unsafe_blockers,
+        allowed_to_continue=allowed,
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_safe_step=_next_step(status, missing_or_failed),
+    )
+
+
+def build_workflow_gate_from_json(raw_json: str) -> WorkflowGatePacket:
+    """Validate local JSON text and build a workflow gate packet."""
+    return build_workflow_gate(WorkflowGateInput.model_validate_json(raw_json))


### PR DESCRIPTION
## Summary

Reimplements #92 on a clean branch after the previous PR was invalidated during branch reset.

Adds a local/offline workflow enforcement gate:

```text
python -m tools.skeleton_core.cli workflow-gate --input tests/fixtures/workflow_gate_python_update_ready.json
python -m tools.skeleton_core.cli workflow-gate --input tests/fixtures/workflow_gate_python_update_missing_format.json
python -m tools.skeleton_core.cli workflow-gate --input tests/fixtures/workflow_gate_pr_ready_missing_review_gate.json
python -m tools.skeleton_core.cli workflow-gate --input tests/fixtures/workflow_gate_runner_missing_env_check.json
```

## Gates covered

```text
Python update gate: local_black_applied + format_preflight + head_sha_verified
PR review gate: pr_review_gate + ci_status
Runner dispatch gate: runner_env_check + runner_command_pack
Queue advance gate: queue_state + runner_report_ingest
Actions report gate: github_actions_runner_control
```

## Safety

```text
Local/offline/public-safe JSON only.
No GitHub writes from CLI.
No live API calls.
No runner execution.
No .env reads.
No secrets.
No merge/deploy authority.
No runtime changes.
```

## Validation expected from CI

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
```

Closes #92.