### PR TITLE
feat(construction-takeoff): add v0 parser scaffold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+takeoff = [
+    "ezdxf>=1.3.0",
+    "PyMuPDF>=1.24.0",
+    "pandas>=2.2.0",
+    "openpyxl>=3.1.0",
+    "shapely>=2.0.0",
+]
 dev = [
     "pytest>=8.2.0",
     "pytest-asyncio>=0.23.0",

--- a/tests/construction_takeoff/test_cli.py
+++ b/tests/construction_takeoff/test_cli.py
@@ -9,9 +9,9 @@ def test_pilot_cli_writes_expected_artifacts(tmp_path: Path) -> None:
     source_dir = tmp_path / "sources"
     output_dir = tmp_path / "out"
     source_dir.mkdir()
-    (source_dir / "Consum Quartier Erdgeschoss.pdf").write_text("not a real pdf", encoding="utf-8")
-    (source_dir / "Consum Quartier Erdgeschoss.dxf").write_text("not a real dxf", encoding="utf-8")
-    (source_dir / "Consum Quartier LEGENDE.pdf").write_text("legend", encoding="utf-8")
+    (source_dir / "Synthetic Floor Plan.pdf").write_text("not a real pdf", encoding="utf-8")
+    (source_dir / "Synthetic Floor Plan.dxf").write_text("not a real dxf", encoding="utf-8")
+    (source_dir / "Synthetic Legend.pdf").write_text("legend", encoding="utf-8")
 
     exit_code = main(
         [
@@ -35,6 +35,10 @@ def test_pilot_cli_writes_expected_artifacts(tmp_path: Path) -> None:
         "pdf_text_blocks.csv",
         "dxf_layers.csv",
         "dxf_entities_summary.csv",
+        "rooms_prelim.csv",
+        "walls_prelim.csv",
+        "crosscheck_matrix.csv",
+        "assumptions.csv",
         "review_items.csv",
         "workbook_manifest.csv",
         "gemini_intake_packet.json",
@@ -47,6 +51,23 @@ def test_pilot_cli_writes_expected_artifacts(tmp_path: Path) -> None:
     with (output_dir / "source_inventory.csv").open(encoding="utf-8") as handle:
         rows = list(csv.DictReader(handle))
     assert len(rows) == 3
+    with (output_dir / "rooms_prelim.csv").open(encoding="utf-8") as handle:
+        room_rows = list(csv.DictReader(handle))
+    assert room_rows
+    assert room_rows[0]["review_required"] == "yes"
+    assert room_rows[0]["version_match_status"] == "not_performed"
+    with (output_dir / "walls_prelim.csv").open(encoding="utf-8") as handle:
+        wall_rows = list(csv.DictReader(handle))
+    assert wall_rows[0]["status"] == "placeholder_review_required"
+    with (output_dir / "crosscheck_matrix.csv").open(encoding="utf-8") as handle:
+        crosscheck_rows = list(csv.DictReader(handle))
+    assert {row["check_name"] for row in crosscheck_rows} >= {
+        "pdf_current_state_evidence",
+        "pdf_vector_version_match",
+    }
+    with (output_dir / "assumptions.csv").open(encoding="utf-8") as handle:
+        assumption_rows = list(csv.DictReader(handle))
+    assert assumption_rows[0]["review_required"] == "yes"
 
     packet = json.loads((output_dir / "gemini_intake_packet.json").read_text(encoding="utf-8"))
     assert packet["schema_version"] == "gemini_adapter.input.v1"

--- a/tests/construction_takeoff/test_dxf_probe.py
+++ b/tests/construction_takeoff/test_dxf_probe.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from tools.construction_takeoff.dxf_probe import extract_closed_polyline_room_candidates
+
+
+class FakeLWPolyline:
+    closed = True
+
+    dxf = SimpleNamespace(layer="ROOM_BOUNDARY", handle="ABC1")
+
+    def dxftype(self) -> str:
+        return "LWPOLYLINE"
+
+    def get_points(self) -> list[tuple[int, int]]:
+        return [(0, 0), (4, 0), (4, 3), (0, 3)]
+
+
+class FakeLine:
+    dxf = SimpleNamespace(layer="LINES", handle="ABC2")
+
+    def dxftype(self) -> str:
+        return "LINE"
+
+
+class FakeDocument:
+    header = {"$INSUNITS": 6}
+
+    def modelspace(self) -> list[object]:
+        return [FakeLWPolyline(), FakeLine()]
+
+
+def test_extract_closed_polyline_room_candidates_from_synthetic_dxf(
+    monkeypatch, tmp_path: Path
+) -> None:
+    dxf_path = tmp_path / "synthetic_room_boundaries.dxf"
+    dxf_path.write_text("synthetic placeholder", encoding="utf-8")
+    monkeypatch.setitem(
+        sys.modules, "ezdxf", SimpleNamespace(readfile=lambda _path: FakeDocument())
+    )
+
+    rows = extract_closed_polyline_room_candidates(dxf_path)
+
+    assert len(rows) == 1
+    assert rows[0].source_ref == "synthetic_room_boundaries.dxf"
+    assert rows[0].source_entity_id == "ABC1"
+    assert rows[0].source_layer == "ROOM_BOUNDARY"
+    assert rows[0].area_raw == "12.000000"
+    assert rows[0].area_unit == "meters_squared"
+    assert rows[0].status == "candidate_review_required"
+    assert rows[0].review_required == "yes"
+    assert rows[0].version_match_status == "not_performed"

--- a/tests/construction_takeoff/test_source_inventory.py
+++ b/tests/construction_takeoff/test_source_inventory.py
@@ -4,21 +4,21 @@ from tools.construction_takeoff.source_inventory import build_source_inventory
 
 
 def test_build_source_inventory_classifies_common_sources(tmp_path: Path) -> None:
-    (tmp_path / "Consum Quartier Erdgeschoss.pdf").write_text("pdf", encoding="utf-8")
-    (tmp_path / "Consum Quartier Erdgeschoss.dxf").write_text("dxf", encoding="utf-8")
-    (tmp_path / "Consum Quartier LEGENDE.pdf").write_text("legend", encoding="utf-8")
-    (tmp_path / "Scans").mkdir()
+    (tmp_path / "Synthetic Erdgeschoss.pdf").write_text("pdf", encoding="utf-8")
+    (tmp_path / "Synthetic Erdgeschoss.dxf").write_text("dxf", encoding="utf-8")
+    (tmp_path / "Synthetic LEGENDE.pdf").write_text("legend", encoding="utf-8")
+    (tmp_path / "Synthetic Scans").mkdir()
 
     records = build_source_inventory(tmp_path, "erdgeschoss", "pdf_current_vector_measurement")
 
     by_name = {record.private_source_ref: record for record in records}
-    assert by_name["Consum Quartier Erdgeschoss.pdf"].source_type == "pdf"
-    assert by_name["Consum Quartier Erdgeschoss.pdf"].priority_for_this_object == (
+    assert by_name["Synthetic Erdgeschoss.pdf"].source_type == "pdf"
+    assert by_name["Synthetic Erdgeschoss.pdf"].priority_for_this_object == (
         "pdf_current_variant_selector"
     )
-    assert by_name["Consum Quartier Erdgeschoss.dxf"].source_type == "dxf"
-    assert by_name["Consum Quartier Erdgeschoss.dxf"].priority_for_this_object == (
+    assert by_name["Synthetic Erdgeschoss.dxf"].source_type == "dxf"
+    assert by_name["Synthetic Erdgeschoss.dxf"].priority_for_this_object == (
         "vector_measurement_after_pdf_match"
     )
-    assert by_name["Consum Quartier LEGENDE.pdf"].source_role == "legend_dictionary"
-    assert by_name["Scans"].source_type == "folder"
+    assert by_name["Synthetic LEGENDE.pdf"].source_role == "legend_dictionary"
+    assert by_name["Synthetic Scans"].source_type == "folder"

--- a/tools/construction_takeoff/cli.py
+++ b/tools/construction_takeoff/cli.py
@@ -6,13 +6,26 @@ import argparse
 import csv
 from pathlib import Path
 
-from .dxf_probe import probe_dxf, write_dxf_entities_summary, write_dxf_layers
+from .dxf_probe import (
+    extract_closed_polyline_room_candidates,
+    probe_dxf,
+    write_dxf_entities_summary,
+    write_dxf_layers,
+)
 from .gemini_packet import build_gemini_packet, write_gemini_packet
 from .notebooklm_handoff import build_notebooklm_handoff, write_notebooklm_handoff
 from .pdf_extract import extract_pdf_text_blocks, write_pdf_text_blocks
-from .schemas import ArtifactSet, PilotConfig, ReviewItem
+from .schemas import (
+    ArtifactSet,
+    AssumptionRow,
+    CrosscheckRow,
+    PilotConfig,
+    ReviewItem,
+    RoomPrelim,
+    WallPrelim,
+)
 from .source_inventory import build_source_inventory, write_source_inventory
-from .workbook_export import write_workbook_manifest
+from .workbook_export import write_workbook_manifest, write_workbook_xlsx
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -38,8 +51,13 @@ def run_pilot(config: PilotConfig) -> ArtifactSet:
         pdf_text_blocks_csv=config.output_dir / "pdf_text_blocks.csv",
         dxf_layers_csv=config.output_dir / "dxf_layers.csv",
         dxf_entities_summary_csv=config.output_dir / "dxf_entities_summary.csv",
+        rooms_prelim_csv=config.output_dir / "rooms_prelim.csv",
+        walls_prelim_csv=config.output_dir / "walls_prelim.csv",
+        crosscheck_matrix_csv=config.output_dir / "crosscheck_matrix.csv",
+        assumptions_csv=config.output_dir / "assumptions.csv",
         review_items_csv=config.output_dir / "review_items.csv",
         workbook_manifest_csv=config.output_dir / "workbook_manifest.csv",
+        workbook_xlsx=config.output_dir / "workbook.xlsx",
         gemini_intake_packet_json=config.output_dir / "gemini_intake_packet.json",
         notebooklm_handoff_md=config.output_dir / "notebooklm_handoff.md",
         runner_log_md=config.output_dir / "runner_log.md",
@@ -51,6 +69,7 @@ def run_pilot(config: PilotConfig) -> ArtifactSet:
     pdf_rows = []
     dxf_layer_rows = []
     dxf_entity_rows = []
+    room_rows: list[RoomPrelim] = []
     for record in records:
         source_path = config.source_dir / record.private_source_ref
         if record.source_type == "pdf" and source_path.is_file():
@@ -59,12 +78,21 @@ def run_pilot(config: PilotConfig) -> ArtifactSet:
             layer_rows, entity_rows = probe_dxf(source_path)
             dxf_layer_rows.extend(layer_rows)
             dxf_entity_rows.extend(entity_rows)
+            room_rows.extend(extract_closed_polyline_room_candidates(source_path))
 
     write_pdf_text_blocks(pdf_rows, artifacts.pdf_text_blocks_csv)
     write_dxf_layers(dxf_layer_rows, artifacts.dxf_layers_csv)
     write_dxf_entities_summary(dxf_entity_rows, artifacts.dxf_entities_summary_csv)
 
-    review_items = _initial_review_items(records)
+    wall_rows = _placeholder_wall_rows(records)
+    crosscheck_rows = _build_crosscheck_rows(records, room_rows)
+    assumption_rows = _build_assumption_rows(config)
+    _write_dataclass_rows(room_rows, RoomPrelim, artifacts.rooms_prelim_csv)
+    _write_dataclass_rows(wall_rows, WallPrelim, artifacts.walls_prelim_csv)
+    _write_dataclass_rows(crosscheck_rows, CrosscheckRow, artifacts.crosscheck_matrix_csv)
+    _write_dataclass_rows(assumption_rows, AssumptionRow, artifacts.assumptions_csv)
+
+    review_items = _initial_review_items(records, room_rows)
     _write_review_items(review_items, artifacts.review_items_csv)
 
     packet = build_gemini_packet(config, records)
@@ -73,25 +101,56 @@ def run_pilot(config: PilotConfig) -> ArtifactSet:
     handoff = build_notebooklm_handoff(config, records)
     write_notebooklm_handoff(handoff, artifacts.notebooklm_handoff_md)
 
+    workbook_created = write_workbook_xlsx(
+        [
+            artifacts.source_inventory_csv,
+            artifacts.pdf_text_blocks_csv,
+            artifacts.dxf_layers_csv,
+            artifacts.dxf_entities_summary_csv,
+            artifacts.rooms_prelim_csv,
+            artifacts.walls_prelim_csv,
+            artifacts.crosscheck_matrix_csv,
+            artifacts.assumptions_csv,
+            artifacts.review_items_csv,
+        ],
+        artifacts.workbook_xlsx,
+    )
+    if not workbook_created:
+        review_items.append(
+            ReviewItem(
+                review_item_id=_next_review_id(review_items),
+                severity="info",
+                entity_type="parser_dependency",
+                entity_id="openpyxl",
+                issue="XLSX workbook export skipped because openpyxl is not installed.",
+                recommended_action="Install the takeoff optional dependency group in the private Runner.",
+            )
+        )
+        _write_review_items(review_items, artifacts.review_items_csv)
+
+    _write_runner_log(config, artifacts, len(records), len(review_items), workbook_created)
     write_workbook_manifest(
         [
             artifacts.source_inventory_csv,
             artifacts.pdf_text_blocks_csv,
             artifacts.dxf_layers_csv,
             artifacts.dxf_entities_summary_csv,
+            artifacts.rooms_prelim_csv,
+            artifacts.walls_prelim_csv,
+            artifacts.crosscheck_matrix_csv,
+            artifacts.assumptions_csv,
             artifacts.review_items_csv,
+            artifacts.workbook_xlsx,
             artifacts.gemini_intake_packet_json,
             artifacts.notebooklm_handoff_md,
             artifacts.runner_log_md,
         ],
         artifacts.workbook_manifest_csv,
     )
-
-    _write_runner_log(config, artifacts, len(records), len(review_items))
     return artifacts
 
 
-def _initial_review_items(records: list) -> list[ReviewItem]:
+def _initial_review_items(records: list, room_rows: list[RoomPrelim]) -> list[ReviewItem]:
     items: list[ReviewItem] = []
     has_pdf = any(record.source_type == "pdf" for record in records)
     has_vector = any(record.source_type in {"dxf", "dwg"} for record in records)
@@ -100,7 +159,7 @@ def _initial_review_items(records: list) -> list[ReviewItem]:
     if not has_pdf:
         items.append(
             ReviewItem(
-                review_item_id="RI-0001",
+                review_item_id=_next_review_id(items),
                 severity="blocker",
                 entity_type="source_set",
                 entity_id="all",
@@ -111,7 +170,7 @@ def _initial_review_items(records: list) -> list[ReviewItem]:
     if not has_vector:
         items.append(
             ReviewItem(
-                review_item_id="RI-0002",
+                review_item_id=_next_review_id(items),
                 severity="warning",
                 entity_type="source_set",
                 entity_id="all",
@@ -122,7 +181,7 @@ def _initial_review_items(records: list) -> list[ReviewItem]:
     if not has_legend:
         items.append(
             ReviewItem(
-                review_item_id="RI-0003",
+                review_item_id=_next_review_id(items),
                 severity="warning",
                 entity_type="source_set",
                 entity_id="all",
@@ -130,7 +189,136 @@ def _initial_review_items(records: list) -> list[ReviewItem]:
                 recommended_action="Confirm legend/symbol interpretation before room and wall extraction.",
             )
         )
+    if any(row.status == "unsupported" for row in room_rows):
+        items.append(
+            ReviewItem(
+                review_item_id=_next_review_id(items),
+                severity="warning",
+                entity_type="parser_dependency",
+                entity_id="ezdxf",
+                issue="DXF room candidate extraction skipped because the parser dependency is missing.",
+                recommended_action="Install the takeoff optional dependency group in the private Runner.",
+            )
+        )
+    if any(row.status == "failed_parse" for row in room_rows):
+        items.append(
+            ReviewItem(
+                review_item_id=_next_review_id(items),
+                severity="warning",
+                entity_type="dxf_parse",
+                entity_id="rooms_prelim",
+                issue="DXF parser failed before producing room candidates.",
+                recommended_action="Inspect the private DXF locally and retry after parser validation.",
+            )
+        )
+    if has_vector and room_rows and all(row.status == "no_candidates" for row in room_rows):
+        items.append(
+            ReviewItem(
+                review_item_id=_next_review_id(items),
+                severity="warning",
+                entity_type="room_candidates",
+                entity_id="rooms_prelim",
+                issue="No simple closed polyline room candidates were detected.",
+                recommended_action="Review DXF layers and confirm whether room boundaries use another entity type.",
+            )
+        )
+    if has_vector:
+        items.append(
+            ReviewItem(
+                review_item_id=_next_review_id(items),
+                severity="warning",
+                entity_type="version_match",
+                entity_id="dxf_pdf",
+                issue="PDF/DXF current-state version matching has not been performed.",
+                recommended_action="Manually match vector candidates to the current PDF before using quantities.",
+            )
+        )
     return items
+
+
+def _placeholder_wall_rows(records: list) -> list[WallPrelim]:
+    source_refs = ", ".join(
+        record.private_source_ref
+        for record in records
+        if record.source_type in {"dxf", "dwg", "pdf"}
+    )
+    return [
+        WallPrelim(
+            wall_prelim_id="WALL-PRELIM-0001",
+            source_ref=source_refs,
+            source_entity_id="",
+            source_layer="",
+            length_raw="",
+            height_raw="",
+            area_raw="",
+            unit="",
+            confidence="0.00",
+        )
+    ]
+
+
+def _build_crosscheck_rows(records: list, room_rows: list[RoomPrelim]) -> list[CrosscheckRow]:
+    has_pdf = any(record.source_type == "pdf" for record in records)
+    room_candidate_count = sum(row.status == "candidate_review_required" for row in room_rows)
+    return [
+        CrosscheckRow(
+            crosscheck_id="CHECK-0001",
+            check_name="pdf_current_state_evidence",
+            source_refs=_refs_for(records, {"pdf"}),
+            status="present_review_required" if has_pdf else "missing_review_required",
+            review_required="yes",
+            notes="PDF source presence is only an evidence gate; current-state matching is manual.",
+        ),
+        CrosscheckRow(
+            crosscheck_id="CHECK-0002",
+            check_name="vector_room_candidate_extraction",
+            source_refs=_refs_for(records, {"dxf", "dwg"}),
+            status="candidate_rows_present" if room_candidate_count else "no_candidate_rows",
+            review_required="yes",
+            notes=f"Closed-polyline room candidate rows detected: {room_candidate_count}.",
+        ),
+        CrosscheckRow(
+            crosscheck_id="CHECK-0003",
+            check_name="pdf_vector_version_match",
+            source_refs=_refs_for(records, {"pdf", "dxf", "dwg"}),
+            status="not_performed",
+            review_required="yes",
+            notes="Version matching is outside the public-safe v0 parser scaffold.",
+        ),
+    ]
+
+
+def _build_assumption_rows(config: PilotConfig) -> list[AssumptionRow]:
+    return [
+        AssumptionRow(
+            assumption_id="ASSUMP-0001",
+            scope=config.scope,
+            assumption="Closed DXF polylines may represent room boundary candidates.",
+            status="open",
+            review_required="yes",
+            notes="Room labels, wall buildup, scale calibration, and PDF current-state matching remain manual.",
+        )
+    ]
+
+
+def _refs_for(records: list, source_types: set[str]) -> str:
+    return ", ".join(
+        record.private_source_ref for record in records if record.source_type in source_types
+    )
+
+
+def _write_dataclass_rows(rows: list, row_type: type, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(row_type.__dataclass_fields__.keys())
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row.to_row())
+
+
+def _next_review_id(items: list[ReviewItem]) -> str:
+    return f"RI-{len(items) + 1:04d}"
 
 
 def _write_review_items(items: list[ReviewItem], output_path: Path) -> None:
@@ -147,6 +335,7 @@ def _write_runner_log(
     artifacts: ArtifactSet,
     source_count: int,
     review_item_count: int,
+    workbook_created: bool,
 ) -> None:
     artifacts.runner_log_md.write_text(
         "\n".join(
@@ -158,8 +347,9 @@ def _write_runner_log(
                 f"Source priority: {config.source_priority}",
                 f"Source count: {source_count}",
                 f"Initial review items: {review_item_count}",
+                f"Workbook XLSX: {'created' if workbook_created else 'skipped_openpyxl_not_available'}",
                 "",
-                "Status: INITIAL_SCAFFOLD_COMPLETE",
+                "Status: PRELIMINARY_PARSER_SCAFFOLD_COMPLETE_REVIEW_REQUIRED",
                 "",
             ]
         ),
@@ -186,8 +376,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"pdf_text_blocks={artifacts.pdf_text_blocks_csv}")
         print(f"dxf_layers={artifacts.dxf_layers_csv}")
         print(f"dxf_entities_summary={artifacts.dxf_entities_summary_csv}")
+        print(f"rooms_prelim={artifacts.rooms_prelim_csv}")
+        print(f"walls_prelim={artifacts.walls_prelim_csv}")
+        print(f"crosscheck_matrix={artifacts.crosscheck_matrix_csv}")
+        print(f"assumptions={artifacts.assumptions_csv}")
         print(f"review_items={artifacts.review_items_csv}")
         print(f"workbook_manifest={artifacts.workbook_manifest_csv}")
+        print(f"workbook_xlsx={artifacts.workbook_xlsx}")
         print(f"gemini_packet={artifacts.gemini_intake_packet_json}")
         print(f"notebooklm_handoff={artifacts.notebooklm_handoff_md}")
         print(f"runner_log={artifacts.runner_log_md}")

--- a/tools/construction_takeoff/dxf_probe.py
+++ b/tools/construction_takeoff/dxf_probe.py
@@ -10,6 +10,8 @@ import csv
 from pathlib import Path
 from typing import Any
 
+from .schemas import RoomPrelim
+
 LAYER_FIELDS = ["source_ref", "layer", "status", "notes"]
 ENTITY_FIELDS = ["source_ref", "entity_type", "layer", "count", "status", "notes"]
 
@@ -86,12 +88,143 @@ def probe_dxf(dxf_path: Path) -> tuple[list[dict[str, str]], list[dict[str, str]
     return layer_rows, entity_rows
 
 
+def extract_closed_polyline_room_candidates(dxf_path: Path) -> list[RoomPrelim]:
+    try:
+        import ezdxf  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        return [
+            RoomPrelim(
+                room_prelim_id="ROOM-PRELIM-0001",
+                source_ref=dxf_path.name,
+                source_entity_id="",
+                source_layer="",
+                area_raw="",
+                area_unit="",
+                confidence="0.00",
+                status="unsupported",
+                notes="ezdxf is not installed; room candidate extraction was skipped.",
+            )
+        ]
+
+    try:
+        document: Any = ezdxf.readfile(dxf_path)
+        unit = _drawing_area_unit(document)
+        candidates: list[RoomPrelim] = []
+        for index, entity in enumerate(document.modelspace(), start=1):
+            if entity.dxftype() not in {"LWPOLYLINE", "POLYLINE"} or not _is_closed_polyline(
+                entity
+            ):
+                continue
+            points = _polyline_points(entity)
+            area = abs(_shoelace_area(points))
+            if len(points) < 3 or area <= 0:
+                continue
+            candidates.append(
+                RoomPrelim(
+                    room_prelim_id=f"ROOM-PRELIM-{len(candidates) + 1:04d}",
+                    source_ref=dxf_path.name,
+                    source_entity_id=_entity_id(entity, index),
+                    source_layer=str(getattr(entity.dxf, "layer", "")),
+                    area_raw=f"{area:.6f}",
+                    area_unit=unit,
+                    confidence="0.45",
+                    status="candidate_review_required",
+                    notes=(
+                        "Closed DXF polyline candidate; PDF/current-state matching and room label "
+                        "association are not performed."
+                    ),
+                )
+            )
+    except Exception as exc:  # pragma: no cover - depends on parser internals
+        return [
+            RoomPrelim(
+                room_prelim_id="ROOM-PRELIM-0001",
+                source_ref=dxf_path.name,
+                source_entity_id="",
+                source_layer="",
+                area_raw="",
+                area_unit="",
+                confidence="0.00",
+                status="failed_parse",
+                notes=f"{type(exc).__name__}: {exc}",
+            )
+        ]
+
+    return candidates or [
+        RoomPrelim(
+            room_prelim_id="ROOM-PRELIM-0001",
+            source_ref=dxf_path.name,
+            source_entity_id="",
+            source_layer="",
+            area_raw="",
+            area_unit=unit,
+            confidence="0.00",
+            status="no_candidates",
+            notes="No simple closed DXF polylines found for room candidates.",
+        )
+    ]
+
+
 def write_dxf_layers(rows: list[dict[str, str]], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=LAYER_FIELDS)
         writer.writeheader()
         writer.writerows(rows)
+
+
+def _is_closed_polyline(entity: Any) -> bool:
+    closed = getattr(entity, "closed", None)
+    if isinstance(closed, bool):
+        return closed
+    is_closed = getattr(entity, "is_closed", None)
+    if callable(is_closed):
+        return bool(is_closed())
+    if isinstance(is_closed, bool):
+        return is_closed
+    return bool(getattr(entity, "is_closed", False))
+
+
+def _polyline_points(entity: Any) -> list[tuple[float, float]]:
+    if entity.dxftype() == "LWPOLYLINE":
+        if hasattr(entity, "get_points"):
+            return [(float(point[0]), float(point[1])) for point in entity.get_points()]
+        return [(float(point[0]), float(point[1])) for point in entity]
+
+    points = []
+    vertices = entity.vertices() if callable(getattr(entity, "vertices", None)) else entity.vertices
+    for vertex in vertices:
+        location = vertex.dxf.location
+        points.append((float(location.x), float(location.y)))
+    return points
+
+
+def _shoelace_area(points: list[tuple[float, float]]) -> float:
+    if len(points) < 3:
+        return 0.0
+    pairs = zip(points, [*points[1:], points[0]], strict=True)
+    return sum((x1 * y2) - (x2 * y1) for (x1, y1), (x2, y2) in pairs) / 2
+
+
+def _drawing_area_unit(document: Any) -> str:
+    try:
+        unit_code = int(document.header.get("$INSUNITS", 0))
+    except Exception:
+        unit_code = 0
+    unit_names = {
+        0: "drawing_units_squared",
+        1: "inches_squared",
+        2: "feet_squared",
+        4: "millimeters_squared",
+        5: "centimeters_squared",
+        6: "meters_squared",
+    }
+    return unit_names.get(unit_code, f"insunits_{unit_code}_squared")
+
+
+def _entity_id(entity: Any, fallback_index: int) -> str:
+    handle = getattr(getattr(entity, "dxf", object()), "handle", "")
+    return str(handle or f"modelspace_index_{fallback_index}")
 
 
 def write_dxf_entities_summary(rows: list[dict[str, str]], output_path: Path) -> None:

--- a/tools/construction_takeoff/gemini_packet.py
+++ b/tools/construction_takeoff/gemini_packet.py
@@ -47,7 +47,9 @@ def build_gemini_packet(config: PilotConfig, records: list[SourceRecord]) -> dic
 
 def write_gemini_packet(packet: dict[str, object], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(packet, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    output_path.write_text(
+        json.dumps(packet, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
 
 
 def _source_counts(records: list[SourceRecord]) -> dict[str, int]:

--- a/tools/construction_takeoff/schemas.py
+++ b/tools/construction_takeoff/schemas.py
@@ -12,6 +12,13 @@ from typing import Literal
 
 SourceType = Literal["pdf", "dxf", "dwg", "pln", "scan", "folder", "other"]
 ParseStatus = Literal["pending", "parsed", "unsupported", "failed_parse", "metadata_only"]
+PrelimStatus = Literal[
+    "candidate_review_required",
+    "placeholder_review_required",
+    "unsupported",
+    "failed_parse",
+    "no_candidates",
+]
 
 
 @dataclass(frozen=True)
@@ -46,6 +53,70 @@ class ReviewItem:
 
 
 @dataclass(frozen=True)
+class RoomPrelim:
+    room_prelim_id: str
+    source_ref: str
+    source_entity_id: str
+    source_layer: str
+    area_raw: str
+    area_unit: str
+    confidence: str
+    status: PrelimStatus
+    review_required: str = "yes"
+    version_match_status: str = "not_performed"
+    notes: str = "Preliminary closed-polyline candidate only; not a final quantity claim."
+
+    def to_row(self) -> dict[str, str]:
+        return {key: str(value) for key, value in asdict(self).items()}
+
+
+@dataclass(frozen=True)
+class WallPrelim:
+    wall_prelim_id: str
+    source_ref: str
+    source_entity_id: str
+    source_layer: str
+    length_raw: str
+    height_raw: str
+    area_raw: str
+    unit: str
+    confidence: str
+    status: PrelimStatus = "placeholder_review_required"
+    review_required: str = "yes"
+    version_match_status: str = "not_performed"
+    notes: str = "Wall extraction is not implemented in this public-safe v0 scaffold."
+
+    def to_row(self) -> dict[str, str]:
+        return {key: str(value) for key, value in asdict(self).items()}
+
+
+@dataclass(frozen=True)
+class CrosscheckRow:
+    crosscheck_id: str
+    check_name: str
+    source_refs: str
+    status: str
+    review_required: str
+    notes: str
+
+    def to_row(self) -> dict[str, str]:
+        return {key: str(value) for key, value in asdict(self).items()}
+
+
+@dataclass(frozen=True)
+class AssumptionRow:
+    assumption_id: str
+    scope: str
+    assumption: str
+    status: str
+    review_required: str
+    notes: str = ""
+
+    def to_row(self) -> dict[str, str]:
+        return {key: str(value) for key, value in asdict(self).items()}
+
+
+@dataclass(frozen=True)
 class PilotConfig:
     source_dir: Path
     output_dir: Path
@@ -62,8 +133,13 @@ class ArtifactSet:
     pdf_text_blocks_csv: Path
     dxf_layers_csv: Path
     dxf_entities_summary_csv: Path
+    rooms_prelim_csv: Path
+    walls_prelim_csv: Path
+    crosscheck_matrix_csv: Path
+    assumptions_csv: Path
     review_items_csv: Path
     workbook_manifest_csv: Path
+    workbook_xlsx: Path
     gemini_intake_packet_json: Path
     notebooklm_handoff_md: Path
     runner_log_md: Path

--- a/tools/construction_takeoff/source_inventory.py
+++ b/tools/construction_takeoff/source_inventory.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from .schemas import SourceRecord
 
-
 SOURCE_TYPE_BY_SUFFIX = {
     ".pdf": "pdf",
     ".dxf": "dxf",
@@ -71,14 +70,18 @@ def priority_for(source_type: str, name: str, source_priority: str) -> str:
     return "standard_priority"
 
 
-def build_source_inventory(source_dir: Path, scope: str, source_priority: str) -> list[SourceRecord]:
+def build_source_inventory(
+    source_dir: Path, scope: str, source_priority: str
+) -> list[SourceRecord]:
     if not source_dir.exists():
         raise FileNotFoundError(f"source directory does not exist: {source_dir}")
     if not source_dir.is_dir():
         raise NotADirectoryError(f"source path is not a directory: {source_dir}")
 
     records: list[SourceRecord] = []
-    for index, path in enumerate(sorted(source_dir.iterdir(), key=lambda item: item.name.lower()), start=1):
+    for index, path in enumerate(
+        sorted(source_dir.iterdir(), key=lambda item: item.name.lower()), start=1
+    ):
         source_type = classify_source(path)
         parse_status = "pending" if source_type in {"pdf", "dxf", "dwg"} else "metadata_only"
         records.append(

--- a/tools/construction_takeoff/workbook_export.py
+++ b/tools/construction_takeoff/workbook_export.py
@@ -1,13 +1,15 @@
-"""Workbook manifest exporter.
+"""Workbook manifest and optional XLSX exporter.
 
-The v0 pilot writes a CSV manifest instead of requiring openpyxl in public CI.
-Runner can later add XLSX export when optional dependencies are installed.
+The v0 pilot never requires openpyxl in public CI. When it is available in a
+private Runner environment, the same preliminary CSV artifacts are copied into
+an XLSX workbook for manual review.
 """
 
 from __future__ import annotations
 
 import csv
 from pathlib import Path
+from typing import Any
 
 
 def write_workbook_manifest(artifact_paths: list[Path], output_path: Path) -> None:
@@ -23,3 +25,35 @@ def write_workbook_manifest(artifact_paths: list[Path], output_path: Path) -> No
                     "notes": "v0 manifest; XLSX export is a later Runner adapter",
                 }
             )
+
+
+def write_workbook_xlsx(csv_paths: list[Path], output_path: Path) -> bool:
+    try:
+        from openpyxl import Workbook  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        return False
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    workbook: Any = Workbook()
+    default_sheet = workbook.active
+    workbook.remove(default_sheet)
+
+    for csv_path in csv_paths:
+        worksheet = workbook.create_sheet(title=_safe_sheet_title(csv_path.stem))
+        if not csv_path.exists():
+            worksheet.append(["artifact", "exists", "notes"])
+            worksheet.append(
+                [csv_path.name, "no", "Artifact was not created before workbook export."]
+            )
+            continue
+        with csv_path.open(newline="", encoding="utf-8") as handle:
+            for row in csv.reader(handle):
+                worksheet.append(row)
+
+    workbook.save(output_path)
+    return True
+
+
+def _safe_sheet_title(title: str) -> str:
+    safe = "".join(char if char not in "[]:*?/\\\\" else "_" for char in title)
+    return safe[:31] or "sheet"


### PR DESCRIPTION
## Summary
- Adds Construction Takeoff v0 parser scaffold outputs.
- Adds preliminary rooms/walls/crosscheck/assumptions artifacts.
- Adds closed DXF polyline room-candidate extraction with review-required status.
- Adds optional XLSX workbook export when openpyxl is available.
- Keeps all quantity outputs preliminary and review-required.

## Verification
- `python -m ruff check tools/construction_takeoff tests/construction_takeoff`
- `python -m black --check tools/construction_takeoff tests/construction_takeoff`
- `python -m pytest tests/construction_takeoff -q`

## Manual verification result from Hetzner
- ruff: passed
- black --check: passed
- pytest: 3 passed
- private grep: clean

## Safety
- Private data used: no.
- No live Gemini call.
- No private drawings.
- No Jeeves runtime/app code changes.
- No deploy/merge.

Refs #114.