### PR TITLE
feat(core): add bounded create-pr CLI

### DIFF
--- a/tests/skeleton_core/test_cli_create_pr.py
+++ b/tests/skeleton_core/test_cli_create_pr.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.skeleton_core.atomic_writer import AtomicWritePanic
+from tools.skeleton_core.cli_create_pr import (
+    CreatePrPanic,
+    parse_target_files,
+    validate_target_file,
+    validate_target_files,
+)
+
+
+def test_parse_target_files_rejects_shortcuts() -> None:
+    with pytest.raises(CreatePrPanic):
+        parse_target_files(".")
+
+    with pytest.raises(CreatePrPanic):
+        parse_target_files("-A")
+
+
+def test_validate_target_file_allows_green_zone_report(tmp_path: Path) -> None:
+    target = tmp_path / "knowledge_base" / "reports" / "report.json"
+    target.parent.mkdir(parents=True)
+    target.write_text("{}", encoding="utf-8")
+
+    assert (
+        validate_target_file("knowledge_base/reports/report.json", repo_root=tmp_path)
+        == "knowledge_base/reports/report.json"
+    )
+
+
+def test_validate_target_file_allows_skeleton_diary(tmp_path: Path) -> None:
+    target = tmp_path / "knowledge_base" / "skeleton_diary.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# diary\n", encoding="utf-8")
+
+    assert (
+        validate_target_file("knowledge_base/skeleton_diary.md", repo_root=tmp_path)
+        == "knowledge_base/skeleton_diary.md"
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "src/bad.py",
+        "tests/bad.py",
+        "canon/bad.md",
+        "README.md",
+    ],
+)
+def test_validate_target_file_blocks_bad_paths(tmp_path: Path, bad_path: str) -> None:
+    target = tmp_path / bad_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("bad", encoding="utf-8")
+
+    with pytest.raises((CreatePrPanic, AtomicWritePanic)):
+        validate_target_file(bad_path, repo_root=tmp_path)
+
+
+def test_validate_target_files_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(CreatePrPanic):
+        validate_target_files(["knowledge_base/reports/missing.json"], repo_root=tmp_path)

--- a/tools/skeleton_core/active_executor.py
+++ b/tools/skeleton_core/active_executor.py
@@ -52,6 +52,7 @@ ExecutorMode = Literal["plan", "real"]
 
 VALIDATE_STATE_COMMAND = "python -m tools.skeleton_core.cli validate-state"
 CREATE_REPORT_COMMAND = "python -m tools.skeleton_core.cli create-report"
+CREATE_PR_COMMAND = "python -m tools.skeleton_core.cli create-pr"
 
 ALLOWED_WRITE_PATHS = [
     "knowledge_base/active_tasks/",
@@ -64,6 +65,7 @@ SAFE_COMMAND_PREFIXES = (
     ("python", "-m", "black", "--check"),
     ("python", "-m", "tools.skeleton_core.cli", "validate-state"),
     ("python", "-m", "tools.skeleton_core.cli", "create-report"),
+    ("python", "-m", "tools.skeleton_core.cli", "create-pr"),
     ("git", "status", "--short"),
     ("git", "diff", "--stat"),
 )
@@ -115,9 +117,13 @@ class ActiveTaskPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: int
-    type: Literal["integrity_check"]
+    type: Literal["integrity_check", "pr_creation"]
     command: str
     safety_level: Literal["green"]
+    pr_creation_allowed: bool = False
+    target_files: list[str] = Field(default_factory=list)
+    pr_title: str = ""
+    pr_body: str = ""
 
 
 class CommandResult(BaseModel):
@@ -200,8 +206,27 @@ def load_active_task_payload(
     if payload.id != issue_number:
         return None, [f"task_payload_id_mismatch:{payload.id}!={issue_number}"]
 
-    if payload.command not in {VALIDATE_STATE_COMMAND, CREATE_REPORT_COMMAND}:
+    if payload.command not in {
+        VALIDATE_STATE_COMMAND,
+        CREATE_REPORT_COMMAND,
+        CREATE_PR_COMMAND,
+    }:
         return None, [f"task_payload_command_not_allowed:{payload.command}"]
+
+    if payload.command == CREATE_PR_COMMAND:
+        blocked: list[str] = []
+        if payload.type != "pr_creation":
+            blocked.append("create_pr_requires_pr_creation_type")
+        if not payload.pr_creation_allowed:
+            blocked.append("create_pr_requires_pr_creation_allowed_true")
+        if not payload.target_files:
+            blocked.append("create_pr_requires_target_files")
+        if not payload.pr_title.strip():
+            blocked.append("create_pr_requires_pr_title")
+        if not payload.pr_body.strip():
+            blocked.append("create_pr_requires_pr_body")
+        if blocked:
+            return None, blocked
 
     return payload, []
 
@@ -217,6 +242,23 @@ def safe_write(target_path: str | Path, content: str, *, repo_root: Path | None 
 
 def report_target_path(issue_number: int) -> str:
     return f"knowledge_base/reports/self_integrity_report_{issue_number}.json"
+
+
+def build_create_pr_command(issue_number: int, task_payload: ActiveTaskPayload) -> str:
+    target_files = ",".join(task_payload.target_files)
+    return " ".join(
+        [
+            CREATE_PR_COMMAND,
+            "--issue",
+            str(issue_number),
+            "--target-files",
+            shlex.quote(target_files),
+            "--title",
+            shlex.quote(task_payload.pr_title),
+            "--body",
+            shlex.quote(task_payload.pr_body),
+        ]
+    )
 
 
 def build_self_integrity_report(issue: GitHubIssueExport, packet: ExecutionPacket) -> str:
@@ -308,11 +350,19 @@ def build_active_execution_packet(
     command = task_payload.command if task_payload else VALIDATE_STATE_COMMAND
 
     writes_files = command == CREATE_REPORT_COMMAND
-    action_id = (
-        "atomic-write-self-integrity-report" if writes_files else "first-breath-validate-state"
-    )
+    creates_pr = command == CREATE_PR_COMMAND
 
-    planned_command = command if real_run else ""
+    if creates_pr:
+        action_id = "create-pr-for-green-zone-artifacts"
+    elif writes_files:
+        action_id = "atomic-write-self-integrity-report"
+    else:
+        action_id = "first-breath-validate-state"
+
+    if creates_pr and task_payload is not None:
+        planned_command = build_create_pr_command(issue.number, task_payload) if real_run else ""
+    else:
+        planned_command = command if real_run else ""
 
     return ExecutionPacket(
         issue_number=issue.number,
@@ -320,7 +370,7 @@ def build_active_execution_packet(
         title=issue.title,
         mode=ExecutionMode.REAL if real_run else ExecutionMode.DRY_RUN,
         real_run=real_run,
-        allowed_commands=[VALIDATE_STATE_COMMAND, CREATE_REPORT_COMMAND],
+        allowed_commands=[VALIDATE_STATE_COMMAND, CREATE_REPORT_COMMAND, CREATE_PR_COMMAND],
         target_branch=f"skeleton-exec-issue-{issue.number}",
         trigger_labels=labels,
         audit_verified=verified,
@@ -333,9 +383,13 @@ def build_active_execution_packet(
                 action_id=action_id,
                 action_type=ExecutionActionType.NOOP,
                 description=(
-                    "Sprint 8 atomic Green Zone report write."
-                    if writes_files
-                    else "Read-only Skeleton integrity check."
+                    "Sprint 9 bounded PR creation for explicit target files."
+                    if creates_pr
+                    else (
+                        "Sprint 8 atomic Green Zone report write."
+                        if writes_files
+                        else "Read-only Skeleton integrity check."
+                    )
                 ),
                 dry_run_only=not real_run,
                 command=planned_command,
@@ -359,7 +413,7 @@ def build_active_execution_packet(
         ],
         executor_allowed=real_run,
         file_writes_allowed=writes_files,
-        pr_creation_allowed=False,
+        pr_creation_allowed=creates_pr,
         merge_allowed=False,
         deploy_allowed=False,
         canon_write_allowed=False,
@@ -390,8 +444,14 @@ def validate_active_packet(packet: ExecutionPacket) -> list[str]:
     if packet.real_run and not packet.executor_allowed:
         reasons.append("real_run_requires_executor_allowed")
 
-    if packet.pr_creation_allowed:
-        reasons.append("pr_creation_not_allowed")
+    create_pr_actions = [
+        action for action in packet.planned_actions if action.command.startswith(CREATE_PR_COMMAND)
+    ]
+
+    if packet.pr_creation_allowed and not create_pr_actions:
+        reasons.append("pr_creation_allowed_without_create_pr_action")
+    if create_pr_actions and not packet.pr_creation_allowed:
+        reasons.append("create_pr_action_requires_pr_creation_allowed")
     if packet.merge_allowed:
         reasons.append("merge_not_allowed")
     if packet.deploy_allowed:

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -9,6 +9,11 @@ if len(sys.argv) > 1 and sys.argv[1] == "create-report":
 
     raise SystemExit(_create_report_main(sys.argv[2:]))
 
+if len(sys.argv) > 1 and sys.argv[1] == "create-pr":
+    from tools.skeleton_core.cli_create_pr import main as _create_pr_main
+
+    raise SystemExit(_create_pr_main(sys.argv[2:]))
+
 import argparse
 import json
 import sys

--- a/tools/skeleton_core/cli_create_pr.py
+++ b/tools/skeleton_core/cli_create_pr.py
@@ -1,0 +1,294 @@
+"""Bounded GitHub PR creator for Skeleton Core.
+
+Sprint 9: Git Autonomy.
+
+This module is intentionally narrow:
+- no git add . / git add -A
+- no force push
+- no src/, tests/, or canon/ mutation
+- target files must be explicit
+- target files must be inside Green Zone or explicitly allowed
+- tracked dirty files outside target files cause fail-closed panic
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+from tools.skeleton_core.atomic_writer import ALLOWED_WRITE_PATHS, AtomicWritePanic
+from tools.skeleton_core.memory_service import append_to_skeleton_diary, utc_now_iso
+
+EXPLICIT_ALLOWED_FILES = {
+    "knowledge_base/skeleton_diary.md",
+}
+
+IMMUTABLE_PREFIXES = (
+    "src/",
+    "tests/",
+    "canon/",
+)
+
+
+class CreatePrPanic(RuntimeError):
+    """Fail-closed PR creation panic."""
+
+
+def _run(args: list[str], *, cwd: Path) -> str:
+    completed = subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise CreatePrPanic(
+            "git_or_gh_command_failed:"
+            + json.dumps(
+                {
+                    "args": args,
+                    "returncode": completed.returncode,
+                    "stdout_tail": completed.stdout[-1000:],
+                    "stderr_tail": completed.stderr[-1000:],
+                },
+                ensure_ascii=False,
+            )
+        )
+    return completed.stdout.strip()
+
+
+def _repo_root(repo_root: str | Path | None = None) -> Path:
+    if repo_root is not None:
+        return Path(repo_root).resolve()
+    return Path.cwd().resolve()
+
+
+def parse_target_files(raw: str) -> list[str]:
+    files = [item.strip() for item in raw.split(",") if item.strip()]
+    if not files:
+        raise CreatePrPanic("no_target_files")
+
+    if "." in files or "./" in files or "-A" in files:
+        raise CreatePrPanic("forbidden_target_file_shortcut")
+
+    if len(files) != len(set(files)):
+        raise CreatePrPanic("duplicate_target_files")
+
+    return files
+
+
+def _to_repo_relative(path: str | Path, *, repo_root: Path) -> str:
+    candidate = Path(path)
+
+    resolved = candidate.resolve() if candidate.is_absolute() else (repo_root / candidate).resolve()
+
+    try:
+        rel = resolved.relative_to(repo_root)
+    except ValueError as err:
+        raise CreatePrPanic(f"target_file_outside_repo:{path}") from err
+
+    rel_str = rel.as_posix()
+
+    if rel_str in {"", "."}:
+        raise CreatePrPanic("target_file_is_repo_root")
+
+    return rel_str
+
+
+def validate_target_file(path: str | Path, *, repo_root: str | Path | None = None) -> str:
+    root = _repo_root(repo_root)
+    rel = _to_repo_relative(path, repo_root=root)
+
+    for prefix in IMMUTABLE_PREFIXES:
+        if rel == prefix.rstrip("/") or rel.startswith(prefix):
+            raise CreatePrPanic(f"target_file_in_immutable_zone:{rel}")
+
+    target = root / rel
+    if not target.exists():
+        raise CreatePrPanic(f"target_file_missing:{rel}")
+    if not target.is_file():
+        raise CreatePrPanic(f"target_file_not_regular_file:{rel}")
+
+    if rel in EXPLICIT_ALLOWED_FILES:
+        return rel
+
+    for allowed_raw in ALLOWED_WRITE_PATHS:
+        allowed_prefix = allowed_raw.rstrip("/") + "/"
+        if rel.startswith(allowed_prefix):
+            return rel
+
+    raise AtomicWritePanic(f"target_file_outside_green_zone:{rel}")
+
+
+def validate_target_files(
+    target_files: list[str],
+    *,
+    repo_root: str | Path | None = None,
+) -> list[str]:
+    return [validate_target_file(path, repo_root=repo_root) for path in target_files]
+
+
+def _dirty_tracked_files(*, repo_root: Path) -> set[str]:
+    unstaged = _run(["git", "diff", "--name-only"], cwd=repo_root)
+    staged = _run(["git", "diff", "--cached", "--name-only"], cwd=repo_root)
+
+    dirty: set[str] = set()
+    for blob in (unstaged, staged):
+        for line in blob.splitlines():
+            item = line.strip()
+            if item:
+                dirty.add(item)
+    return dirty
+
+
+def ensure_tracked_dirty_files_are_explicit_targets(
+    target_files: list[str],
+    *,
+    repo_root: Path,
+) -> None:
+    dirty = _dirty_tracked_files(repo_root=repo_root)
+    allowed = set(target_files)
+    unexpected = sorted(dirty - allowed)
+
+    if unexpected:
+        raise CreatePrPanic(
+            "tracked_worktree_dirty_outside_target_files:"
+            + json.dumps(unexpected, ensure_ascii=False)
+        )
+
+
+def ensure_start_branch_safe(*, repo_root: Path) -> None:
+    branch = _run(["git", "branch", "--show-current"], cwd=repo_root)
+    if branch != "main":
+        raise CreatePrPanic(f"must_start_from_main_current_branch_is:{branch}")
+
+
+def branch_exists(branch: str, *, repo_root: Path) -> bool:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--verify", branch],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+def create_pull_request(
+    *,
+    issue: int,
+    target_files: list[str],
+    title: str,
+    body: str,
+    repo: str,
+    repo_root: str | Path | None = None,
+) -> dict[str, object]:
+    root = _repo_root(repo_root)
+    validated_files = validate_target_files(target_files, repo_root=root)
+
+    ensure_start_branch_safe(repo_root=root)
+    ensure_tracked_dirty_files_are_explicit_targets(validated_files, repo_root=root)
+
+    branch = f"agent-auto-pr-issue-{issue}"
+
+    if branch_exists(branch, repo_root=root):
+        raise CreatePrPanic(f"branch_already_exists:{branch}")
+
+    _run(["git", "switch", "-c", branch], cwd=root)
+
+    for rel in validated_files:
+        if rel in {".", "-A"}:
+            raise CreatePrPanic(f"forbidden_git_add_target:{rel}")
+        _run(["git", "add", "--force", "--", rel], cwd=root)
+
+    staged = _run(["git", "diff", "--cached", "--name-only"], cwd=root)
+    staged_files = [line.strip() for line in staged.splitlines() if line.strip()]
+
+    if sorted(staged_files) != sorted(validated_files):
+        raise CreatePrPanic(
+            "staged_files_mismatch:"
+            + json.dumps(
+                {
+                    "expected": sorted(validated_files),
+                    "actual": sorted(staged_files),
+                },
+                ensure_ascii=False,
+            )
+        )
+
+    _run(["git", "commit", "-m", f"Auto-generated PR for Issue #{issue}"], cwd=root)
+    _run(["git", "push", "-u", "origin", branch], cwd=root)
+
+    pr_url = _run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            repo,
+            "--base",
+            "main",
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+        ],
+        cwd=root,
+    )
+
+    append_to_skeleton_diary(
+        f"[REAL_EXECUTION] Module cli_create_pr created PR for Issue #{issue}: {pr_url}"
+    )
+
+    return {
+        "ok": True,
+        "schema_version": "skeleton_create_pr_result.v1",
+        "issue": issue,
+        "branch": branch,
+        "target_files": validated_files,
+        "pr_url": pr_url,
+        "created_at_utc": utc_now_iso(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Create a bounded Skeleton PR.")
+    parser.add_argument("--issue", type=int, required=True)
+    parser.add_argument("--target-files", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--body", required=True)
+    parser.add_argument("--repo", default="alanua/jeeves")
+    args = parser.parse_args(argv)
+
+    try:
+        result = create_pull_request(
+            issue=args.issue,
+            target_files=parse_target_files(args.target_files),
+            title=args.title,
+            body=args.body,
+            repo=args.repo,
+        )
+    except Exception as err:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": str(err),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return 1
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements Sprint 9 Git Autonomy foundation.

Scope:
- adds tools/skeleton_core/cli_create_pr.py
- routes python -m tools.skeleton_core.cli create-pr
- allows active_executor to build a create-pr command only when task payload explicitly enables pr_creation_allowed
- target files must be explicit and must exist
- target files must be inside Green Zone or explicitly allowed, such as knowledge_base/skeleton_diary.md
- src/, tests/, and canon/ remain immutable
- dirty tracked files outside explicit target files cause fail-closed panic
- git add . and git add -A are not used
- git push --force is not used
- PR URL is logged to skeleton_diary.md

Safety:
- fail-closed on git/gh command failure
- no mutation of src/, tests/, canon/
- no arbitrary shell execution
- no automatic merge
- no deploy
- no force push

Validation:
- pytest: 319 passed
- ruff: passed
- black --check: passed
- validate-state: ok true