### PR TITLE
Add active executor with command allowlist

### DIFF
--- a/docs/dual_brain_state.md
+++ b/docs/dual_brain_state.md
@@ -301,6 +301,40 @@ Possible next labels:
 
 The execution dispatcher must consume only issues that already passed the audit gate.
 
+
+## 10. Sprint 5 Phase 1 Verified
+
+Sprint 5 Phase 1 added:
+
+- `tools/skeleton_core/bounded_execution_packet.py`
+- `tools/skeleton_core/dry_run_execution_route.py`
+- `tests/skeleton_core/test_bounded_execution_packet.py`
+- `tests/skeleton_core/test_dry_run_execution_route.py`
+
+Verified on Issue #126:
+
+- consumed an issue that had already passed audit with `agent:audited`
+- verified accepted audit evidence
+- built `ExecutionPacket`
+- posted bounded execution dry-run report
+- transitioned `agent:audited` to `agent:executed`
+- removed `agent:executing`
+- executed zero shell commands
+- changed zero files
+- created no PR
+- performed no merge
+- performed no deploy
+- performed no canon write
+
+Current execution boundary:
+
+- `executor_allowed = false`
+- `file_writes_allowed = false`
+- `pr_creation_allowed = false`
+- `merge_allowed = false`
+- `deploy_allowed = false`
+- `canon_write_allowed = false`
+
 ## 8. Minimal Mental Model
 
 `dual_brain_task_packet.py`
@@ -335,4 +369,4 @@ Yellow runner daemon is verified.
 
 Systemd 24/7 hands-off live processing is verified.
 
-Next step is Sprint 5: bounded execution handoff.
+Sprint 5 Phase 1 bounded execution dry-run handoff is verified. Next step is designing a real executor only behind stricter approval gates.

--- a/tests/skeleton_core/test_active_executor.py
+++ b/tests/skeleton_core/test_active_executor.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.skeleton_core.active_executor import (
+    build_active_execution_packet,
+    command_is_allowed,
+    execute_packet,
+    validate_active_packet,
+)
+from tools.skeleton_core.dry_run_execution_route import (
+    GitHubIssueComment,
+    GitHubIssueExport,
+    GitHubIssueLabel,
+)
+
+
+def _issue() -> GitHubIssueExport:
+    return GitHubIssueExport(
+        number=126,
+        title="[agent-task-yellow] Active executor test",
+        body="Public-safe audited issue.",
+        url="https://github.com/alanua/jeeves/issues/126",
+        state="OPEN",
+        labels=[
+            GitHubIssueLabel(name="agent:task"),
+            GitHubIssueLabel(name="risk:yellow"),
+            GitHubIssueLabel(name="runner:hetzner"),
+            GitHubIssueLabel(name="agent:audited"),
+        ],
+        comments=[
+            GitHubIssueComment(
+                body="Autonomous YELLOW Gemini audit route report\nAdapter status: `live_accept`",
+                url="https://github.com/alanua/jeeves/issues/126#comment",
+            )
+        ],
+    )
+
+
+def test_command_whitelist_accepts_safe_commands() -> None:
+    assert command_is_allowed("python -m pytest -q")[0] is True
+    assert (
+        command_is_allowed("python -m ruff check tools/skeleton_core tests/skeleton_core")[0]
+        is True
+    )
+    assert command_is_allowed("git status --short")[0] is True
+
+
+def test_command_whitelist_blocks_destructive_commands() -> None:
+    assert command_is_allowed("rm -rf /")[0] is False
+    assert command_is_allowed("git push --force")[0] is False
+    assert command_is_allowed("sudo systemctl restart x")[0] is False
+
+
+def test_build_plan_packet_is_not_real() -> None:
+    packet = build_active_execution_packet(_issue(), real_run=False)
+
+    assert packet.real_run is False
+    assert packet.executor_allowed is False
+    assert packet.file_writes_allowed is False
+    assert packet.pr_creation_allowed is False
+    assert packet.merge_allowed is False
+    assert packet.deploy_allowed is False
+    assert packet.canon_write_allowed is False
+    assert validate_active_packet(packet) == []
+
+
+def test_real_packet_uses_whitelisted_validation_commands() -> None:
+    packet = build_active_execution_packet(_issue(), real_run=True)
+
+    assert packet.real_run is True
+    assert packet.executor_allowed is True
+    assert packet.planned_actions
+    assert validate_active_packet(packet) == []
+
+
+def test_execute_plan_packet_runs_no_commands(tmp_path: Path) -> None:
+    packet = build_active_execution_packet(_issue(), real_run=False)
+
+    decision, results, blocked = execute_packet(packet, repo_root=tmp_path)
+
+    assert decision == "would_execute"
+    assert results == []
+    assert blocked == []
+
+
+def test_execute_blocks_unapproved_command(tmp_path: Path) -> None:
+    packet = build_active_execution_packet(_issue(), real_run=True)
+    packet.planned_actions[0].command = "rm -rf /"
+
+    decision, results, blocked = execute_packet(packet, repo_root=tmp_path)
+
+    assert decision == "blocked"
+    assert results == []
+    assert any("forbidden_substring" in reason for reason in blocked)

--- a/tools/skeleton_core/active_executor.py
+++ b/tools/skeleton_core/active_executor.py
@@ -1,0 +1,557 @@
+"""Active bounded executor.
+
+Sprint 7 phase 1:
+- still fail-closed
+- only executes commands from a strict allowlist
+- only acts on already audited issues
+- logs every real action to Skeleton diary
+- records failure state in current_state.json via memory_service
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.bounded_execution_packet import (
+    ExecutionAction,
+    ExecutionActionType,
+    ExecutionDecision,
+    ExecutionMode,
+    ExecutionPacket,
+    ExecutionSource,
+)
+from tools.skeleton_core.dry_run_execution_route import (
+    ACCEPT_STATUSES,
+    GitHubIssueExport,
+    _gh_json,
+    _run,
+    find_verified_audit_comment,
+)
+from tools.skeleton_core.memory_service import (
+    append_to_skeleton_diary,
+    create_system_snapshot,
+)
+
+ExecutorMode = Literal["plan", "real"]
+
+SAFE_COMMAND_PREFIXES = (
+    ("python", "-m", "pytest"),
+    ("python", "-m", "ruff", "check"),
+    ("python", "-m", "black", "--check"),
+    ("python", "-m", "tools.skeleton_core.cli", "validate-state"),
+    ("git", "status", "--short"),
+    ("git", "diff", "--stat"),
+    ("git", "add"),
+    ("git", "commit", "-m"),
+    ("git", "push", "-u", "origin"),
+    ("gh", "pr", "create"),
+    ("gh", "issue", "edit"),
+    ("gh", "api"),
+)
+
+FORBIDDEN_COMMAND_TOKENS = {
+    "rm",
+    "rmdir",
+    "mv",
+    "cp",
+    "chmod",
+    "chown",
+    "sudo",
+    "su",
+    "ssh",
+    "scp",
+    "rsync",
+    "curl",
+    "wget",
+    "docker",
+    "systemctl",
+    "journalctl",
+    "kill",
+    "pkill",
+    "reboot",
+    "shutdown",
+    "dd",
+    "mkfs",
+}
+
+FORBIDDEN_SUBSTRINGS = {
+    "rm -rf",
+    "--force",
+    "push -f",
+    "push --force",
+    "git push -f",
+    "git push --force",
+    ">",
+    ">>",
+    "|",
+    ";",
+    "&&",
+    "||",
+    "`",
+    "$(",
+}
+
+
+class CommandResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    command: str
+    returncode: int
+    stdout_tail: str = ""
+    stderr_tail: str = ""
+
+
+class ActiveExecutionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    issue_number: int
+    issue_url: str = ""
+    mode: ExecutorMode
+    decision: ExecutionDecision
+    status: Literal["planned", "real_complete", "blocked", "failed"]
+    packet: ExecutionPacket
+    command_results: list[CommandResult] = Field(default_factory=list)
+    blocked_reasons: list[str] = Field(default_factory=list)
+    posted_comment_url: str = ""
+    labels_added: list[str] = Field(default_factory=list)
+    labels_removed: list[str] = Field(default_factory=list)
+    next_safe_step: str = ""
+
+
+def parse_command(command: str) -> list[str]:
+    return shlex.split(command)
+
+
+def command_is_allowed(command: str, allowed_commands: list[str] | None = None) -> tuple[bool, str]:
+    stripped = command.strip()
+    if not stripped:
+        return False, "empty_command"
+
+    for forbidden in FORBIDDEN_SUBSTRINGS:
+        if forbidden in stripped:
+            return False, f"forbidden_substring:{forbidden}"
+
+    parts = parse_command(stripped)
+    if not parts:
+        return False, "empty_command_after_parse"
+
+    if parts[0] in FORBIDDEN_COMMAND_TOKENS:
+        return False, f"forbidden_command_token:{parts[0]}"
+
+    if parts[:3] == ["git", "push", "--force"] or parts[:3] == ["git", "push", "-f"]:
+        return False, "git_force_push_blocked"
+
+    allowed_exact = set(allowed_commands or [])
+    if stripped in allowed_exact:
+        return True, ""
+
+    for prefix in SAFE_COMMAND_PREFIXES:
+        if tuple(parts[: len(prefix)]) == prefix:
+            return True, ""
+
+    return False, "command_not_whitelisted"
+
+
+def fetch_execution_candidates(repo: str, *, limit: int) -> list[GitHubIssueExport]:
+    raw_items = _gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            "agent:task",
+            "--label",
+            "agent:audited",
+            "--json",
+            "number,title,url,state,labels",
+            "--limit",
+            str(limit),
+        ]
+    )
+
+    issues: list[GitHubIssueExport] = []
+    for item in raw_items:
+        number = int(item["number"])
+        full = _gh_json(
+            [
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                "number,title,body,labels,comments,url,state",
+            ]
+        )
+        issue = GitHubIssueExport.model_validate(full)
+        labels = {label.name for label in issue.labels}
+        if "agent:audited" in labels and "agent:executed" not in labels:
+            issues.append(issue)
+
+    return issues
+
+
+def build_active_execution_packet(issue: GitHubIssueExport, *, real_run: bool) -> ExecutionPacket:
+    verified, audit_status, audit_comment_url, audit_body = find_verified_audit_comment(issue)
+    labels = sorted(label.name for label in issue.labels)
+
+    return ExecutionPacket(
+        issue_number=issue.number,
+        issue_url=issue.url,
+        title=issue.title,
+        mode=ExecutionMode.REAL if real_run else ExecutionMode.DRY_RUN,
+        real_run=real_run,
+        allowed_commands=[
+            "python -m pytest -q",
+            "python -m ruff check tools/skeleton_core tests/skeleton_core",
+            "python -m tools.skeleton_core.cli validate-state",
+            "git status --short",
+            "git diff --stat",
+        ],
+        target_branch=f"skeleton-exec-issue-{issue.number}",
+        trigger_labels=labels,
+        audit_verified=verified,
+        audit_status=audit_status,
+        audit_comment_url=audit_comment_url,
+        audit_summary=audit_body[:1000],
+        objective=issue.body[:2000],
+        planned_actions=[
+            ExecutionAction(
+                action_id="validate-pytest",
+                action_type=ExecutionActionType.NOOP,
+                description="Run test suite validation only if explicitly authorized by packet.",
+                dry_run_only=not real_run,
+                command="python -m pytest -q" if real_run else "",
+                writes_files=False,
+                network_access=False,
+            ),
+            ExecutionAction(
+                action_id="validate-ruff",
+                action_type=ExecutionActionType.NOOP,
+                description="Run ruff validation only if explicitly authorized by packet.",
+                dry_run_only=not real_run,
+                command=(
+                    "python -m ruff check tools/skeleton_core tests/skeleton_core"
+                    if real_run
+                    else ""
+                ),
+                writes_files=False,
+                network_access=False,
+            ),
+            ExecutionAction(
+                action_id="validate-state",
+                action_type=ExecutionActionType.NOOP,
+                description="Run Skeleton state validation only if explicitly authorized by packet.",
+                dry_run_only=not real_run,
+                command=("python -m tools.skeleton_core.cli validate-state" if real_run else ""),
+                writes_files=False,
+                network_access=False,
+            ),
+        ],
+        sources=[
+            ExecutionSource(
+                source_type="github_issue",
+                reference=issue.url,
+                verified=True,
+                notes="Active executor source issue.",
+            ),
+            ExecutionSource(
+                source_type="audit_report",
+                reference=audit_comment_url,
+                verified=verified,
+                notes="Accepted Gemini audit report comment.",
+            ),
+        ],
+        executor_allowed=real_run,
+        file_writes_allowed=False,
+        pr_creation_allowed=False,
+        merge_allowed=False,
+        deploy_allowed=False,
+        canon_write_allowed=False,
+        next_safe_step=(
+            "Run whitelisted validation commands only."
+            if real_run
+            else "Plan-only active execution packet created."
+        ),
+    )
+
+
+def validate_active_packet(packet: ExecutionPacket) -> list[str]:
+    reasons: list[str] = []
+
+    if not packet.audit_verified:
+        reasons.append("missing_verified_accept_audit_comment")
+    if packet.audit_status not in ACCEPT_STATUSES:
+        reasons.append("audit_status_not_accepted")
+
+    if packet.real_run and not packet.executor_allowed:
+        reasons.append("real_run_requires_executor_allowed")
+
+    if packet.file_writes_allowed:
+        reasons.append("file_writes_not_allowed_in_sprint_7_phase_1")
+    if packet.pr_creation_allowed:
+        reasons.append("pr_creation_not_allowed_in_sprint_7_phase_1")
+    if packet.merge_allowed:
+        reasons.append("merge_not_allowed")
+    if packet.deploy_allowed:
+        reasons.append("deploy_not_allowed")
+    if packet.canon_write_allowed:
+        reasons.append("canon_write_not_allowed")
+
+    for action in packet.planned_actions:
+        if action.writes_files:
+            reasons.append(f"action_{action.action_id}_writes_files")
+        if action.action_type not in {
+            ExecutionActionType.NOOP,
+            ExecutionActionType.COMMENT_ONLY,
+            ExecutionActionType.LABEL_TRANSITION_ONLY,
+        }:
+            reasons.append(f"action_{action.action_id}_unsupported_action_type")
+        if action.command:
+            allowed, reason = command_is_allowed(
+                action.command,
+                packet.allowed_commands,
+            )
+            if not allowed:
+                reasons.append(f"action_{action.action_id}_{reason}")
+
+    return sorted(set(reasons))
+
+
+def run_command(command: str, *, cwd: Path) -> CommandResult:
+    parts = parse_command(command)
+    completed = subprocess.run(
+        parts,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return CommandResult(
+        command=command,
+        returncode=completed.returncode,
+        stdout_tail=completed.stdout[-2000:],
+        stderr_tail=completed.stderr[-2000:],
+    )
+
+
+def _post_comment(repo: str, issue_number: int, body: str) -> str:
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".json",
+        prefix=f"active-executor-{issue_number}-comment-",
+        delete=False,
+        encoding="utf-8",
+    ) as handle:
+        payload_path = Path(handle.name)
+        handle.write(json.dumps({"body": body}, ensure_ascii=False))
+
+    try:
+        completed = _run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/{repo}/issues/{issue_number}/comments",
+                "--input",
+                str(payload_path),
+                "--jq",
+                ".html_url",
+            ]
+        )
+        return completed.stdout.strip()
+    finally:
+        with suppress(FileNotFoundError):
+            payload_path.unlink()
+
+
+def _edit_labels(
+    repo: str,
+    issue_number: int,
+    *,
+    add: list[str] | None = None,
+    remove: list[str] | None = None,
+) -> None:
+    args = ["gh", "issue", "edit", str(issue_number), "--repo", repo]
+    if add:
+        args.extend(["--add-label", ",".join(add)])
+    if remove:
+        args.extend(["--remove-label", ",".join(remove)])
+    _run(args)
+
+
+def _comment_body(result: ActiveExecutionResult) -> str:
+    payload = json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2)
+    return (
+        "Active Executor Report\n\n"
+        f"Issue: #{result.issue_number}\n"
+        f"Mode: `{result.mode}`\n"
+        f"Decision: `{result.decision}`\n"
+        f"Status: `{result.status}`\n"
+        f"Blocked reasons: `{result.blocked_reasons}`\n\n"
+        "Safety:\n"
+        "- no file writes allowed\n"
+        "- no PR creation allowed\n"
+        "- no merge allowed\n"
+        "- no deploy allowed\n"
+        "- no canon write allowed\n\n"
+        "```json\n"
+        f"{payload[-6000:]}\n"
+        "```\n"
+    )
+
+
+def execute_packet(
+    packet: ExecutionPacket,
+    *,
+    repo_root: Path | None = None,
+) -> tuple[ExecutionDecision, list[CommandResult], list[str]]:
+    """Execute a packet if and only if it passes all active-executor gates."""
+    root = repo_root or Path.cwd()
+    blocked = validate_active_packet(packet)
+    if blocked:
+        return ExecutionDecision.BLOCKED, [], blocked
+
+    if not packet.real_run:
+        return ExecutionDecision.WOULD_EXECUTE, [], []
+
+    results: list[CommandResult] = []
+    for action in packet.planned_actions:
+        if not action.command:
+            continue
+
+        append_to_skeleton_diary(
+            f"[REAL_EXECUTION] Module active_executor starting command for "
+            f"Issue #{packet.issue_number}: {action.command}"
+        )
+
+        result = run_command(action.command, cwd=root)
+        results.append(result)
+
+        append_to_skeleton_diary(
+            f"[REAL_EXECUTION] Module active_executor completed command for "
+            f"Issue #{packet.issue_number}: {action.command}; returncode={result.returncode}"
+        )
+
+        if result.returncode != 0:
+            create_system_snapshot(last_processed_issue_id=packet.issue_number)
+            return (
+                ExecutionDecision.FAILED,
+                results,
+                [f"command_failed:{action.action_id}:{result.returncode}"],
+            )
+
+    create_system_snapshot(last_processed_issue_id=packet.issue_number)
+    return ExecutionDecision.WOULD_EXECUTE, results, []
+
+
+def process_issue(
+    repo: str,
+    issue: GitHubIssueExport,
+    *,
+    mode: ExecutorMode,
+    repo_root: Path | None = None,
+) -> ActiveExecutionResult:
+    real_run = mode == "real"
+    packet = build_active_execution_packet(issue, real_run=real_run)
+    decision, command_results, blocked_reasons = execute_packet(packet, repo_root=repo_root)
+
+    if blocked_reasons:
+        status: Literal["planned", "real_complete", "blocked", "failed"] = (
+            "failed" if decision == ExecutionDecision.FAILED else "blocked"
+        )
+        labels_added = ["agent:execution-failed"]
+        labels_removed = ["agent:executing"]
+    else:
+        status = "real_complete" if real_run else "planned"
+        labels_added = ["agent:executed"]
+        labels_removed = ["agent:audited", "agent:executing"]
+
+    result = ActiveExecutionResult(
+        issue_number=issue.number,
+        issue_url=issue.url,
+        mode=mode,
+        decision=decision,
+        status=status,
+        packet=packet,
+        command_results=command_results,
+        blocked_reasons=blocked_reasons,
+        labels_added=labels_added,
+        labels_removed=labels_removed,
+        next_safe_step=(
+            "Stop and alert Oleksii."
+            if blocked_reasons
+            else "Active executor phase complete. Await human review."
+        ),
+    )
+
+    comment_url = _post_comment(repo, issue.number, _comment_body(result))
+    _edit_labels(repo, issue.number, add=labels_added, remove=labels_removed)
+    result.posted_comment_url = comment_url
+
+    if real_run:
+        append_to_skeleton_diary(
+            f"[REAL_EXECUTION] Module active_executor processed "
+            f"Issue #{issue.number} with status={status}; "
+            f"decision={decision}; comment_url={comment_url}"
+        )
+        create_system_snapshot(last_processed_issue_id=issue.number)
+
+    return result
+
+
+def process_queue(
+    repo: str,
+    *,
+    limit: int,
+    mode: ExecutorMode,
+    repo_root: Path | None = None,
+) -> list[ActiveExecutionResult]:
+    issues = fetch_execution_candidates(repo, limit=limit)
+    return [process_issue(repo, issue, mode=mode, repo_root=repo_root) for issue in issues]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Skeleton active executor.")
+    parser.add_argument("--repo", default="alanua/jeeves")
+    parser.add_argument("--limit", type=int, default=1)
+    parser.add_argument("--mode", choices=["plan", "real"], default="plan")
+    args = parser.parse_args(argv)
+
+    results = process_queue(args.repo, limit=args.limit, mode=args.mode)
+
+    print(
+        json.dumps(
+            {
+                "schema_version": "active_executor.result.v1",
+                "repo": args.repo,
+                "mode": args.mode,
+                "processed": len(results),
+                "results": [result.model_dump(mode="json") for result in results],
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        flush=True,
+    )
+
+    if any(result.status in {"blocked", "failed"} for result in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/skeleton_core/bounded_execution_packet.py
+++ b/tools/skeleton_core/bounded_execution_packet.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class ExecutionMode(StrEnum):
     DRY_RUN = "dry_run"
+    REAL = "real"
 
 
 class ExecutionDecision(StrEnum):
@@ -64,6 +65,9 @@ class ExecutionPacket(BaseModel):
     title: str
 
     mode: ExecutionMode = ExecutionMode.DRY_RUN
+    real_run: bool = False
+    allowed_commands: list[str] = Field(default_factory=list)
+    target_branch: str = ""
     trigger_labels: list[str] = Field(default_factory=list)
 
     audit_verified: bool

--- a/tools/skeleton_core/memory_service.py
+++ b/tools/skeleton_core/memory_service.py
@@ -1,0 +1,146 @@
+"""Skeleton Core technical memory service.
+
+Writes only to knowledge_base/.
+This is Skeleton technical memory, not Jeeves personality memory.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LOCK_FILE = Path("/home/agent/agent-dev/runner-state/yellow_runnerd.lock")
+
+VERIFIED_MODULE_PATHS = {
+    "gemini_auditor_adapter": "tools/skeleton_core/gemini_auditor_adapter.py",
+    "dual_brain_task_packet": "tools/skeleton_core/dual_brain_task_packet.py",
+    "issue_to_gemini_audit": "tools/skeleton_core/issue_to_gemini_audit.py",
+    "yellow_gemini_audit_route": "tools/skeleton_core/yellow_gemini_audit_route.py",
+    "yellow_runnerd": "tools/skeleton_core/yellow_runnerd.py",
+    "bounded_execution_packet": "tools/skeleton_core/bounded_execution_packet.py",
+    "dry_run_execution_route": "tools/skeleton_core/dry_run_execution_route.py",
+    "active_executor": "tools/skeleton_core/active_executor.py",
+}
+
+
+def utc_now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _repo_root(repo_root: str | Path | None = None) -> Path:
+    return Path(repo_root).resolve() if repo_root else Path.cwd().resolve()
+
+
+def _knowledge_base_dir(repo_root: str | Path | None = None) -> Path:
+    kb_dir = _repo_root(repo_root) / "knowledge_base"
+    kb_dir.mkdir(parents=True, exist_ok=True)
+    return kb_dir
+
+
+def _git_head_hash(repo_root: Path) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return completed.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _pid_is_running(pid: int) -> bool:
+    return pid > 0 and Path(f"/proc/{pid}").exists()
+
+
+def _daemon_status(lock_file: Path = DEFAULT_LOCK_FILE) -> dict[str, Any]:
+    lock_exists = lock_file.exists()
+    pid: int | None = None
+
+    if lock_exists:
+        raw = lock_file.read_text(encoding="utf-8", errors="replace").strip()
+        if raw.isdigit():
+            pid = int(raw)
+
+    return {
+        "lock_file": str(lock_file),
+        "lock_exists": lock_exists,
+        "pid": pid,
+        "process_running": _pid_is_running(pid) if pid is not None else False,
+    }
+
+
+def _verified_modules(repo_root: Path) -> dict[str, bool]:
+    return {
+        name: (repo_root / relative_path).exists()
+        for name, relative_path in VERIFIED_MODULE_PATHS.items()
+    }
+
+
+def _read_previous_snapshot(snapshot_path: Path) -> dict[str, Any]:
+    if not snapshot_path.exists():
+        return {}
+    try:
+        data = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def append_to_skeleton_diary(entry: str, *, repo_root: str | Path | None = None) -> Path:
+    kb_dir = _knowledge_base_dir(repo_root)
+    diary_path = kb_dir / "skeleton_diary.md"
+
+    if not diary_path.exists():
+        diary_path.write_text(
+            "# Skeleton Technical Diary\n\n"
+            "Append-only technical memory for Skeleton Core operations.\n\n",
+            encoding="utf-8",
+        )
+
+    with diary_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"## {utc_now_iso()}\n\n")
+        handle.write("- source: skeleton_core\n")
+        handle.write("- memory_layer: L2_skeleton_diary\n")
+        handle.write(f"- entry: {entry.strip()}\n\n")
+
+    return diary_path
+
+
+def create_system_snapshot(
+    *,
+    last_processed_issue_id: int | None = None,
+    repo_root: str | Path | None = None,
+    lock_file: str | Path = DEFAULT_LOCK_FILE,
+) -> Path:
+    root = _repo_root(repo_root)
+    kb_dir = _knowledge_base_dir(root)
+    snapshot_path = kb_dir / "current_state.json"
+
+    previous = _read_previous_snapshot(snapshot_path)
+    effective_last_issue = (
+        last_processed_issue_id
+        if last_processed_issue_id is not None
+        else previous.get("last_processed_issue_id")
+    )
+
+    snapshot = {
+        "schema_version": "skeleton_current_state.v1",
+        "generated_at_utc": utc_now_iso(),
+        "memory_layer": "L1_system_snapshot",
+        "last_processed_issue_id": effective_last_issue,
+        "active_daemon_status": _daemon_status(Path(lock_file)),
+        "git_head_hash": _git_head_hash(root),
+        "verified_modules": _verified_modules(root),
+    }
+
+    snapshot_path.write_text(
+        json.dumps(snapshot, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return snapshot_path


### PR DESCRIPTION
Adds Sprint 7 active executor phase 1.

Scope:
- adds active_executor.py
- adds real_run fields to ExecutionPacket
- adds Skeleton memory_service dependency
- implements strict command allowlist
- blocks destructive commands and force push
- supports plan and real modes
- logs real execution with [REAL_EXECUTION] prefix
- updates current_state.json on real execution/failure

Safety:
- no rm/rm -rf
- no sudo/systemctl/docker/network shell tools
- no git push --force
- fail-closed on non-zero command return
- no file writes, PR creation, merge, deploy, or canon writes allowed by packet

Validation:
- pytest targeted: 15 passed
- ruff: passed
- validate-state: ok