### PR TITLE
docs(skeleton): add Gemini second-brain pass to construction takeoff

### DIFF
--- a/knowledge_base/chatgpt_exoskeleton/runner_tasks/construction_takeoff_runner_task_template.md
+++ b/knowledge_base/chatgpt_exoskeleton/runner_tasks/construction_takeoff_runner_task_template.md
@@ -26,6 +26,8 @@ This template is generic. Replace placeholders only in private task packets or p
 <PDF_CONTROL_FILES>
 <SCAN_FOLDER>
 <EXPECTED_WORKBOOK_NAME>
+<OPTIONAL_GEMINI_PACKET_PATH>
+<OPTIONAL_GEMINI_OUTPUT_PATH>
 ```
 
 ## Source priority
@@ -54,6 +56,8 @@ OpenCV
 IfcOpenShell if available
 ```
 
+Optional Gemini second-brain review may use only the existing Gemini Auditor adapter after explicit approval and after the bridge is verified for the Runner environment.
+
 ## Forbidden
 
 ```text
@@ -65,6 +69,7 @@ No final billable quantity claims.
 No live external model/API calls unless separately approved.
 No merge/deploy/server/production changes.
 No secrets, .env, credentials, or tokens.
+No treating Gemini as a geometry source of record or final authority.
 ```
 
 ## Expected private output folder
@@ -83,6 +88,8 @@ No secrets, .env, credentials, or tokens.
 <WORKING_OUTPUT_FOLDER>/assumptions.csv
 <WORKING_OUTPUT_FOLDER>/<EXPECTED_WORKBOOK_NAME>.xlsx
 <WORKING_OUTPUT_FOLDER>/runner_log.md
+<WORKING_OUTPUT_FOLDER>/gemini_intake_packet.json optional, private/local only
+<WORKING_OUTPUT_FOLDER>/gemini_auditor_output.json optional, private/local only
 ```
 
 ## Runner workflow
@@ -97,8 +104,77 @@ No secrets, .env, credentials, or tokens.
 7. Build preliminary tables.
 8. Run validation gates.
 9. Write CSV/XLSX/log artifacts.
-10. Report status and review items.
+10. Optionally build a Gemini Intake Packet from summarized table/gate results.
+11. Optionally run the Gemini Auditor adapter if explicitly approved and verified.
+12. Validate Gemini output fail-closed.
+13. Convert Gemini findings into review items/questions only after ChatGPT/Skeleton synthesis.
+14. Report status and review items.
 ```
+
+## Optional Gemini second-brain stage
+
+Use this stage only when explicitly approved for the private pilot and only through the Runner-mediated Gemini Auditor adapter.
+
+Allowed use:
+
+```text
+preliminary tables + validation-gate summaries
+-> Gemini Intake Packet
+-> stateless anomaly/consistency review
+-> adapter output validation
+-> ChatGPT/Skeleton synthesis
+-> Oleksii review
+```
+
+Gemini review questions may include:
+
+```text
+Are source priorities applied consistently?
+Are room, wall, opening, height, façade, and slope values internally consistent?
+Which table rows look suspicious or need human review?
+Which validation gates failed or need better evidence?
+Are assumptions separated from extracted facts?
+Are conflicts between DXF/DWG, IFC, PDF, sections, façades, and scans represented in CROSSCHECK_MATRIX or REVIEW_ITEMS?
+```
+
+Gemini must not:
+
+```text
+execute commands
+access files outside the prepared packet
+update canon
+produce final billable quantities
+merge or deploy
+publish private project material
+be treated as the geometry source of record
+```
+
+## Gemini packet privacy gate
+
+Before any Gemini packet is created, choose one route:
+
+```text
+PUBLIC_SAFE = synthetic/redacted example only.
+STRICT_REDACTION = real-derived summary after deterministic redaction.
+INTERNAL_BHK = private/internal working packet only inside approved Runner/server environment.
+```
+
+The packet should include table and gate summaries, source-role labels, row identifiers, conflict categories, and exact review questions. It should not include raw drawings or unnecessary private context.
+
+## Gemini output validation gate
+
+The adapter output must fail closed if Gemini:
+
+```text
+sets canon_claim=true
+returns commands
+returns live access references
+violates schema
+claims final authority over quantities
+contains private leakage in a public report path
+```
+
+Gemini results may become candidate REVIEW_ITEMS, ASSUMPTIONS, or cross-check notes only after ChatGPT/Skeleton synthesis.
 
 ## DXF/DWG parser expectations
 
@@ -129,6 +205,8 @@ opening subtraction gate
 DG/sloped ceiling section gate
 façade separation gate
 privacy/publication gate
+Gemini packet privacy gate, if second-brain review is used
+Gemini output validation gate, if second-brain review is used
 ```
 
 Every failed or uncertain gate must create a REVIEW_ITEMS row.
@@ -140,6 +218,7 @@ What changed:
 What was extracted:
 What was not extracted:
 Validation gates:
+Gemini review status, if used:
 Conflicts:
 Review items:
 Private outputs created:
@@ -156,6 +235,7 @@ This runner task is done only when:
 - preliminary workbook exists;
 - runner log exists;
 - review items exist for unresolved gates;
+- optional Gemini review, if used, produced only evidence/review output;
 - no private files/data were committed to public GitHub;
 - Oleksii has enough information to review one floor/object.
 ```
@@ -168,6 +248,7 @@ A public GitHub report may say only:
 private pilot run completed / blocked / needs review
 artifact types created
 validation gates passed/failed by category
+Gemini review used / not used / blocked by bridge status
 next safe step
 ```
 

--- a/knowledge_base/chatgpt_exoskeleton/skills/construction_takeoff_from_drawings.md
+++ b/knowledge_base/chatgpt_exoskeleton/skills/construction_takeoff_from_drawings.md
@@ -76,8 +76,109 @@ source inventory
 -> cross-check matrix
 -> review items
 -> preliminary workbook
+-> optional Gemini second-brain review pass
+-> ChatGPT/Skeleton synthesis
 -> human review
 ```
+
+## Gemini second-brain review pass
+
+Gemini may be used as a Runner-mediated second-brain auditor after local/private extraction has produced preliminary tables and validation-gate results.
+
+Gemini is evidence/review support only. It is not a geometry source of record, not an executor, not a canon writer, not a merger/deployer, and not the final quantity authority. ChatGPT/Skeleton remains the architect, control plane, privacy gate, and canon gate. Oleksii remains the final reviewer for ambiguous construction facts.
+
+Use this review pattern:
+
+```text
+private drawings
+-> local source inventory
+-> local extraction/parsing
+-> preliminary CSV/XLSX tables
+-> validation gates
+-> redacted/public-safe or approved private Gemini Intake Packet
+-> Gemini anomaly/consistency review
+-> adapter fail-closed output validation
+-> ChatGPT/Skeleton synthesis
+-> Oleksii review
+```
+
+Gemini may help answer:
+
+```text
+Are source priorities applied consistently?
+Are room areas, wall areas, openings, heights, and façade values internally consistent?
+Which rows look suspicious or need human review?
+Which validation gates failed or are underspecified?
+Are there conflicts between DXF/DWG, IFC, PDF, sections, façades, and scans?
+Are assumptions clearly separated from extracted facts?
+Are statuses and confidence levels assigned consistently?
+```
+
+Gemini must not:
+
+```text
+produce final billable quantity claims
+execute commands
+access parser/source files outside the Runner packet
+update canon
+merge, deploy, or touch server/runtime state
+publish private project data
+be treated as the geometry source of record
+```
+
+## Gemini Intake Packet for Construction Takeoff
+
+The Runner may prepare a Gemini packet only after the privacy gate chooses a safe route:
+
+```text
+PUBLIC_SAFE = synthetic/redacted examples only.
+STRICT_REDACTION = real-derived summaries after deterministic redaction.
+INTERNAL_BHK = private/internal working packet allowed only inside approved Runner/server environment.
+```
+
+A Construction Takeoff Gemini packet should include only the minimum needed review surface:
+
+```text
+schema_version
+packet_id
+objective
+mode
+privacy_level
+confirmed_canon
+evidence summary
+draft_artifact summary
+exact_questions
+forbidden_actions
+```
+
+The evidence summary should describe table/gate results and row identifiers, not raw private drawings. If real private data is used inside an approved private Runner environment, public reports must mention only artifact types, gate categories, and next safe steps.
+
+## Gemini output handling
+
+Gemini output must pass the Gemini Auditor adapter validation before ChatGPT/Skeleton uses it.
+
+Fail closed if the response:
+
+```text
+sets canon_claim=true
+returns non-empty commands
+returns live access references
+contains secret/private leakage
+violates the output schema
+claims final authority over quantities
+```
+
+After validation, ChatGPT/Skeleton must synthesize Gemini's findings into:
+
+```text
+confirmed observations
+possible conflicts
+review items
+questions for Oleksii
+next safe private runner step
+```
+
+Gemini notes may become REVIEW_ITEMS or ASSUMPTIONS only after ChatGPT/Skeleton review. They are not canon by themselves.
 
 ## Table schemas
 
@@ -413,6 +514,8 @@ opening subtraction gate
 DG/sloped ceiling section gate
 façade separation gate
 privacy/publication gate
+Gemini packet privacy gate, if second-brain review is used
+Gemini output validation gate, if second-brain review is used
 ```
 
 A preliminary workbook is not reviewable unless each relevant gate is either passed or represented as a REVIEW_ITEMS row.
@@ -437,9 +540,22 @@ never upload private drawings or real extracted quantities to public GitHub
 ## Runner / Codex handoff roles
 
 ```text
-ChatGPT/Skeleton: method, schema, gates, review framing
-Runner/Codex: local/offline extraction scripts, parser execution, CSV/XLSX artifacts, logs
+ChatGPT/Skeleton: method, schema, gates, review framing, Gemini packet framing, synthesis
+Runner/Codex: local/offline extraction scripts, parser execution, CSV/XLSX artifacts, logs, optional Gemini adapter call when explicitly approved
+Gemini: stateless second-brain auditor over the prepared packet, evidence only
 Oleksii: final review/acceptance of ambiguous construction facts
+```
+
+## Promotion criteria after private pilot
+
+This skill may be promoted only after a private pilot demonstrates:
+
+```text
+local/private extraction produced a preliminary workbook
+validation gates produced review items for uncertainties
+optional Gemini review, if used, remained evidence-only and fail-closed
+ChatGPT/Skeleton synthesized the findings without leaking private data
+Oleksii reviewed one floor/object end-to-end
 ```
 
 ## Definition of done
@@ -454,6 +570,7 @@ Done requires:
 - privacy route is explicit;
 - table schemas and statuses exist;
 - first private pilot run produces a workbook;
+- optional Gemini second-brain review pass is tested safely when the bridge is verified;
 - one floor/object is reviewed end-to-end;
 - gaps are recorded;
 - after review, status may be promoted from LIKELY_NEEDS_REVIEW to CONFIRMED_WORKFLOW.
@@ -467,4 +584,4 @@ Status remains:
 LIKELY_NEEDS_REVIEW
 ```
 
-Promotion requires one successful private pilot floor/object reviewed by Oleksii.
+Promotion requires one successful private pilot floor/object reviewed by Oleksii. If Gemini second-brain review is used, the Runner-side Gemini bridge must be verified first and the output must remain evidence only.


### PR DESCRIPTION
## Summary

Implements #102 as a public-safe docs/template update.

Changed:
- Adds an optional Gemini second-brain review pass to the Construction Takeoff / Aufmaß skill.
- Updates the private/local runner task template with optional Gemini packet/output placeholders and validation gates.
- Keeps Gemini as stateless reviewer/evidence only, not a geometry source of record or final quantity authority.

## Safety

- Docs/template only.
- No runtime/app code changed.
- No private drawings, object data, quantities, Drive links, or project files included.
- No live Gemini call.
- No merge/deploy authority.

## Validation

Not run in ChatGPT connector. Runner/CI should run:

```bash
python -m tools.skeleton_core.cli validate-state
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
```

## Next safe step

Review the docs diff. Private pilot remains blocked until the Runner-side Gemini bridge is verified via #101 or equivalent.

Closes #102