### PR TITLE
Add mock-first Gemini auditor adapter

### DIFF
--- a/tests/fixtures/gemini_auditor_input_live_missing_key.json
+++ b/tests/fixtures/gemini_auditor_input_live_missing_key.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "gemini_adapter.input.v1",
+  "packet_id": "gemini-test-live-missing-key-001",
+  "objective": "Verify live mode blocks when no environment key is available.",
+  "mode": "live",
+  "privacy_level": "PUBLIC_SAFE",
+  "confirmed_canon": "Live mode requires GEMINI_API_KEY or GOOGLE_API_KEY in runner environment.",
+  "evidence": "Public-safe synthetic evidence only.",
+  "draft_artifact": "Synthetic live-mode request.",
+  "exact_questions": [
+    "Should this block without a key?"
+  ],
+  "forbidden_actions": [
+    "do not execute commands",
+    "do not update canon"
+  ]
+}

--- a/tests/fixtures/gemini_auditor_input_public_safe.json
+++ b/tests/fixtures/gemini_auditor_input_public_safe.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "gemini_adapter.input.v1",
+  "packet_id": "gemini-test-public-safe-001",
+  "objective": "Review a public-safe Skeleton bridge packet.",
+  "mode": "mock",
+  "privacy_level": "PUBLIC_SAFE",
+  "confirmed_canon": "Gemini is a stateless auditor and cannot execute commands or update canon.",
+  "evidence": "Public-safe synthetic evidence only.",
+  "draft_artifact": "Synthetic draft artifact for adapter validation.",
+  "exact_questions": [
+    "Does the packet preserve the no-commands rule?",
+    "Does the packet preserve canon_claim=false?"
+  ],
+  "forbidden_actions": [
+    "do not execute commands",
+    "do not update canon",
+    "do not merge or deploy"
+  ]
+}

--- a/tests/fixtures/gemini_auditor_input_secret_blocked.json
+++ b/tests/fixtures/gemini_auditor_input_secret_blocked.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "gemini_adapter.input.v1",
+  "packet_id": "gemini-test-secret-blocked-001",
+  "objective": "Verify secret scanner blocks leaked key-like content.",
+  "mode": "mock",
+  "privacy_level": "PUBLIC_SAFE",
+  "confirmed_canon": "No secrets may pass through the Gemini auditor adapter.",
+  "evidence": "Synthetic secret leak: api_key=SHOULD_NOT_PASS",
+  "draft_artifact": "Synthetic draft artifact.",
+  "exact_questions": [
+    "Should this be blocked by scanner?"
+  ],
+  "forbidden_actions": [
+    "do not execute commands"
+  ]
+}

--- a/tests/skeleton_core/test_gemini_auditor_adapter.py
+++ b/tests/skeleton_core/test_gemini_auditor_adapter.py
@@ -1,5 +1,3 @@
-import os
-
 from tools.skeleton_core.gemini_auditor_adapter import (
     GeminiAuditorInput,
     GeminiAuditorOutput,

--- a/tests/skeleton_core/test_gemini_auditor_adapter.py
+++ b/tests/skeleton_core/test_gemini_auditor_adapter.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from tools.skeleton_core.gemini_auditor_adapter import (
     GeminiAuditorInput,
     GeminiAuditorOutput,
@@ -5,6 +7,10 @@ from tools.skeleton_core.gemini_auditor_adapter import (
     run_adapter_from_json,
     validate_output,
 )
+
+
+def _read_fixture(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
 
 
 def test_mock_public_safe_accepts() -> None:
@@ -123,7 +129,7 @@ def test_output_validation_blocks_forbidden_fields() -> None:
 
 def test_fixture_public_safe_accepts() -> None:
     result = run_adapter_from_json(
-        open("tests/fixtures/gemini_auditor_input_public_safe.json", encoding="utf-8").read()
+        _read_fixture("tests/fixtures/gemini_auditor_input_public_safe.json")
     )
 
     assert result.status == "mock_accept"
@@ -133,7 +139,7 @@ def test_fixture_live_missing_key_blocks(monkeypatch) -> None:
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     result = run_adapter_from_json(
-        open("tests/fixtures/gemini_auditor_input_live_missing_key.json", encoding="utf-8").read()
+        _read_fixture("tests/fixtures/gemini_auditor_input_live_missing_key.json")
     )
 
     assert result.status == "blocked_live_mode_missing_key"
@@ -141,7 +147,7 @@ def test_fixture_live_missing_key_blocks(monkeypatch) -> None:
 
 def test_fixture_secret_blocks() -> None:
     result = run_adapter_from_json(
-        open("tests/fixtures/gemini_auditor_input_secret_blocked.json", encoding="utf-8").read()
+        _read_fixture("tests/fixtures/gemini_auditor_input_secret_blocked.json")
     )
 
     assert result.status == "blocked_secret_or_pii"

--- a/tests/skeleton_core/test_gemini_auditor_adapter.py
+++ b/tests/skeleton_core/test_gemini_auditor_adapter.py
@@ -13,12 +13,12 @@ def _read_fixture(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
 
 
-def test_mock_public_safe_accepts() -> None:
-    packet = GeminiAuditorInput(
+def _packet(mode: str = "mock") -> GeminiAuditorInput:
+    return GeminiAuditorInput(
         schema_version="gemini_adapter.input.v1",
-        packet_id="test-public-safe",
+        packet_id=f"test-{mode}",
         objective="Review synthetic packet.",
-        mode="mock",
+        mode=mode,
         privacy_level="PUBLIC_SAFE",
         confirmed_canon="Gemini cannot execute commands or update canon.",
         evidence="Synthetic public-safe evidence.",
@@ -27,7 +27,9 @@ def test_mock_public_safe_accepts() -> None:
         forbidden_actions=["do not execute commands"],
     )
 
-    result = run_adapter(packet)
+
+def test_mock_public_safe_accepts() -> None:
+    result = run_adapter(_packet())
 
     assert result.status == "mock_accept"
     assert result.output is not None
@@ -37,23 +39,23 @@ def test_mock_public_safe_accepts() -> None:
     assert result.deploy_allowed is False
 
 
-def test_live_missing_key_blocks(monkeypatch) -> None:
+def test_live_disabled_blocks_before_key_check(monkeypatch) -> None:
+    monkeypatch.delenv("GEMINI_API_LIVE_MODE", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-    packet = GeminiAuditorInput(
-        schema_version="gemini_adapter.input.v1",
-        packet_id="test-live-missing-key",
-        objective="Review synthetic packet.",
-        mode="live",
-        privacy_level="PUBLIC_SAFE",
-        confirmed_canon="Live mode needs environment key.",
-        evidence="Synthetic public-safe evidence.",
-        draft_artifact="Synthetic draft.",
-        exact_questions=["Should this block?"],
-        forbidden_actions=["do not execute commands"],
-    )
 
-    result = run_adapter(packet)
+    result = run_adapter(_packet("live"))
+
+    assert result.status == "blocked_live_mode_disabled"
+    assert result.output is None
+
+
+def test_live_missing_key_blocks_when_live_flag_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("GEMINI_API_LIVE_MODE", "true")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    result = run_adapter(_packet("live"))
 
     assert result.status == "blocked_live_mode_missing_key"
     assert result.output is None
@@ -135,9 +137,23 @@ def test_fixture_public_safe_accepts() -> None:
     assert result.status == "mock_accept"
 
 
-def test_fixture_live_missing_key_blocks(monkeypatch) -> None:
+def test_fixture_live_disabled_blocks(monkeypatch) -> None:
+    monkeypatch.delenv("GEMINI_API_LIVE_MODE", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    result = run_adapter_from_json(
+        _read_fixture("tests/fixtures/gemini_auditor_input_live_missing_key.json")
+    )
+
+    assert result.status == "blocked_live_mode_disabled"
+
+
+def test_fixture_live_missing_key_blocks_when_live_flag_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("GEMINI_API_LIVE_MODE", "true")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
     result = run_adapter_from_json(
         _read_fixture("tests/fixtures/gemini_auditor_input_live_missing_key.json")
     )

--- a/tests/skeleton_core/test_gemini_auditor_adapter.py
+++ b/tests/skeleton_core/test_gemini_auditor_adapter.py
@@ -1,0 +1,149 @@
+import os
+
+from tools.skeleton_core.gemini_auditor_adapter import (
+    GeminiAuditorInput,
+    GeminiAuditorOutput,
+    run_adapter,
+    run_adapter_from_json,
+    validate_output,
+)
+
+
+def test_mock_public_safe_accepts() -> None:
+    packet = GeminiAuditorInput(
+        schema_version="gemini_adapter.input.v1",
+        packet_id="test-public-safe",
+        objective="Review synthetic packet.",
+        mode="mock",
+        privacy_level="PUBLIC_SAFE",
+        confirmed_canon="Gemini cannot execute commands or update canon.",
+        evidence="Synthetic public-safe evidence.",
+        draft_artifact="Synthetic draft.",
+        exact_questions=["Is this safe?"],
+        forbidden_actions=["do not execute commands"],
+    )
+
+    result = run_adapter(packet)
+
+    assert result.status == "mock_accept"
+    assert result.output is not None
+    assert result.output.canon_claim is False
+    assert result.output.commands == []
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_live_missing_key_blocks(monkeypatch) -> None:
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    packet = GeminiAuditorInput(
+        schema_version="gemini_adapter.input.v1",
+        packet_id="test-live-missing-key",
+        objective="Review synthetic packet.",
+        mode="live",
+        privacy_level="PUBLIC_SAFE",
+        confirmed_canon="Live mode needs environment key.",
+        evidence="Synthetic public-safe evidence.",
+        draft_artifact="Synthetic draft.",
+        exact_questions=["Should this block?"],
+        forbidden_actions=["do not execute commands"],
+    )
+
+    result = run_adapter(packet)
+
+    assert result.status == "blocked_live_mode_missing_key"
+    assert result.output is None
+
+
+def test_secret_blocks() -> None:
+    raw_json = """
+    {
+      "schema_version": "gemini_adapter.input.v1",
+      "packet_id": "test-secret",
+      "objective": "Review leaked secret.",
+      "mode": "mock",
+      "privacy_level": "PUBLIC_SAFE",
+      "confirmed_canon": "No secrets.",
+      "evidence": "api_key=SHOULD_NOT_PASS",
+      "draft_artifact": "Synthetic draft.",
+      "exact_questions": ["Should this block?"],
+      "forbidden_actions": ["do not execute commands"]
+    }
+    """
+
+    result = run_adapter_from_json(raw_json)
+
+    assert result.status == "blocked_secret_or_pii"
+    assert "generic_api_key" in result.security_flags
+
+
+def test_schema_validation_blocks_extra_field() -> None:
+    raw_json = """
+    {
+      "schema_version": "gemini_adapter.input.v1",
+      "packet_id": "test-extra",
+      "objective": "Review synthetic packet.",
+      "mode": "mock",
+      "privacy_level": "PUBLIC_SAFE",
+      "confirmed_canon": "No commands.",
+      "evidence": "Synthetic evidence.",
+      "draft_artifact": "Synthetic draft.",
+      "exact_questions": ["Is this safe?"],
+      "forbidden_actions": ["do not execute commands"],
+      "unexpected": "blocked"
+    }
+    """
+
+    result = run_adapter_from_json(raw_json)
+
+    assert result.status == "blocked_schema_validation"
+
+
+def test_output_validation_blocks_forbidden_fields() -> None:
+    output = GeminiAuditorOutput(
+        schema_version="gemini-auditor-mock-output-v0.1",
+        packet_id="test-output",
+        decision="accept",
+        security_flags=[],
+        summary="Unsafe output.",
+        rationale=["bad"],
+        blocked_instruction="",
+        exoskeleton_note="",
+        canon_claim=True,
+        commands=["run something"],
+        architecture_suggestions=["suggestion"],
+        live_access_references=["live ref"],
+    )
+
+    errors = validate_output(output, strict_mode=True)
+
+    assert "canon_claim_must_be_false" in errors
+    assert "commands_must_be_empty" in errors
+    assert "live_access_references_must_be_empty" in errors
+    assert "architecture_suggestions_must_be_empty_in_strict_mode" in errors
+
+
+def test_fixture_public_safe_accepts() -> None:
+    result = run_adapter_from_json(
+        open("tests/fixtures/gemini_auditor_input_public_safe.json", encoding="utf-8").read()
+    )
+
+    assert result.status == "mock_accept"
+
+
+def test_fixture_live_missing_key_blocks(monkeypatch) -> None:
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    result = run_adapter_from_json(
+        open("tests/fixtures/gemini_auditor_input_live_missing_key.json", encoding="utf-8").read()
+    )
+
+    assert result.status == "blocked_live_mode_missing_key"
+
+
+def test_fixture_secret_blocks() -> None:
+    result = run_adapter_from_json(
+        open("tests/fixtures/gemini_auditor_input_secret_blocked.json", encoding="utf-8").read()
+    )
+
+    assert result.status == "blocked_secret_or_pii"

--- a/tools/skeleton_core/gemini_auditor_adapter.py
+++ b/tools/skeleton_core/gemini_auditor_adapter.py
@@ -1,0 +1,325 @@
+"""Mock-first Gemini auditor adapter for Skeleton runner workflows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+InputMode = Literal["mock", "live"]
+PrivacyLevel = Literal["PUBLIC_SAFE", "STRICT_REDACTION", "INTERNAL_BHK"]
+Decision = Literal["accept", "block", "revise"]
+AdapterStatus = Literal[
+    "mock_accept",
+    "mock_revise",
+    "mock_block",
+    "live_accept",
+    "live_revise",
+    "live_block",
+    "blocked_schema_validation",
+    "blocked_secret_or_pii",
+    "blocked_live_mode_missing_key",
+    "blocked_output_validation",
+    "blocked_live_transport_error",
+    "unknown_needs_review",
+]
+
+OUTPUT_SCHEMA_VERSION = "gemini-auditor-mock-output-v0.1"
+DEFAULT_MODEL = "gemini-2.5-flash"
+SECRET_PATTERNS = {
+    "gemini_api_key": r"AIza[0-9A-Za-z_\-]{20,}",
+    "generic_api_key": r"(?i)(api[_-]?key|secret|token|password)\s*[:=]\s*['\"]?[^\s,'\"]+",
+    "email_address": r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
+    "private_key": r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
+}
+POISON_PATTERNS = {
+    "poisoned_instruction": r"(?i)poisoned_instruction|ignore previous|bypass.+control|disable.+gate",
+    "structural_code_injection": r"(?i)__proto__|constructor\s*:|import\s+os|subprocess|eval\(|exec\(",
+}
+
+
+class GeminiAuditorInput(BaseModel):
+    """Strict input packet sent by the runner toward the adapter."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["gemini_adapter.input.v1"]
+    packet_id: str
+    objective: str
+    mode: InputMode = "mock"
+    privacy_level: PrivacyLevel = "PUBLIC_SAFE"
+    confirmed_canon: str
+    evidence: str
+    draft_artifact: str
+    exact_questions: list[str] = Field(default_factory=list)
+    forbidden_actions: list[str] = Field(default_factory=list)
+
+
+class GeminiAuditorOutput(BaseModel):
+    """Strict output packet returned by Gemini/mock through the adapter."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["gemini-auditor-mock-output-v0.1"]
+    packet_id: str
+    decision: Decision
+    security_flags: list[str] = Field(default_factory=list)
+    summary: str
+    rationale: list[str] = Field(default_factory=list)
+    blocked_instruction: str = ""
+    exoskeleton_note: str = ""
+    canon_claim: bool = False
+    commands: list[str] = Field(default_factory=list)
+    architecture_suggestions: list[str] = Field(default_factory=list)
+    live_access_references: list[str] = Field(default_factory=list)
+
+
+class GeminiAdapterPacket(BaseModel):
+    """Adapter result returned to the runner/ChatGPT side."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: AdapterStatus
+    packet_id: str = ""
+    mode: InputMode = "mock"
+    model: str = DEFAULT_MODEL
+    output: GeminiAuditorOutput | None = None
+    blocked_reasons: list[str] = Field(default_factory=list)
+    security_flags: list[str] = Field(default_factory=list)
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    next_safe_step: str
+
+
+def scan_sensitive_text(text: str) -> list[str]:
+    """Return matched secret/PII/poison flags for text."""
+    flags = []
+    for name, pattern in {**SECRET_PATTERNS, **POISON_PATTERNS}.items():
+        if re.search(pattern, text):
+            flags.append(name)
+    return sorted(set(flags))
+
+
+def _packet_text(packet: GeminiAuditorInput) -> str:
+    return json.dumps(packet.model_dump(mode="json"), ensure_ascii=False, sort_keys=True)
+
+
+def _blocked(
+    status: AdapterStatus,
+    *,
+    packet_id: str = "",
+    mode: InputMode = "mock",
+    model: str = DEFAULT_MODEL,
+    reasons: list[str] | None = None,
+    flags: list[str] | None = None,
+) -> GeminiAdapterPacket:
+    return GeminiAdapterPacket(
+        status=status,
+        packet_id=packet_id,
+        mode=mode,
+        model=model,
+        blocked_reasons=reasons or [],
+        security_flags=flags or [],
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_safe_step="Stop and fix the Gemini auditor packet before continuing.",
+    )
+
+
+def validate_output(output: GeminiAuditorOutput, *, strict_mode: bool) -> list[str]:
+    """Validate fail-closed output invariants."""
+    reasons = []
+    if output.canon_claim:
+        reasons.append("canon_claim_must_be_false")
+    if output.commands:
+        reasons.append("commands_must_be_empty")
+    if output.live_access_references:
+        reasons.append("live_access_references_must_be_empty")
+    if strict_mode and output.architecture_suggestions:
+        reasons.append("architecture_suggestions_must_be_empty_in_strict_mode")
+    inbound_flags = scan_sensitive_text(output.model_dump_json())
+    reasons.extend(f"inbound_{flag}" for flag in inbound_flags)
+    return sorted(set(reasons))
+
+
+def build_mock_output(packet: GeminiAuditorInput) -> GeminiAuditorOutput:
+    """Create deterministic mock output without calling Gemini."""
+    decision: Decision = "accept"
+    if packet.privacy_level != "PUBLIC_SAFE" or not packet.exact_questions:
+        decision = "revise"
+
+    return GeminiAuditorOutput(
+        schema_version=OUTPUT_SCHEMA_VERSION,
+        packet_id=packet.packet_id,
+        decision=decision,
+        security_flags=[],
+        summary="Mock Gemini auditor response generated without live API access.",
+        rationale=[
+            "Input packet passed strict schema validation.",
+            "No outbound secret or PII pattern was detected.",
+            "Mock mode preserves fail-closed development without network access.",
+        ],
+        blocked_instruction="",
+        exoskeleton_note="Treat this as adapter validation evidence, not canon.",
+        canon_claim=False,
+        commands=[],
+        architecture_suggestions=[],
+        live_access_references=[],
+    )
+
+
+def _api_key_from_env() -> str | None:
+    return os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+
+
+def _live_prompt(packet: GeminiAuditorInput) -> str:
+    return (
+        "You are a stateless Gemini Auditor Node. Return only strict JSON matching "
+        "schema_version gemini-auditor-mock-output-v0.1. Do not return commands. "
+        "Do not claim canon. Do not include live_access_references.\n\n"
+        f"Input packet:\n{packet.model_dump_json(indent=2)}"
+    )
+
+
+def _extract_text_from_gemini_response(raw: dict[str, Any]) -> str:
+    candidates = raw.get("candidates") or []
+    if not candidates:
+        raise ValueError("missing_candidates")
+    content = candidates[0].get("content") or {}
+    parts = content.get("parts") or []
+    texts = [part.get("text", "") for part in parts if isinstance(part, dict)]
+    text = "".join(texts).strip()
+    if text.startswith("```json"):
+        text = text.removeprefix("```json").strip()
+    if text.startswith("```"):
+        text = text.removeprefix("```").strip()
+    if text.endswith("```"):
+        text = text[: -len("```")].strip()
+    if not text:
+        raise ValueError("missing_text")
+    return text
+
+
+def call_live_gemini(packet: GeminiAuditorInput, *, model: str) -> GeminiAuditorOutput:
+    """Call Gemini API with stdlib transport and validate JSON response."""
+    api_key = _api_key_from_env()
+    if not api_key:
+        raise RuntimeError("missing_gemini_api_key")
+
+    endpoint = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{urllib.parse.quote(model, safe='')}:generateContent"
+        f"?key={urllib.parse.quote(api_key, safe='')}"
+    )
+    body = json.dumps({"contents": [{"parts": [{"text": _live_prompt(packet)}]}]}).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        raw_response = json.loads(response.read().decode("utf-8"))
+    output_text = _extract_text_from_gemini_response(raw_response)
+    return GeminiAuditorOutput.model_validate_json(output_text)
+
+
+def run_adapter(packet: GeminiAuditorInput, *, model: str = DEFAULT_MODEL) -> GeminiAdapterPacket:
+    """Run mock-first Gemini auditor adapter."""
+    flags = scan_sensitive_text(_packet_text(packet))
+    if flags:
+        return _blocked(
+            "blocked_secret_or_pii",
+            packet_id=packet.packet_id,
+            mode=packet.mode,
+            model=model,
+            reasons=[f"outbound_{flag}" for flag in flags],
+            flags=flags,
+        )
+
+    if packet.mode == "live" and not _api_key_from_env():
+        return _blocked(
+            "blocked_live_mode_missing_key",
+            packet_id=packet.packet_id,
+            mode=packet.mode,
+            model=model,
+            reasons=["GEMINI_API_KEY or GOOGLE_API_KEY is required for live mode."],
+        )
+
+    try:
+        output = build_mock_output(packet) if packet.mode == "mock" else call_live_gemini(packet, model=model)
+    except (RuntimeError, urllib.error.URLError, TimeoutError) as exc:
+        return _blocked(
+            "blocked_live_transport_error",
+            packet_id=packet.packet_id,
+            mode=packet.mode,
+            model=model,
+            reasons=[str(exc)],
+        )
+    except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+        return _blocked(
+            "blocked_output_validation",
+            packet_id=packet.packet_id,
+            mode=packet.mode,
+            model=model,
+            reasons=[str(exc)],
+        )
+
+    strict_mode = packet.privacy_level == "STRICT_REDACTION"
+    output_errors = validate_output(output, strict_mode=strict_mode)
+    if output_errors:
+        return _blocked(
+            "blocked_output_validation",
+            packet_id=packet.packet_id,
+            mode=packet.mode,
+            model=model,
+            reasons=output_errors,
+        )
+
+    prefix = "mock" if packet.mode == "mock" else "live"
+    status: AdapterStatus = f"{prefix}_{output.decision}"  # type: ignore[assignment]
+    return GeminiAdapterPacket(
+        status=status,
+        packet_id=packet.packet_id,
+        mode=packet.mode,
+        model=model,
+        output=output,
+        blocked_reasons=[],
+        security_flags=output.security_flags,
+        merge_allowed=False,
+        deploy_allowed=False,
+        next_safe_step="Return this packet to ChatGPT/Skeleton for synthesis and review.",
+    )
+
+
+def run_adapter_from_json(raw_json: str, *, model: str = DEFAULT_MODEL) -> GeminiAdapterPacket:
+    """Validate JSON input and run the adapter."""
+    try:
+        packet = GeminiAuditorInput.model_validate_json(raw_json)
+    except ValidationError as exc:
+        return _blocked("blocked_schema_validation", reasons=[exc.json()])
+    return run_adapter(packet, model=model)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the Gemini auditor adapter.")
+    parser.add_argument("--input", required=True, type=Path, help="Path to input packet JSON")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Gemini model name")
+    args = parser.parse_args(argv)
+
+    result = run_adapter_from_json(args.input.read_text(encoding="utf-8"), model=args.model)
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0 if not result.status.startswith("blocked_") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/skeleton_core/gemini_auditor_adapter.py
+++ b/tools/skeleton_core/gemini_auditor_adapter.py
@@ -37,9 +37,7 @@ OUTPUT_SCHEMA_VERSION = "gemini-auditor-mock-output-v0.1"
 DEFAULT_MODEL = "gemini-2.5-flash"
 SECRET_PATTERNS = {
     "gemini_api_key": r"AIza[0-9A-Za-z_\-]{20,}",
-    "generic_api_key": (
-        r"(?i)(api[_-]?key|secret|token|password)" r"\s*[:=]\s*['\"]?[^\s,'\"]+"
-    ),
+    "generic_api_key": (r"(?i)(api[_-]?key|secret|token|password)" r"\s*[:=]\s*['\"]?[^\s,'\"]+"),
     "email_address": r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
     "private_key": r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
 }
@@ -116,9 +114,7 @@ def scan_sensitive_text(text: str) -> list[str]:
 
 
 def _packet_text(packet: GeminiAuditorInput) -> str:
-    return json.dumps(
-        packet.model_dump(mode="json"), ensure_ascii=False, sort_keys=True
-    )
+    return json.dumps(packet.model_dump(mode="json"), ensure_ascii=False, sort_keys=True)
 
 
 def _blocked(
@@ -235,9 +231,7 @@ def call_live_gemini(packet: GeminiAuditorInput, *, model: str) -> GeminiAuditor
         f"{urllib.parse.quote(model, safe='')}:generateContent"
         f"?key={urllib.parse.quote(api_key, safe='')}"
     )
-    body = json.dumps(
-        {"contents": [{"parts": [{"text": _live_prompt(packet)}]}]}
-    ).encode("utf-8")
+    body = json.dumps({"contents": [{"parts": [{"text": _live_prompt(packet)}]}]}).encode("utf-8")
     request = urllib.request.Request(
         endpoint,
         data=body,
@@ -251,9 +245,7 @@ def call_live_gemini(packet: GeminiAuditorInput, *, model: str) -> GeminiAuditor
     return GeminiAuditorOutput.model_validate_json(output_text)
 
 
-def run_adapter(
-    packet: GeminiAuditorInput, *, model: str = DEFAULT_MODEL
-) -> GeminiAdapterPacket:
+def run_adapter(packet: GeminiAuditorInput, *, model: str = DEFAULT_MODEL) -> GeminiAdapterPacket:
     """Run mock-first Gemini auditor adapter."""
     flags = scan_sensitive_text(_packet_text(packet))
     if flags:
@@ -334,9 +326,7 @@ def run_adapter(
     )
 
 
-def run_adapter_from_json(
-    raw_json: str, *, model: str = DEFAULT_MODEL
-) -> GeminiAdapterPacket:
+def run_adapter_from_json(raw_json: str, *, model: str = DEFAULT_MODEL) -> GeminiAdapterPacket:
     """Validate JSON input and run the adapter."""
     try:
         packet = GeminiAuditorInput.model_validate_json(raw_json)

--- a/tools/skeleton_core/gemini_auditor_adapter.py
+++ b/tools/skeleton_core/gemini_auditor_adapter.py
@@ -38,8 +38,7 @@ DEFAULT_MODEL = "gemini-2.5-flash"
 SECRET_PATTERNS = {
     "gemini_api_key": r"AIza[0-9A-Za-z_\-]{20,}",
     "generic_api_key": (
-        r"(?i)(api[_-]?key|secret|token|password)"
-        r"\s*[:=]\s*['\"]?[^\s,'\"]+"
+        r"(?i)(api[_-]?key|secret|token|password)" r"\s*[:=]\s*['\"]?[^\s,'\"]+"
     ),
     "email_address": r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
     "private_key": r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
@@ -117,7 +116,9 @@ def scan_sensitive_text(text: str) -> list[str]:
 
 
 def _packet_text(packet: GeminiAuditorInput) -> str:
-    return json.dumps(packet.model_dump(mode="json"), ensure_ascii=False, sort_keys=True)
+    return json.dumps(
+        packet.model_dump(mode="json"), ensure_ascii=False, sort_keys=True
+    )
 
 
 def _blocked(
@@ -250,7 +251,9 @@ def call_live_gemini(packet: GeminiAuditorInput, *, model: str) -> GeminiAuditor
     return GeminiAuditorOutput.model_validate_json(output_text)
 
 
-def run_adapter(packet: GeminiAuditorInput, *, model: str = DEFAULT_MODEL) -> GeminiAdapterPacket:
+def run_adapter(
+    packet: GeminiAuditorInput, *, model: str = DEFAULT_MODEL
+) -> GeminiAdapterPacket:
     """Run mock-first Gemini auditor adapter."""
     flags = scan_sensitive_text(_packet_text(packet))
     if flags:
@@ -331,7 +334,9 @@ def run_adapter(packet: GeminiAuditorInput, *, model: str = DEFAULT_MODEL) -> Ge
     )
 
 
-def run_adapter_from_json(raw_json: str, *, model: str = DEFAULT_MODEL) -> GeminiAdapterPacket:
+def run_adapter_from_json(
+    raw_json: str, *, model: str = DEFAULT_MODEL
+) -> GeminiAdapterPacket:
     """Validate JSON input and run the adapter."""
     try:
         packet = GeminiAuditorInput.model_validate_json(raw_json)
@@ -355,7 +360,10 @@ def main(argv: list[str] | None = None) -> int:
         args.input.read_text(encoding="utf-8"),
         model=args.model,
     )
-    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    print(
+        json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2),
+        flush=True,
+    )
     return 0 if not result.status.startswith("blocked_") else 1
 
 

--- a/tools/skeleton_core/gemini_auditor_adapter.py
+++ b/tools/skeleton_core/gemini_auditor_adapter.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import os
 import re
-import sys
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/tools/skeleton_core/gemini_auditor_adapter.py
+++ b/tools/skeleton_core/gemini_auditor_adapter.py
@@ -26,6 +26,7 @@ AdapterStatus = Literal[
     "live_block",
     "blocked_schema_validation",
     "blocked_secret_or_pii",
+    "blocked_live_mode_disabled",
     "blocked_live_mode_missing_key",
     "blocked_output_validation",
     "blocked_live_transport_error",
@@ -36,13 +37,20 @@ OUTPUT_SCHEMA_VERSION = "gemini-auditor-mock-output-v0.1"
 DEFAULT_MODEL = "gemini-2.5-flash"
 SECRET_PATTERNS = {
     "gemini_api_key": r"AIza[0-9A-Za-z_\-]{20,}",
-    "generic_api_key": r"(?i)(api[_-]?key|secret|token|password)\s*[:=]\s*['\"]?[^\s,'\"]+",
+    "generic_api_key": (
+        r"(?i)(api[_-]?key|secret|token|password)"
+        r"\s*[:=]\s*['\"]?[^\s,'\"]+"
+    ),
     "email_address": r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
     "private_key": r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
 }
 POISON_PATTERNS = {
-    "poisoned_instruction": r"(?i)poisoned_instruction|ignore previous|bypass.+control|disable.+gate",
-    "structural_code_injection": r"(?i)__proto__|constructor\s*:|import\s+os|subprocess|eval\(|exec\(",
+    "poisoned_instruction": (
+        r"(?i)poisoned_instruction|ignore previous|bypass.+control|disable.+gate"
+    ),
+    "structural_code_injection": (
+        r"(?i)__proto__|constructor\s*:|import\s+os|subprocess|eval\(|exec\("
+    ),
 }
 
 
@@ -145,6 +153,7 @@ def validate_output(output: GeminiAuditorOutput, *, strict_mode: bool) -> list[s
         reasons.append("live_access_references_must_be_empty")
     if strict_mode and output.architecture_suggestions:
         reasons.append("architecture_suggestions_must_be_empty_in_strict_mode")
+
     inbound_flags = scan_sensitive_text(output.model_dump_json())
     reasons.extend(f"inbound_{flag}" for flag in inbound_flags)
     return sorted(set(reasons))
@@ -180,6 +189,10 @@ def _api_key_from_env() -> str | None:
     return os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
 
 
+def _live_mode_enabled() -> bool:
+    return os.environ.get("GEMINI_API_LIVE_MODE", "").casefold() == "true"
+
+
 def _live_prompt(packet: GeminiAuditorInput) -> str:
     return (
         "You are a stateless Gemini Auditor Node. Return only strict JSON matching "
@@ -193,10 +206,12 @@ def _extract_text_from_gemini_response(raw: dict[str, Any]) -> str:
     candidates = raw.get("candidates") or []
     if not candidates:
         raise ValueError("missing_candidates")
+
     content = candidates[0].get("content") or {}
     parts = content.get("parts") or []
     texts = [part.get("text", "") for part in parts if isinstance(part, dict)]
     text = "".join(texts).strip()
+
     if text.startswith("```json"):
         text = text.removeprefix("```json").strip()
     if text.startswith("```"):
@@ -219,7 +234,9 @@ def call_live_gemini(packet: GeminiAuditorInput, *, model: str) -> GeminiAuditor
         f"{urllib.parse.quote(model, safe='')}:generateContent"
         f"?key={urllib.parse.quote(api_key, safe='')}"
     )
-    body = json.dumps({"contents": [{"parts": [{"text": _live_prompt(packet)}]}]}).encode("utf-8")
+    body = json.dumps(
+        {"contents": [{"parts": [{"text": _live_prompt(packet)}]}]}
+    ).encode("utf-8")
     request = urllib.request.Request(
         endpoint,
         data=body,
@@ -228,6 +245,7 @@ def call_live_gemini(packet: GeminiAuditorInput, *, model: str) -> GeminiAuditor
     )
     with urllib.request.urlopen(request, timeout=60) as response:
         raw_response = json.loads(response.read().decode("utf-8"))
+
     output_text = _extract_text_from_gemini_response(raw_response)
     return GeminiAuditorOutput.model_validate_json(output_text)
 
@@ -245,6 +263,15 @@ def run_adapter(packet: GeminiAuditorInput, *, model: str = DEFAULT_MODEL) -> Ge
             flags=flags,
         )
 
+    if packet.mode == "live" and not _live_mode_enabled():
+        return _blocked(
+            "blocked_live_mode_disabled",
+            packet_id=packet.packet_id,
+            mode=packet.mode,
+            model=model,
+            reasons=["GEMINI_API_LIVE_MODE=true is required for live mode."],
+        )
+
     if packet.mode == "live" and not _api_key_from_env():
         return _blocked(
             "blocked_live_mode_missing_key",
@@ -255,7 +282,11 @@ def run_adapter(packet: GeminiAuditorInput, *, model: str = DEFAULT_MODEL) -> Ge
         )
 
     try:
-        output = build_mock_output(packet) if packet.mode == "mock" else call_live_gemini(packet, model=model)
+        output = (
+            build_mock_output(packet)
+            if packet.mode == "mock"
+            else call_live_gemini(packet, model=model)
+        )
     except (RuntimeError, urllib.error.URLError, TimeoutError) as exc:
         return _blocked(
             "blocked_live_transport_error",
@@ -311,11 +342,19 @@ def run_adapter_from_json(raw_json: str, *, model: str = DEFAULT_MODEL) -> Gemin
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run the Gemini auditor adapter.")
-    parser.add_argument("--input", required=True, type=Path, help="Path to input packet JSON")
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to input packet JSON",
+    )
     parser.add_argument("--model", default=DEFAULT_MODEL, help="Gemini model name")
     args = parser.parse_args(argv)
 
-    result = run_adapter_from_json(args.input.read_text(encoding="utf-8"), model=args.model)
+    result = run_adapter_from_json(
+        args.input.read_text(encoding="utf-8"),
+        model=args.model,
+    )
     print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
     return 0 if not result.status.startswith("blocked_") else 1
 


### PR DESCRIPTION
## Summary

Implements the mock-first Gemini Auditor Node adapter described in:

```text
knowledge_base/chatgpt_exoskeleton/skills/gemini_auditor_node.md
knowledge_base/chatgpt_exoskeleton/runner_tasks/gemini_auditor_adapter_task.md
```

Adds:

```text
tools/skeleton_core/gemini_auditor_adapter.py
tests/skeleton_core/test_gemini_auditor_adapter.py
tests/fixtures/gemini_auditor_input_public_safe.json
tests/fixtures/gemini_auditor_input_live_missing_key.json
tests/fixtures/gemini_auditor_input_secret_blocked.json
```

## Behavior

```text
Mock mode is default.
Live mode requires GEMINI_API_KEY or GOOGLE_API_KEY in runner environment.
Input uses strict Pydantic schema.
Output uses strict schema.
Outbound and inbound payloads are scanned for secrets/PII/poison patterns.
Gemini output is blocked if canon_claim=true, commands are non-empty, or live_access_references are non-empty.
Strict mode blocks architecture_suggestions.
```

## Safety

```text
No direct ChatGPT -> Gemini connection.
No hardcoded API keys.
No .env reads.
No secret printing.
No commands from Gemini.
No merge/deploy authority.
No private project data in fixtures.
```

## Validation expected

```bash
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
python -m tools.skeleton_core.cli validate-state
python -m tools.skeleton_core.gemini_auditor_adapter --input tests/fixtures/gemini_auditor_input_public_safe.json
```

After merge, live test can be run only in the runner environment with GEMINI_API_KEY set.