### PR TITLE
feat(takeoff): add parser pilot scaffold

### DIFF
--- a/tests/construction_takeoff/test_cli.py
+++ b/tests/construction_takeoff/test_cli.py
@@ -1,0 +1,57 @@
+import csv
+import json
+from pathlib import Path
+
+from tools.construction_takeoff.cli import main
+
+
+def test_pilot_cli_writes_expected_artifacts(tmp_path: Path) -> None:
+    source_dir = tmp_path / "sources"
+    output_dir = tmp_path / "out"
+    source_dir.mkdir()
+    (source_dir / "Consum Quartier Erdgeschoss.pdf").write_text("not a real pdf", encoding="utf-8")
+    (source_dir / "Consum Quartier Erdgeschoss.dxf").write_text("not a real dxf", encoding="utf-8")
+    (source_dir / "Consum Quartier LEGENDE.pdf").write_text("legend", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "pilot",
+            "--source-dir",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--scope",
+            "erdgeschoss",
+            "--targets",
+            "rooms,walls_by_room",
+            "--gemini-packet-only",
+            "--notebooklm-handoff",
+        ]
+    )
+
+    assert exit_code == 0
+    expected = [
+        "source_inventory.csv",
+        "pdf_text_blocks.csv",
+        "dxf_layers.csv",
+        "dxf_entities_summary.csv",
+        "review_items.csv",
+        "workbook_manifest.csv",
+        "gemini_intake_packet.json",
+        "notebooklm_handoff.md",
+        "runner_log.md",
+    ]
+    for filename in expected:
+        assert (output_dir / filename).exists()
+
+    with (output_dir / "source_inventory.csv").open(encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) == 3
+
+    packet = json.loads((output_dir / "gemini_intake_packet.json").read_text(encoding="utf-8"))
+    assert packet["schema_version"] == "gemini_adapter.input.v1"
+    assert packet["mode"] == "mock"
+    assert "NotebookLM" in packet["confirmed_canon"]
+
+    handoff = (output_dir / "notebooklm_handoff.md").read_text(encoding="utf-8")
+    assert "NotebookLM is not the parser" in handoff

--- a/tests/construction_takeoff/test_source_inventory.py
+++ b/tests/construction_takeoff/test_source_inventory.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from tools.construction_takeoff.source_inventory import build_source_inventory
+
+
+def test_build_source_inventory_classifies_common_sources(tmp_path: Path) -> None:
+    (tmp_path / "Consum Quartier Erdgeschoss.pdf").write_text("pdf", encoding="utf-8")
+    (tmp_path / "Consum Quartier Erdgeschoss.dxf").write_text("dxf", encoding="utf-8")
+    (tmp_path / "Consum Quartier LEGENDE.pdf").write_text("legend", encoding="utf-8")
+    (tmp_path / "Scans").mkdir()
+
+    records = build_source_inventory(tmp_path, "erdgeschoss", "pdf_current_vector_measurement")
+
+    by_name = {record.private_source_ref: record for record in records}
+    assert by_name["Consum Quartier Erdgeschoss.pdf"].source_type == "pdf"
+    assert by_name["Consum Quartier Erdgeschoss.pdf"].priority_for_this_object == (
+        "pdf_current_variant_selector"
+    )
+    assert by_name["Consum Quartier Erdgeschoss.dxf"].source_type == "dxf"
+    assert by_name["Consum Quartier Erdgeschoss.dxf"].priority_for_this_object == (
+        "vector_measurement_after_pdf_match"
+    )
+    assert by_name["Consum Quartier LEGENDE.pdf"].source_role == "legend_dictionary"
+    assert by_name["Scans"].source_type == "folder"

--- a/tools/construction_takeoff/__init__.py
+++ b/tools/construction_takeoff/__init__.py
@@ -1,0 +1,5 @@
+"""Construction Takeoff parser pilot package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/tools/construction_takeoff/cli.py
+++ b/tools/construction_takeoff/cli.py
@@ -1,0 +1,160 @@
+"""Command line entrypoint for the Construction Takeoff parser pilot."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+from .gemini_packet import build_gemini_packet, write_gemini_packet
+from .notebooklm_handoff import build_notebooklm_handoff, write_notebooklm_handoff
+from .schemas import ArtifactSet, PilotConfig, ReviewItem
+from .source_inventory import build_source_inventory, write_source_inventory
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Construction Takeoff parser pilot")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    pilot = subparsers.add_parser("pilot", help="Run the initial private/local pilot scaffold")
+    pilot.add_argument("--source-dir", required=True, type=Path)
+    pilot.add_argument("--output-dir", required=True, type=Path)
+    pilot.add_argument("--scope", required=True)
+    pilot.add_argument("--targets", default="rooms,walls_by_room")
+    pilot.add_argument("--source-priority", default="pdf_current_vector_measurement")
+    pilot.add_argument("--gemini-packet-only", action="store_true")
+    pilot.add_argument("--notebooklm-handoff", action="store_true")
+    return parser
+
+
+def run_pilot(config: PilotConfig) -> ArtifactSet:
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    artifacts = ArtifactSet(
+        source_inventory_csv=config.output_dir / "source_inventory.csv",
+        review_items_csv=config.output_dir / "review_items.csv",
+        gemini_intake_packet_json=config.output_dir / "gemini_intake_packet.json",
+        notebooklm_handoff_md=config.output_dir / "notebooklm_handoff.md",
+        runner_log_md=config.output_dir / "runner_log.md",
+    )
+
+    records = build_source_inventory(config.source_dir, config.scope, config.source_priority)
+    write_source_inventory(records, artifacts.source_inventory_csv)
+
+    review_items = _initial_review_items(records)
+    _write_review_items(review_items, artifacts.review_items_csv)
+
+    packet = build_gemini_packet(config, records)
+    write_gemini_packet(packet, artifacts.gemini_intake_packet_json)
+
+    handoff = build_notebooklm_handoff(config, records)
+    write_notebooklm_handoff(handoff, artifacts.notebooklm_handoff_md)
+
+    _write_runner_log(config, artifacts, len(records), len(review_items))
+    return artifacts
+
+
+def _initial_review_items(records: list) -> list[ReviewItem]:
+    items: list[ReviewItem] = []
+    has_pdf = any(record.source_type == "pdf" for record in records)
+    has_vector = any(record.source_type in {"dxf", "dwg"} for record in records)
+    has_legend = any("legende" in record.private_source_ref.lower() for record in records)
+
+    if not has_pdf:
+        items.append(
+            ReviewItem(
+                review_item_id="RI-0001",
+                severity="blocker",
+                entity_type="source_set",
+                entity_id="all",
+                issue="No PDF source found for current visual/version selection.",
+                recommended_action="Add or select the current PDF drawing before extraction.",
+            )
+        )
+    if not has_vector:
+        items.append(
+            ReviewItem(
+                review_item_id="RI-0002",
+                severity="warning",
+                entity_type="source_set",
+                entity_id="all",
+                issue="No DXF/DWG vector source found for precise measurement.",
+                recommended_action="Use PDF printed values only as preliminary or add vector sources.",
+            )
+        )
+    if not has_legend:
+        items.append(
+            ReviewItem(
+                review_item_id="RI-0003",
+                severity="warning",
+                entity_type="source_set",
+                entity_id="all",
+                issue="No legend source detected.",
+                recommended_action="Confirm legend/symbol interpretation before room and wall extraction.",
+            )
+        )
+    return items
+
+
+def _write_review_items(items: list[ReviewItem], output_path: Path) -> None:
+    fieldnames = list(ReviewItem.__dataclass_fields__.keys())
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for item in items:
+            writer.writerow(item.to_row())
+
+
+def _write_runner_log(
+    config: PilotConfig,
+    artifacts: ArtifactSet,
+    source_count: int,
+    review_item_count: int,
+) -> None:
+    artifacts.runner_log_md.write_text(
+        "\n".join(
+            [
+                "# Construction Takeoff Runner Log",
+                "",
+                f"Scope: {config.scope}",
+                f"Targets: {', '.join(config.targets)}",
+                f"Source priority: {config.source_priority}",
+                f"Source count: {source_count}",
+                f"Initial review items: {review_item_count}",
+                "",
+                "Status: INITIAL_SCAFFOLD_COMPLETE",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "pilot":
+        config = PilotConfig(
+            source_dir=args.source_dir,
+            output_dir=args.output_dir,
+            scope=args.scope,
+            targets=tuple(part.strip() for part in args.targets.split(",") if part.strip()),
+            source_priority=args.source_priority,
+            gemini_packet_only=args.gemini_packet_only,
+            notebooklm_handoff=args.notebooklm_handoff,
+        )
+        artifacts = run_pilot(config)
+        print(f"source_inventory={artifacts.source_inventory_csv}")
+        print(f"review_items={artifacts.review_items_csv}")
+        print(f"gemini_packet={artifacts.gemini_intake_packet_json}")
+        print(f"notebooklm_handoff={artifacts.notebooklm_handoff_md}")
+        print(f"runner_log={artifacts.runner_log_md}")
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/construction_takeoff/cli.py
+++ b/tools/construction_takeoff/cli.py
@@ -6,10 +6,13 @@ import argparse
 import csv
 from pathlib import Path
 
+from .dxf_probe import probe_dxf, write_dxf_entities_summary, write_dxf_layers
 from .gemini_packet import build_gemini_packet, write_gemini_packet
 from .notebooklm_handoff import build_notebooklm_handoff, write_notebooklm_handoff
+from .pdf_extract import extract_pdf_text_blocks, write_pdf_text_blocks
 from .schemas import ArtifactSet, PilotConfig, ReviewItem
 from .source_inventory import build_source_inventory, write_source_inventory
+from .workbook_export import write_workbook_manifest
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -32,7 +35,11 @@ def run_pilot(config: PilotConfig) -> ArtifactSet:
 
     artifacts = ArtifactSet(
         source_inventory_csv=config.output_dir / "source_inventory.csv",
+        pdf_text_blocks_csv=config.output_dir / "pdf_text_blocks.csv",
+        dxf_layers_csv=config.output_dir / "dxf_layers.csv",
+        dxf_entities_summary_csv=config.output_dir / "dxf_entities_summary.csv",
         review_items_csv=config.output_dir / "review_items.csv",
+        workbook_manifest_csv=config.output_dir / "workbook_manifest.csv",
         gemini_intake_packet_json=config.output_dir / "gemini_intake_packet.json",
         notebooklm_handoff_md=config.output_dir / "notebooklm_handoff.md",
         runner_log_md=config.output_dir / "runner_log.md",
@@ -40,6 +47,22 @@ def run_pilot(config: PilotConfig) -> ArtifactSet:
 
     records = build_source_inventory(config.source_dir, config.scope, config.source_priority)
     write_source_inventory(records, artifacts.source_inventory_csv)
+
+    pdf_rows = []
+    dxf_layer_rows = []
+    dxf_entity_rows = []
+    for record in records:
+        source_path = config.source_dir / record.private_source_ref
+        if record.source_type == "pdf" and source_path.is_file():
+            pdf_rows.extend(extract_pdf_text_blocks(source_path))
+        if record.source_type == "dxf" and source_path.is_file():
+            layer_rows, entity_rows = probe_dxf(source_path)
+            dxf_layer_rows.extend(layer_rows)
+            dxf_entity_rows.extend(entity_rows)
+
+    write_pdf_text_blocks(pdf_rows, artifacts.pdf_text_blocks_csv)
+    write_dxf_layers(dxf_layer_rows, artifacts.dxf_layers_csv)
+    write_dxf_entities_summary(dxf_entity_rows, artifacts.dxf_entities_summary_csv)
 
     review_items = _initial_review_items(records)
     _write_review_items(review_items, artifacts.review_items_csv)
@@ -49,6 +72,20 @@ def run_pilot(config: PilotConfig) -> ArtifactSet:
 
     handoff = build_notebooklm_handoff(config, records)
     write_notebooklm_handoff(handoff, artifacts.notebooklm_handoff_md)
+
+    write_workbook_manifest(
+        [
+            artifacts.source_inventory_csv,
+            artifacts.pdf_text_blocks_csv,
+            artifacts.dxf_layers_csv,
+            artifacts.dxf_entities_summary_csv,
+            artifacts.review_items_csv,
+            artifacts.gemini_intake_packet_json,
+            artifacts.notebooklm_handoff_md,
+            artifacts.runner_log_md,
+        ],
+        artifacts.workbook_manifest_csv,
+    )
 
     _write_runner_log(config, artifacts, len(records), len(review_items))
     return artifacts
@@ -146,7 +183,11 @@ def main(argv: list[str] | None = None) -> int:
         )
         artifacts = run_pilot(config)
         print(f"source_inventory={artifacts.source_inventory_csv}")
+        print(f"pdf_text_blocks={artifacts.pdf_text_blocks_csv}")
+        print(f"dxf_layers={artifacts.dxf_layers_csv}")
+        print(f"dxf_entities_summary={artifacts.dxf_entities_summary_csv}")
         print(f"review_items={artifacts.review_items_csv}")
+        print(f"workbook_manifest={artifacts.workbook_manifest_csv}")
         print(f"gemini_packet={artifacts.gemini_intake_packet_json}")
         print(f"notebooklm_handoff={artifacts.notebooklm_handoff_md}")
         print(f"runner_log={artifacts.runner_log_md}")

--- a/tools/construction_takeoff/dxf_probe.py
+++ b/tools/construction_takeoff/dxf_probe.py
@@ -1,0 +1,102 @@
+"""DXF probe adapter for the Construction Takeoff pilot.
+
+ezdxf is optional. Without it, the adapter records unsupported rows so the
+private Runner can install richer dependencies later without breaking public CI.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+LAYER_FIELDS = ["source_ref", "layer", "status", "notes"]
+ENTITY_FIELDS = ["source_ref", "entity_type", "layer", "count", "status", "notes"]
+
+
+def probe_dxf(dxf_path: Path) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    try:
+        import ezdxf  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        return (
+            [
+                {
+                    "source_ref": dxf_path.name,
+                    "layer": "",
+                    "status": "unsupported",
+                    "notes": "ezdxf is not installed in this environment.",
+                }
+            ],
+            [
+                {
+                    "source_ref": dxf_path.name,
+                    "entity_type": "",
+                    "layer": "",
+                    "count": "0",
+                    "status": "unsupported",
+                    "notes": "ezdxf is not installed in this environment.",
+                }
+            ],
+        )
+
+    try:
+        document: Any = ezdxf.readfile(dxf_path)
+        layer_rows = [
+            {"source_ref": dxf_path.name, "layer": layer.dxf.name, "status": "parsed", "notes": ""}
+            for layer in document.layers
+        ]
+        counts: dict[tuple[str, str], int] = {}
+        for entity in document.modelspace():
+            entity_type = entity.dxftype()
+            layer = getattr(entity.dxf, "layer", "")
+            key = (entity_type, layer)
+            counts[key] = counts.get(key, 0) + 1
+        entity_rows = [
+            {
+                "source_ref": dxf_path.name,
+                "entity_type": entity_type,
+                "layer": layer,
+                "count": str(count),
+                "status": "parsed",
+                "notes": "",
+            }
+            for (entity_type, layer), count in sorted(counts.items())
+        ]
+    except Exception as exc:  # pragma: no cover - depends on parser internals
+        return (
+            [
+                {
+                    "source_ref": dxf_path.name,
+                    "layer": "",
+                    "status": "failed_parse",
+                    "notes": f"{type(exc).__name__}: {exc}",
+                }
+            ],
+            [
+                {
+                    "source_ref": dxf_path.name,
+                    "entity_type": "",
+                    "layer": "",
+                    "count": "0",
+                    "status": "failed_parse",
+                    "notes": f"{type(exc).__name__}: {exc}",
+                }
+            ],
+        )
+    return layer_rows, entity_rows
+
+
+def write_dxf_layers(rows: list[dict[str, str]], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=LAYER_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_dxf_entities_summary(rows: list[dict[str, str]], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=ENTITY_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)

--- a/tools/construction_takeoff/gemini_packet.py
+++ b/tools/construction_takeoff/gemini_packet.py
@@ -1,0 +1,57 @@
+"""Gemini auditor packet builder for Construction Takeoff pilots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .schemas import PilotConfig, SourceRecord
+
+
+def build_gemini_packet(config: PilotConfig, records: list[SourceRecord]) -> dict[str, object]:
+    return {
+        "schema_version": "gemini_adapter.input.v1",
+        "packet_id": f"construction-takeoff-{config.scope}",
+        "objective": "Review preliminary Construction Takeoff source inventory and identify risks before extraction.",
+        "mode": "mock",
+        "privacy_level": "STRICT_REDACTION",
+        "confirmed_canon": (
+            "Runner/Antigravity/Codex parse private files locally. Gemini is a stateless "
+            "second-brain auditor only. NotebookLM is private evidence memory/result-reading "
+            "layer only. PDF selects current visual state; vector files provide measurements "
+            "only after matching to the current PDF variant."
+        ),
+        "evidence": {
+            "scope": config.scope,
+            "targets": list(config.targets),
+            "source_priority": config.source_priority,
+            "source_counts": _source_counts(records),
+            "records": [record.to_row() for record in records],
+        },
+        "draft_artifact": "source_inventory.csv and initial review_items.csv placeholders",
+        "exact_questions": [
+            "Are source roles and priorities internally consistent?",
+            "Which source types are missing for the requested targets?",
+            "Which files should be reviewed before room and wall area extraction?",
+            "Which risks should be represented in REVIEW_ITEMS before proceeding?",
+        ],
+        "forbidden_actions": [
+            "Do not execute commands.",
+            "Do not claim final quantities.",
+            "Do not request secrets or credentials.",
+            "Do not treat Gemini as geometry source of record.",
+            "Do not publish private drawing data.",
+        ],
+    }
+
+
+def write_gemini_packet(packet: dict[str, object], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(packet, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _source_counts(records: list[SourceRecord]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for record in records:
+        counts[record.source_type] = counts.get(record.source_type, 0) + 1
+    return counts

--- a/tools/construction_takeoff/notebooklm_handoff.py
+++ b/tools/construction_takeoff/notebooklm_handoff.py
@@ -1,0 +1,71 @@
+"""NotebookLM handoff builder for private Construction Takeoff review."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .schemas import PilotConfig, SourceRecord
+
+
+def build_notebooklm_handoff(config: PilotConfig, records: list[SourceRecord]) -> str:
+    lines = [
+        "# Construction Takeoff NotebookLM Handoff",
+        "",
+        "Status: INITIAL_SOURCE_INVENTORY",
+        "Privacy: PRIVATE_REVIEW_CONTEXT",
+        "",
+        "## Purpose",
+        "",
+        "Load this handoff into NotebookLM together with selected private source PDFs/reports/results ",
+        "so it can act as a private evidence memory and result-reading/Q&A layer.",
+        "",
+        "NotebookLM is not the parser, not the executor, and not the final quantity authority.",
+        "",
+        "## Pilot scope",
+        "",
+        f"- Scope: `{config.scope}`",
+        f"- Targets: `{', '.join(config.targets)}`",
+        f"- Source priority: `{config.source_priority}`",
+        "",
+        "## Source priority rule",
+        "",
+        "PDF selects the current visual/version state. DWG/DXF provide precise vector measurements ",
+        "only after the relevant candidate geometry has been matched to the PDF current variant.",
+        "",
+        "## Source inventory summary",
+        "",
+    ]
+
+    for record in records:
+        lines.append(
+            "- "
+            f"{record.source_id}: {record.private_source_ref} | "
+            f"type={record.source_type} | scope={record.floor_or_scope} | "
+            f"role={record.source_role} | priority={record.priority_for_this_object} | "
+            f"status={record.parse_status}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Questions for NotebookLM review",
+            "",
+            "1. Which documents look essential for the requested quantity target?",
+            "2. Which sources appear to be current visual state versus measurement candidates?",
+            "3. Which source conflicts should be checked before producing room/wall quantities?",
+            "4. Which assumptions must remain open for Oleksii review?",
+            "",
+            "## Forbidden interpretations",
+            "",
+            "- Do not treat this handoff as final quantity output.",
+            "- Do not treat NotebookLM answers as final authority.",
+            "- Do not publish private source names or results outside the private review context.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_notebooklm_handoff(content: str, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")

--- a/tools/construction_takeoff/pdf_extract.py
+++ b/tools/construction_takeoff/pdf_extract.py
@@ -1,0 +1,80 @@
+"""PDF text extraction probe for the Construction Takeoff pilot.
+
+PyMuPDF is optional. When it is absent, the adapter records an unsupported row
+instead of failing the whole pilot.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+PDF_FIELDS = ["source_ref", "page", "block_index", "text", "status", "notes"]
+
+
+def extract_pdf_text_blocks(pdf_path: Path) -> list[dict[str, str]]:
+    try:
+        import fitz  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        return [
+            {
+                "source_ref": pdf_path.name,
+                "page": "",
+                "block_index": "",
+                "text": "",
+                "status": "unsupported",
+                "notes": "PyMuPDF is not installed in this environment.",
+            }
+        ]
+
+    rows: list[dict[str, str]] = []
+    try:
+        document: Any = fitz.open(pdf_path)
+        for page_index, page in enumerate(document, start=1):
+            text = page.get_text("text") or ""
+            for block_index, block_text in enumerate(_split_blocks(text), start=1):
+                rows.append(
+                    {
+                        "source_ref": pdf_path.name,
+                        "page": str(page_index),
+                        "block_index": str(block_index),
+                        "text": block_text,
+                        "status": "parsed",
+                        "notes": "",
+                    }
+                )
+    except Exception as exc:  # pragma: no cover - depends on parser internals
+        return [
+            {
+                "source_ref": pdf_path.name,
+                "page": "",
+                "block_index": "",
+                "text": "",
+                "status": "failed_parse",
+                "notes": f"{type(exc).__name__}: {exc}",
+            }
+        ]
+    return rows or [
+        {
+            "source_ref": pdf_path.name,
+            "page": "",
+            "block_index": "",
+            "text": "",
+            "status": "parsed",
+            "notes": "No text blocks extracted.",
+        }
+    ]
+
+
+def write_pdf_text_blocks(rows: list[dict[str, str]], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=PDF_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _split_blocks(text: str) -> list[str]:
+    blocks = [line.strip() for line in text.splitlines() if line.strip()]
+    return blocks[:500]

--- a/tools/construction_takeoff/schemas.py
+++ b/tools/construction_takeoff/schemas.py
@@ -1,0 +1,65 @@
+"""Data schemas for the Construction Takeoff parser pilot.
+
+The pilot keeps all real source paths private. Public reports should contain only
+artifact names, statuses, and review categories.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+SourceType = Literal["pdf", "dxf", "dwg", "pln", "scan", "folder", "other"]
+ParseStatus = Literal["pending", "parsed", "unsupported", "failed_parse", "metadata_only"]
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    source_id: str
+    private_source_ref: str
+    source_type: SourceType
+    file_format: str
+    floor_or_scope: str
+    source_role: str
+    priority_for_this_object: str
+    parse_status: ParseStatus
+    notes: str = ""
+
+    def to_row(self) -> dict[str, str]:
+        return {key: str(value) for key, value in asdict(self).items()}
+
+
+@dataclass(frozen=True)
+class ReviewItem:
+    review_item_id: str
+    severity: Literal["info", "warning", "blocker"]
+    entity_type: str
+    entity_id: str
+    issue: str
+    recommended_action: str
+    status: str = "open"
+    notes: str = ""
+
+    def to_row(self) -> dict[str, str]:
+        return {key: str(value) for key, value in asdict(self).items()}
+
+
+@dataclass(frozen=True)
+class PilotConfig:
+    source_dir: Path
+    output_dir: Path
+    scope: str
+    targets: tuple[str, ...]
+    source_priority: str
+    gemini_packet_only: bool
+    notebooklm_handoff: bool
+
+
+@dataclass(frozen=True)
+class ArtifactSet:
+    source_inventory_csv: Path
+    review_items_csv: Path
+    gemini_intake_packet_json: Path
+    notebooklm_handoff_md: Path
+    runner_log_md: Path

--- a/tools/construction_takeoff/schemas.py
+++ b/tools/construction_takeoff/schemas.py
@@ -59,7 +59,11 @@ class PilotConfig:
 @dataclass(frozen=True)
 class ArtifactSet:
     source_inventory_csv: Path
+    pdf_text_blocks_csv: Path
+    dxf_layers_csv: Path
+    dxf_entities_summary_csv: Path
     review_items_csv: Path
+    workbook_manifest_csv: Path
     gemini_intake_packet_json: Path
     notebooklm_handoff_md: Path
     runner_log_md: Path

--- a/tools/construction_takeoff/source_inventory.py
+++ b/tools/construction_takeoff/source_inventory.py
@@ -1,0 +1,107 @@
+"""Source inventory builder for private Construction Takeoff pilots."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from .schemas import SourceRecord
+
+
+SOURCE_TYPE_BY_SUFFIX = {
+    ".pdf": "pdf",
+    ".dxf": "dxf",
+    ".dwg": "dwg",
+    ".pln": "pln",
+    ".jpg": "scan",
+    ".jpeg": "scan",
+    ".png": "scan",
+    ".webp": "scan",
+}
+
+
+def classify_source(path: Path) -> str:
+    if path.is_dir():
+        return "folder"
+    return SOURCE_TYPE_BY_SUFFIX.get(path.suffix.lower(), "other")
+
+
+def infer_floor_or_scope(name: str, default_scope: str) -> str:
+    lowered = name.lower()
+    floor_markers = {
+        "kellergeschoss": "kellergeschoss",
+        "erdgeschoss": "erdgeschoss",
+        "obergeschoss 1": "obergeschoss_1",
+        "obergeschoss 2": "obergeschoss_2",
+        "obergeschoss 3": "obergeschoss_3",
+        "dachgeschoss": "dachgeschoss",
+    }
+    for marker, value in floor_markers.items():
+        if marker in lowered:
+            return value
+    return default_scope
+
+
+def source_role_for(source_type: str, name: str) -> str:
+    lowered = name.lower()
+    if "legende" in lowered:
+        return "legend_dictionary"
+    if source_type == "pdf":
+        return "current_visual_version_or_control"
+    if source_type in {"dxf", "dwg"}:
+        return "vector_measurement_candidate"
+    if source_type == "pln":
+        return "upstream_archicad_source_metadata_only"
+    if source_type == "scan":
+        return "field_or_visual_check"
+    if source_type == "folder":
+        return "supporting_source_folder"
+    return "context_or_unclassified"
+
+
+def priority_for(source_type: str, name: str, source_priority: str) -> str:
+    lowered = name.lower()
+    if "legende" in lowered:
+        return "mandatory_interpretation_layer"
+    if source_priority == "pdf_current_vector_measurement":
+        if source_type == "pdf":
+            return "pdf_current_variant_selector"
+        if source_type in {"dxf", "dwg"}:
+            return "vector_measurement_after_pdf_match"
+    return "standard_priority"
+
+
+def build_source_inventory(source_dir: Path, scope: str, source_priority: str) -> list[SourceRecord]:
+    if not source_dir.exists():
+        raise FileNotFoundError(f"source directory does not exist: {source_dir}")
+    if not source_dir.is_dir():
+        raise NotADirectoryError(f"source path is not a directory: {source_dir}")
+
+    records: list[SourceRecord] = []
+    for index, path in enumerate(sorted(source_dir.iterdir(), key=lambda item: item.name.lower()), start=1):
+        source_type = classify_source(path)
+        parse_status = "pending" if source_type in {"pdf", "dxf", "dwg"} else "metadata_only"
+        records.append(
+            SourceRecord(
+                source_id=f"SRC-{index:04d}",
+                private_source_ref=path.name,
+                source_type=source_type,  # type: ignore[arg-type]
+                file_format=path.suffix.lower().lstrip(".") if path.suffix else "folder",
+                floor_or_scope=infer_floor_or_scope(path.name, scope),
+                source_role=source_role_for(source_type, path.name),
+                priority_for_this_object=priority_for(source_type, path.name, source_priority),
+                parse_status=parse_status,  # type: ignore[arg-type]
+                notes="",
+            )
+        )
+    return records
+
+
+def write_source_inventory(records: list[SourceRecord], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(SourceRecord.__dataclass_fields__.keys())
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for record in records:
+            writer.writerow(record.to_row())

--- a/tools/construction_takeoff/workbook_export.py
+++ b/tools/construction_takeoff/workbook_export.py
@@ -1,0 +1,25 @@
+"""Workbook manifest exporter.
+
+The v0 pilot writes a CSV manifest instead of requiring openpyxl in public CI.
+Runner can later add XLSX export when optional dependencies are installed.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+def write_workbook_manifest(artifact_paths: list[Path], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["artifact", "exists", "notes"])
+        writer.writeheader()
+        for path in artifact_paths:
+            writer.writerow(
+                {
+                    "artifact": path.name,
+                    "exists": "yes" if path.exists() else "no",
+                    "notes": "v0 manifest; XLSX export is a later Runner adapter",
+                }
+            )


### PR DESCRIPTION
## Summary

Implements the first executable scaffold for #111.

Adds a real Python package under `tools/construction_takeoff/`:
- CLI entrypoint: `python -m tools.construction_takeoff.cli pilot ...`
- source inventory builder
- optional PDF probe adapter with graceful fallback when PyMuPDF is absent
- optional DXF probe adapter with graceful fallback when ezdxf is absent
- Gemini intake packet builder
- NotebookLM handoff builder
- workbook manifest exporter
- synthetic tests

## Architecture

Parsing/execution belongs to Runner / Antigravity / Codex.
Gemini is second-brain review only.
NotebookLM is private evidence memory and result-reading/Q&A only.
ChatGPT/Skeleton remains the control plane and privacy gate.

## Safety

- No private drawing links, object names, addresses, client data, or quantities.
- No secrets or `.env` values.
- No live Gemini call.
- No real Runner execution.
- Heavy parser libraries are optional so CI can validate the scaffold without private runtime dependencies.

## CLI example

```bash
python -m tools.construction_takeoff.cli pilot \
  --source-dir <PRIVATE_LOCAL_SOURCE_DIR> \
  --output-dir <PRIVATE_LOCAL_OUTPUT_DIR> \
  --scope erdgeschoss \
  --targets rooms,walls_by_room \
  --source-priority pdf_current_vector_measurement \
  --gemini-packet-only \
  --notebooklm-handoff
```

## Outputs

```text
source_inventory.csv
pdf_text_blocks.csv
dxf_layers.csv
dxf_entities_summary.csv
review_items.csv
workbook_manifest.csv
gemini_intake_packet.json
notebooklm_handoff.md
runner_log.md
```

## Validation

Expected CI:

```bash
python -m pytest -q
python -m ruff check app/ tests/ tools/
python -m black --check app/ tests/ tools/
```

## Next after this PR

Add room-area candidate extraction and wall-area-by-room candidate tables after this scaffold is green.