### PR TITLE
docs(skeleton): add semi-automatic takeoff Gemini workflow

### DIFF
--- a/knowledge_base/chatgpt_exoskeleton/runner_tasks/semi_automatic_construction_takeoff_gemini_task_template.md
+++ b/knowledge_base/chatgpt_exoskeleton/runner_tasks/semi_automatic_construction_takeoff_gemini_task_template.md
@@ -1,0 +1,140 @@
+# Semi-automatic Construction Takeoff + Gemini Runner Task Template
+
+Status: TEMPLATE
+Scope: private/local runner task framing
+Privacy: public-safe placeholders only
+Related skill: `semi_automatic_construction_takeoff_with_gemini`
+
+## Purpose
+
+Prepare or run a controlled semi-automatic Construction Takeoff / Aufmaß pilot with optional Gemini second-brain review.
+
+This template is generic. Replace placeholders only in private task packets, private Drive handoff, or local Runner context.
+
+## Private placeholders
+
+```text
+<PRIVATE_SOURCE_FOLDER>
+<PRIVATE_OUTPUT_FOLDER>
+<PILOT_SCOPE>
+<QUANTITY_TARGET>
+<SOURCE_PRIORITY_RULE>
+<GEMINI_PRIVACY_LEVEL>
+<RUNNER_MODE>
+```
+
+## Default first-pilot target
+
+```text
+quantity_target = room areas + wall areas by room
+scope = one floor or bounded zone
+openings = review layer unless source is clear
+Gemini = optional review after preliminary tables
+```
+
+## Required source inventory fields
+
+```text
+source_id
+private_source_ref
+source_type
+file_format
+floor_or_scope
+source_role
+revision_or_date
+priority_for_this_object
+parse_status
+notes
+```
+
+## Required room/wall metadata fields
+
+```text
+source_pdf_ref
+source_vector_ref
+version_match_status
+measurement_source
+confidence
+review_item_id
+```
+
+## Object-specific mixed-source rule
+
+Use this rule when private handoff says PDF is the current version and DWG/DXF are precise but mixed:
+
+```text
+PDF selects the current variant/state.
+DWG/DXF provides precise vector dimensions only after matching the relevant candidate geometry to the PDF.
+Mixed vector versions must be separated and reviewed.
+```
+
+## Runner stages
+
+```text
+1. Read private handoff.
+2. Confirm source folder and scope.
+3. Build source_inventory.csv.
+4. Read legend/source-priority notes.
+5. Extract PDF text/labels/printed areas where available.
+6. Extract vector candidate geometry from DXF/DWG where available.
+7. Match vector candidates to current PDF variant.
+8. Produce rooms_prelim.csv.
+9. Produce walls_prelim.csv by room, with height assumptions/statuses.
+10. Produce crosscheck_matrix.csv.
+11. Produce review_items.csv for conflicts/missing data.
+12. Produce workbook.xlsx.
+13. Prepare optional Gemini intake packet from summaries.
+14. Run Gemini adapter only if bridge and privacy level are approved.
+15. Validate Gemini output fail-closed.
+16. Add Gemini findings only as review items/candidate notes.
+```
+
+## Manual checkpoints
+
+Stop and report at these checkpoints if data is uncertain:
+
+```text
+source inventory complete
+scope/target mismatch detected
+PDF/vector version conflict detected
+height source missing for wall areas
+Gemini packet ready but not approved
+Gemini output failed validation
+```
+
+## Gemini packet questions
+
+```text
+Are PDF-current-state and vector-measurement sources applied consistently?
+Which rows likely mix different vector versions or states?
+Which room or wall area rows look inconsistent with source references?
+Which rows require human review before use?
+Are assumptions separated from extracted facts?
+Are conflicts captured in REVIEW_ITEMS?
+Are confidence/status values internally consistent?
+```
+
+## Forbidden
+
+```text
+No private drawings or extracted quantities in public GitHub.
+No final billable quantity claims.
+No raw API keys, .env values, SSH details, tokens, or credentials.
+No merge/deploy/runtime changes.
+No treating Gemini as final authority.
+No trusting mixed DWG/DXF geometry without PDF matching.
+```
+
+## Public report format
+
+```text
+Status:
+Pilot scope:
+Artifact types created:
+Validation gates:
+Gemini review status:
+Blocked/needs review:
+Next safe step:
+```
+
+Do not include real folder links, object names, addresses, client data, drawing names, extracted quantities, or private assumptions in public reports.

--- a/knowledge_base/chatgpt_exoskeleton/skills/semi_automatic_construction_takeoff_with_gemini.md
+++ b/knowledge_base/chatgpt_exoskeleton/skills/semi_automatic_construction_takeoff_with_gemini.md
@@ -1,0 +1,293 @@
+# Semi-automatic Construction Takeoff with Gemini Review
+
+Status: LIKELY_NEEDS_REVIEW
+Priority: HIGH
+Scope: reusable public-safe Skeleton skill/protocol
+Related skill: `construction_takeoff_from_drawings`
+Private route: real drawings, folder links, extracted tables, logs, and Gemini packets stay private only
+
+## Purpose
+
+Coordinate semi-automatic Construction Takeoff / Aufmaß work without pretending the workflow is fully autonomous.
+
+Target loop:
+
+```text
+private drawing source set
+-> source inventory
+-> human-approved quantity scope
+-> local/PDF/vector extraction step
+-> validation gates
+-> optional Gemini review packet
+-> Gemini consistency/anomaly review
+-> ChatGPT/Skeleton synthesis
+-> Oleksii review
+```
+
+The goal is to reduce manual work while keeping source control, privacy, and human review strict.
+
+## Activation rule
+
+Activate this skill when the user asks to prepare or run Construction Takeoff / Aufmaß work with partial automation, Gemini, Runner, Drive drawings, DXF/DWG/PDF/PLN, or room/wall/floor/ceiling quantities.
+
+If the user says to stop real analysis and prepare the workflow, do not continue extracting quantities in the current chat. Switch to preparation mode.
+
+## Non-goals
+
+This skill does not:
+
+```text
+make final billable quantity claims
+replace Oleksii review
+trust mixed vector drawings blindly
+publish private drawings or quantities
+require fully autonomous runner execution
+merge or deploy runtime changes
+```
+
+## Roles
+
+```text
+Oleksii = owner, final reviewer, scope selector, ambiguity resolver.
+ChatGPT/Skeleton = architect, source-priority controller, packet framer, review synthesizer, privacy gate.
+Runner = private/local executor for parsing, extraction scripts, table/workbook creation, optional Gemini adapter call.
+Gemini = stateless second-brain reviewer for conflicts, consistency, suspicious rows, missing evidence, and assumptions.
+Public GitHub = reusable public-safe protocols only.
+Private Drive/local runner = real source set and real outputs.
+```
+
+## Semi-automatic operating principle
+
+```text
+Automate extraction candidates.
+Do not automate trust.
+```
+
+Every produced number must keep source references, confidence, and review status.
+
+## Required user scope before extraction
+
+Do not begin real extraction until the user has provided or confirmed:
+
+```text
+quantity target: room areas, wall areas, floor, ceiling, openings, façade, height, volume, etc.
+scope: floor, zone, room group, façade, or object slice
+source folder/location: private Drive folder or local Runner path
+Gemini privacy level: PUBLIC_SAFE / STRICT_REDACTION / INTERNAL_BHK / no Gemini
+output expectation: CSV/XLSX/report/review-only
+```
+
+If source folder and source priority are already confirmed in private handoff, do not ask again; load the handoff.
+
+## Source priority handling
+
+Use generic source priority from `construction_takeoff_from_drawings.md` unless a private handoff provides an object-specific priority.
+
+When object-specific priority exists, follow it.
+
+Common mixed-source rule:
+
+```text
+PDF may be the current-version selector and visual truth layer.
+DWG/DXF may be the precise measurement/vector layer.
+DWG/DXF can contain mixed adjacent versions and must be version-matched against PDF before use.
+```
+
+Required extraction metadata for each quantity row:
+
+```text
+source_pdf_ref
+source_vector_ref
+version_match_status
+measurement_source
+confidence
+review_item_id
+```
+
+Recommended statuses:
+
+```text
+PDF_CURRENT_VARIANT
+VECTOR_MEASURED_MATCHED_TO_PDF
+VECTOR_CANDIDATE_NEEDS_VERSION_MATCH
+VECTOR_CONFLICT_WITH_PDF
+MIXED_VECTOR_GEOMETRY_REVIEW
+```
+
+## Manual checkpoints
+
+Semi-automatic work must pause at these checkpoints when uncertain:
+
+```text
+1. source inventory complete
+2. scope and target confirmed
+3. legend/source-priority confirmed
+4. first extraction candidate produced
+5. validation gates summarized
+6. Gemini packet preview ready, if Gemini is used
+7. Gemini output validated
+8. final review items ready for Oleksii
+```
+
+A checkpoint can be skipped only when the user explicitly asks for a faster rough pass and privacy boundaries are still respected.
+
+## Runner mode choices
+
+Use one of these modes:
+
+```text
+manual_runner_shell = user or operator runs private commands manually and returns outputs
+reviewed_runner_route = a source-controlled runner route exists and can safely run the task
+no_runner = ChatGPT only prepares packet/checklist, no extraction
+```
+
+Do not claim live runner pickup unless the route is verified.
+
+If the live runner is not generic for the task, prefer `manual_runner_shell` for the first pilot.
+
+## Gemini use conditions
+
+Gemini may be used only after:
+
+```text
+Runner-side Gemini bridge is verified or explicitly approved for the private environment
+privacy level is chosen
+packet contains only the minimum needed review surface
+adapter output validation is fail-closed
+```
+
+Gemini packet should include:
+
+```text
+confirmed source-priority rules
+source inventory summary
+quantity table summaries
+validation gate results
+crosscheck matrix summary
+review item candidates
+exact questions
+forbidden actions
+```
+
+Gemini must not receive unnecessary raw private drawings if summaries are enough.
+
+## Gemini review question template
+
+```text
+1. Are PDF-current-state and vector-measurement sources applied consistently?
+2. Which rows likely mix different vector versions or states?
+3. Which room area or wall area values look inconsistent with perimeter/height/source references?
+4. Which rows require Oleksii review before being used?
+5. Are assumptions clearly separated from extracted facts?
+6. Are conflicts represented in REVIEW_ITEMS instead of being silently resolved?
+7. Are confidence/status values internally consistent?
+```
+
+## Output contract
+
+The private runner should produce, as relevant:
+
+```text
+source_inventory.csv
+legend_dictionary.csv
+scale_anchors.csv
+rooms_prelim.csv
+walls_prelim.csv
+openings_prelim.csv
+height_measurements_prelim.csv
+crosscheck_matrix.csv
+review_items.csv
+assumptions.csv
+workbook.xlsx
+runner_log.md
+gemini_intake_packet.json optional
+gemini_auditor_output.json optional
+```
+
+Public reports may mention only:
+
+```text
+pilot prepared / run completed / blocked
+artifact types created
+validation gate categories
+Gemini used / not used / blocked
+next safe step
+```
+
+Public reports must not include real source folder links, object names, addresses, client data, drawings, extracted rows, quantities, or private assumptions.
+
+## Stop/resume rule
+
+If the user says stop, stop real extraction immediately.
+
+Then record:
+
+```text
+what was started
+what was not run
+current private source folder status
+current scope status
+next safe branch/task
+```
+
+Do not continue analysis in the stopped chat unless the user explicitly resumes.
+
+## Ready-to-run checklist
+
+Before a real pilot run, verify:
+
+```text
+private source folder confirmed
+quantity scope confirmed
+floor/zone confirmed
+source-priority rule confirmed
+output folder confirmed or created privately
+Gemini level confirmed or Gemini disabled
+runner mode chosen
+no public GitHub leakage risk
+```
+
+## First-pilot recommendation
+
+For the first run, prefer:
+
+```text
+one floor or one bounded zone
+room areas first
+wall areas by room second
+openings as review layer, not final subtraction unless source is clear
+PDF + matching DWG/DXF + legend/source-priority check
+Gemini review only after preliminary tables exist
+```
+
+## Failure handling
+
+If parsing fails:
+
+```text
+write FAILED_PARSE in source inventory
+keep the source as visual/control evidence if useful
+create REVIEW_ITEMS row
+continue with other sources if safe
+```
+
+If source conflict occurs:
+
+```text
+never silently choose one source
+record PDF/vector conflict
+assign review_item_id
+ask Oleksii only when the conflict blocks the target quantity
+```
+
+## Promotion criteria
+
+This skill can move from `LIKELY_NEEDS_REVIEW` to `CONFIRMED_WORKFLOW` only after:
+
+```text
+one private pilot scope is completed
+room/wall quantities are produced with source refs and confidence
+Gemini review, if used, stays evidence-only
+Oleksii reviews the output
+lessons learned are folded back into this skill or the main takeoff skill
+```


### PR DESCRIPTION
## Summary

Implements #108 as a public-safe Skeleton skill/protocol for semi-automatic Construction Takeoff / Aufmaß with optional Gemini review.

Adds:
- `semi_automatic_construction_takeoff_with_gemini.md`
- `semi_automatic_construction_takeoff_gemini_task_template.md`

The workflow separates:
- Oleksii scope/review decisions;
- ChatGPT/Skeleton coordination and privacy gate;
- Runner private/local extraction;
- Gemini second-brain review as evidence only.

## Safety

- Docs/template only.
- No real drawing links, object names, addresses, client data, quantities, or private folder data.
- No runtime/app changes.
- No live Gemini call.
- No runner execution.
- No secrets.

## Validation

Not run in ChatGPT connector. Expected check:

```bash
python -m tools.skeleton_core.cli validate-state
```

## Notes

This PR intentionally stops real extraction in the current chat and prepares the next branch/pilot workflow.

Closes #108