### PR TITLE
feat(core): add read-only canon audit route

### DIFF
--- a/tests/skeleton_core/test_canon_audit_route.py
+++ b/tests/skeleton_core/test_canon_audit_route.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.skeleton_core import canon_audit_route
+from tools.skeleton_core.canon_audit_route import CanonAuditRoutePanic
+
+
+def _issue(labels: list[str] | None = None) -> dict[str, object]:
+    return {
+        "number": 141,
+        "title": "Audit this issue",
+        "body": "Check against canon.",
+        "url": "https://github.com/alanua/jeeves/issues/141",
+        "labels": [{"name": label} for label in (labels or [])],
+    }
+
+
+def test_validate_issue_requires_core_labels() -> None:
+    blocked = canon_audit_route.validate_issue_for_canon_audit(_issue(labels=[]))
+
+    assert any(reason.startswith("missing_required_labels") for reason in blocked)
+    assert "missing_runner_label:runner:hetzner_or_runner:any" in blocked
+
+
+def test_validate_issue_accepts_required_labels() -> None:
+    blocked = canon_audit_route.validate_issue_for_canon_audit(
+        _issue(
+            labels=[
+                "agent:task",
+                "risk:yellow",
+                "agent:audited",
+                "agent:canon-audit",
+                "runner:hetzner",
+            ]
+        )
+    )
+
+    assert blocked == []
+
+
+def test_validate_issue_blocks_secret_in_body() -> None:
+    issue = _issue(
+        labels=[
+            "agent:task",
+            "risk:yellow",
+            "agent:audited",
+            "agent:canon-audit",
+            "runner:hetzner",
+        ]
+    )
+    issue["body"] = "OPENAI_API_KEY=value"
+
+    blocked = canon_audit_route.validate_issue_for_canon_audit(issue)
+
+    assert any(reason.startswith("secret_pattern_detected_in_issue") for reason in blocked)
+
+
+def test_run_canon_audit_posts_comment_without_local_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for rel in ["BOOTLOADER.md", "knowledge_base/MEMORY_POLICY.md"]:
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("canon text\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        canon_audit_route,
+        "fetch_issue",
+        lambda repo, issue_number: _issue(
+            labels=[
+                "agent:task",
+                "risk:yellow",
+                "agent:audited",
+                "agent:canon-audit",
+                "runner:hetzner",
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        canon_audit_route,
+        "build_canon_bundle",
+        lambda root=None: "--- FILE: BOOTLOADER.md ---\ncanon text",
+    )
+    monkeypatch.setattr(
+        canon_audit_route,
+        "query_gemini",
+        lambda prompt, model="gemini-2.5-flash": "verdict: aligned",
+    )
+    monkeypatch.setattr(
+        canon_audit_route,
+        "post_comment",
+        lambda repo, issue_number, body: "https://github.com/alanua/jeeves/issues/141#comment",
+    )
+
+    label_edits: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
+
+    def fake_edit_labels(
+        repo: str,
+        issue_number: int,
+        *,
+        add: tuple[str, ...],
+        remove: tuple[str, ...],
+    ) -> None:
+        label_edits.append((add, remove))
+
+    monkeypatch.setattr(canon_audit_route, "edit_labels", fake_edit_labels)
+
+    result = canon_audit_route.run_canon_audit(
+        repo="alanua/jeeves",
+        issue_number=141,
+        repo_root=tmp_path,
+    )
+
+    assert result.status == "audit_complete"
+    assert result.writes_files is False
+    assert result.creates_pr is False
+    assert result.merge_allowed is False
+    assert label_edits == [(("agent:audit-complete",), ("agent:audited",))]
+
+
+def test_run_canon_audit_blocks_unapproved_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        canon_audit_route,
+        "fetch_issue",
+        lambda repo, issue_number: _issue(labels=["agent:task"]),
+    )
+
+    with pytest.raises(CanonAuditRoutePanic):
+        canon_audit_route.run_canon_audit(repo="alanua/jeeves", issue_number=141)

--- a/tests/skeleton_core/test_canon_reader.py
+++ b/tests/skeleton_core/test_canon_reader.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.skeleton_core.canon_reader import (
+    ALLOWED_CANON_PATHS,
+    CanonReaderPanic,
+    build_canon_bundle,
+    read_canon_file,
+    scan_sensitive_text,
+    validate_canon_path,
+)
+
+
+def _make_allowed_files(root: Path) -> None:
+    for rel in ALLOWED_CANON_PATHS:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"content for {rel}\n", encoding="utf-8")
+
+
+def test_validate_canon_path_allows_allowlisted_file(tmp_path: Path) -> None:
+    _make_allowed_files(tmp_path)
+
+    resolved = validate_canon_path("BOOTLOADER.md", root=tmp_path)
+
+    assert resolved == tmp_path / "BOOTLOADER.md"
+
+
+def test_validate_canon_path_blocks_non_allowlisted_file(tmp_path: Path) -> None:
+    path = tmp_path / "README.md"
+    path.write_text("not allowed", encoding="utf-8")
+
+    with pytest.raises(CanonReaderPanic):
+        validate_canon_path("README.md", root=tmp_path)
+
+
+def test_read_canon_file_fails_closed_on_secret_pattern(tmp_path: Path) -> None:
+    path = tmp_path / "BOOTLOADER.md"
+    path.write_text("OPENAI_API_KEY=secret", encoding="utf-8")
+
+    with pytest.raises(CanonReaderPanic):
+        read_canon_file("BOOTLOADER.md", root=tmp_path)
+
+
+def test_build_canon_bundle_reads_allowlist(tmp_path: Path) -> None:
+    _make_allowed_files(tmp_path)
+
+    bundle = build_canon_bundle(paths=["BOOTLOADER.md"], root=tmp_path)
+
+    assert "--- FILE: BOOTLOADER.md ---" in bundle
+    assert "content for BOOTLOADER.md" in bundle
+
+
+def test_scan_sensitive_text_detects_key_names() -> None:
+    hits = scan_sensitive_text("GEMINI_API_KEY=value")
+
+    assert hits

--- a/tools/skeleton_core/canon_audit_route.py
+++ b/tools/skeleton_core/canon_audit_route.py
@@ -1,0 +1,317 @@
+"""Read-only Skeleton canon audit route.
+
+This route:
+- validates that a GitHub issue passed the normal YELLOW audit gate
+- reads allowlisted canon files only
+- sends issue context + canon bundle to Gemini
+- posts the audit report as an issue comment
+- performs no local file writes
+- creates no PR
+- performs no merge/deploy
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from tools.skeleton_core.canon_reader import (
+    CanonReaderPanic,
+    build_canon_bundle,
+    scan_sensitive_text,
+)
+from tools.skeleton_core.llm_service import LLMServicePanic, query_gemini
+
+CANON_AUDIT_ROUTE_SCHEMA_VERSION: Final[str] = "skeleton_canon_audit_route.v1"
+
+REQUIRED_LABELS: Final[frozenset[str]] = frozenset(
+    {
+        "agent:task",
+        "risk:yellow",
+        "agent:audited",
+        "agent:canon-audit",
+    }
+)
+
+RUNNER_LABELS: Final[frozenset[str]] = frozenset({"runner:hetzner", "runner:any"})
+
+
+class CanonAuditRoutePanic(RuntimeError):
+    """Fail-closed canon audit route panic."""
+
+
+@dataclass(frozen=True)
+class CanonAuditRouteResult:
+    issue_number: int
+    issue_url: str
+    status: str
+    comment_url: str
+    labels_added: tuple[str, ...]
+    labels_removed: tuple[str, ...]
+    writes_files: bool = False
+    creates_pr: bool = False
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+    canon_changed: bool = False
+
+
+def _run(args: list[str], *, input_text: str | None = None) -> str:
+    proc = subprocess.run(
+        args,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    if proc.returncode != 0:
+        raise CanonAuditRoutePanic(
+            f"command_failed:{args[0]}:returncode={proc.returncode}:stderr={proc.stderr.strip()}"
+        )
+
+    return proc.stdout
+
+
+def _gh_json(args: list[str]) -> dict[str, Any]:
+    raw = _run(args)
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise CanonAuditRoutePanic("gh_json_not_object")
+    return data
+
+
+def fetch_issue(repo: str, issue_number: int) -> dict[str, Any]:
+    return _gh_json(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,labels,url",
+        ]
+    )
+
+
+def issue_labels(issue: dict[str, Any]) -> set[str]:
+    raw_labels = issue.get("labels", [])
+    labels: set[str] = set()
+
+    if not isinstance(raw_labels, list):
+        raise CanonAuditRoutePanic("issue_labels_not_list")
+
+    for item in raw_labels:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            labels.add(item["name"])
+
+    return labels
+
+
+def validate_issue_for_canon_audit(issue: dict[str, Any]) -> list[str]:
+    labels = issue_labels(issue)
+    blocked: list[str] = []
+
+    missing = sorted(REQUIRED_LABELS - labels)
+    if missing:
+        blocked.append(f"missing_required_labels:{','.join(missing)}")
+
+    if not labels.intersection(RUNNER_LABELS):
+        blocked.append("missing_runner_label:runner:hetzner_or_runner:any")
+
+    body = str(issue.get("body") or "")
+    title = str(issue.get("title") or "")
+
+    sensitive_hits = scan_sensitive_text(title + "\n" + body)
+    if sensitive_hits:
+        blocked.append(f"secret_pattern_detected_in_issue:{','.join(sensitive_hits)}")
+
+    return blocked
+
+
+def build_prompt(issue: dict[str, Any], canon_bundle: str) -> str:
+    title = str(issue.get("title") or "")
+    body = str(issue.get("body") or "")
+    url = str(issue.get("url") or "")
+
+    return f"""
+You are Gemini acting as external auditor for the ChatGPT Exoskeleton / Skeleton Core project.
+
+Hard role boundary:
+- You are an auditor and evidence source only.
+- You must not write canon.
+- You must not modify files.
+- You must not execute commands.
+- You must not merge, deploy, or approve changes.
+- You must clearly separate verified facts from assumptions.
+
+Task:
+Audit whether the provided GitHub issue is aligned with the provided Skeleton canon documents.
+
+GitHub issue:
+Title: {title}
+URL: {url}
+
+Body:
+{body}
+
+Canon bundle:
+{canon_bundle}
+
+Output:
+Return a structured audit report with:
+1. verdict: aligned / mostly aligned / partially aligned / unsafe
+2. key findings
+3. canon alignment
+4. canon drift or contradictions
+5. security and authority concerns
+6. required corrections
+7. final recommendation
+
+Hard constraints:
+- Treat this report as audit evidence only.
+- Do not propose autonomous merge/deploy.
+- Do not propose autonomous canon promotion.
+"""
+
+
+def post_comment(repo: str, issue_number: int, body: str) -> str:
+    return _run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--body-file",
+            "-",
+        ],
+        input_text=body,
+    ).strip()
+
+
+def edit_labels(
+    repo: str,
+    issue_number: int,
+    *,
+    add: tuple[str, ...],
+    remove: tuple[str, ...],
+) -> None:
+    for label in add:
+        _run(["gh", "issue", "edit", str(issue_number), "--repo", repo, "--add-label", label])
+
+    for label in remove:
+        _run(["gh", "issue", "edit", str(issue_number), "--repo", repo, "--remove-label", label])
+
+
+def run_canon_audit(
+    *,
+    repo: str,
+    issue_number: int,
+    repo_root: str | Path | None = None,
+    model: str = "gemini-2.5-flash",
+    update_labels: bool = True,
+) -> CanonAuditRouteResult:
+    issue = fetch_issue(repo, issue_number)
+    blocked = validate_issue_for_canon_audit(issue)
+
+    if blocked:
+        raise CanonAuditRoutePanic(";".join(blocked))
+
+    canon_bundle = build_canon_bundle(root=repo_root)
+    prompt = build_prompt(issue, canon_bundle)
+
+    try:
+        report = query_gemini(prompt, model=model)
+    except (LLMServicePanic, CanonReaderPanic) as err:
+        raise CanonAuditRoutePanic(str(err)) from err
+
+    comment_body = f"""## Skeleton Canon Audit Route Report
+
+Issue: #{issue_number}
+Mode: read-only
+Model: {model}
+Schema: {CANON_AUDIT_ROUTE_SCHEMA_VERSION}
+
+Safety:
+- no local files written
+- no canon changed
+- no PR created
+- no merge/deploy
+- no secrets printed
+- report is audit evidence only
+
+{report}
+"""
+
+    comment_url = post_comment(repo, issue_number, comment_body)
+
+    labels_added = ("agent:audit-complete",)
+    labels_removed = ("agent:audited",)
+
+    if update_labels:
+        edit_labels(repo, issue_number, add=labels_added, remove=labels_removed)
+
+    return CanonAuditRouteResult(
+        issue_number=issue_number,
+        issue_url=str(issue.get("url") or ""),
+        status="audit_complete",
+        comment_url=comment_url,
+        labels_added=labels_added if update_labels else (),
+        labels_removed=labels_removed if update_labels else (),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run read-only Skeleton canon audit route.")
+    parser.add_argument("--repo", default="alanua/jeeves")
+    parser.add_argument("--issue", type=int, required=True)
+    parser.add_argument("--model", default="gemini-2.5-flash")
+    parser.add_argument("--no-labels", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        result = run_canon_audit(
+            repo=args.repo,
+            issue_number=args.issue,
+            model=args.model,
+            update_labels=not args.no_labels,
+        )
+    except CanonAuditRoutePanic as err:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "schema_version": CANON_AUDIT_ROUTE_SCHEMA_VERSION,
+                    "error": str(err),
+                    "writes_files": False,
+                    "creates_pr": False,
+                    "merge_allowed": False,
+                    "deploy_allowed": False,
+                },
+                indent=2,
+            )
+        )
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "schema_version": CANON_AUDIT_ROUTE_SCHEMA_VERSION,
+                "result": result.__dict__,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/skeleton_core/canon_reader.py
+++ b/tools/skeleton_core/canon_reader.py
@@ -1,0 +1,116 @@
+"""Allowlist-only read service for Skeleton canon audit routes.
+
+Sprint 11 boundary:
+- read only predefined files
+- fail closed on non-allowlisted paths
+- fail closed on secret patterns
+- no file writes
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Final
+
+CANON_READER_SCHEMA_VERSION: Final[str] = "skeleton_canon_reader.v1"
+
+ALLOWED_CANON_PATHS: Final[tuple[str, ...]] = (
+    "BOOTLOADER.md",
+    "knowledge_base/START_HERE_FOR_CHATGPT.md",
+    "knowledge_base/MEMORY_POLICY.md",
+    "knowledge_base/WORKING_PROTOCOL.md",
+    "knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md",
+    "knowledge_base/assistant_diary.md",
+    "knowledge_base/CHATGPT_EXOSKELETON.md",
+    "knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md",
+    "knowledge_base/chatgpt_exoskeleton/START_HERE.md",
+    "knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md",
+    "docs/dual_brain_state.md",
+)
+
+SECRET_PATTERNS: Final[tuple[str, ...]] = (
+    r"sk-[A-Za-z0-9_\-]{20,}",
+    r"AIza[0-9A-Za-z_\-]{20,}",
+    r"ghp_[A-Za-z0-9_]{20,}",
+    r"github_pat_[A-Za-z0-9_]{20,}",
+    r"OPENAI_API_KEY\s*=",
+    r"GEMINI_API_KEY\s*=",
+    r"GOOGLE_API_KEY\s*=",
+)
+
+
+class CanonReaderPanic(RuntimeError):
+    """Fail-closed canon reader panic."""
+
+
+def repo_root(path: str | Path | None = None) -> Path:
+    if path is not None:
+        return Path(path).resolve()
+
+    return Path.cwd().resolve()
+
+
+def _relative_posix(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError as err:
+        raise CanonReaderPanic(f"path_outside_repo:{path}") from err
+
+
+def validate_canon_path(path: str | Path, *, root: str | Path | None = None) -> Path:
+    base = repo_root(root)
+    candidate = Path(path)
+
+    resolved = candidate.resolve() if candidate.is_absolute() else (base / candidate).resolve()
+    rel = _relative_posix(resolved, base)
+
+    if rel not in ALLOWED_CANON_PATHS:
+        raise CanonReaderPanic(f"canon_path_not_allowlisted:{rel}")
+
+    if not resolved.exists():
+        raise CanonReaderPanic(f"canon_path_missing:{rel}")
+
+    if not resolved.is_file():
+        raise CanonReaderPanic(f"canon_path_not_file:{rel}")
+
+    return resolved
+
+
+def scan_sensitive_text(text: str) -> list[str]:
+    hits: list[str] = []
+
+    for pattern in SECRET_PATTERNS:
+        if re.search(pattern, text):
+            hits.append(pattern)
+
+    return hits
+
+
+def read_canon_file(path: str | Path, *, root: str | Path | None = None) -> tuple[str, str]:
+    base = repo_root(root)
+    resolved = validate_canon_path(path, root=base)
+    rel = _relative_posix(resolved, base)
+    text = resolved.read_text(encoding="utf-8", errors="replace")
+
+    hits = scan_sensitive_text(text)
+    if hits:
+        raise CanonReaderPanic(f"secret_pattern_detected:{rel}:{','.join(hits)}")
+
+    return rel, text
+
+
+def build_canon_bundle(
+    paths: tuple[str, ...] | list[str] | None = None,
+    *,
+    root: str | Path | None = None,
+) -> str:
+    selected = tuple(paths) if paths is not None else ALLOWED_CANON_PATHS
+
+    parts: list[str] = []
+
+    for path in selected:
+        rel, text = read_canon_file(path, root=root)
+        parts.append(f"\n\n--- FILE: {rel} ---\n{text}\n")
+
+    return "".join(parts)

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -19,6 +19,11 @@ if len(sys.argv) > 1 and sys.argv[1] == "ai-ping":
 
     raise SystemExit(_ai_ping_main(sys.argv[2:]))
 
+if len(sys.argv) > 1 and sys.argv[1] == "canon-audit":
+    from tools.skeleton_core.canon_audit_route import main as _canon_audit_main
+
+    raise SystemExit(_canon_audit_main(sys.argv[2:]))
+
 import argparse
 import json
 import sys


### PR DESCRIPTION
Implements Sprint 11 Canon Audit Layer foundation.

Scope:
- adds tools/skeleton_core/canon_reader.py
- adds tools/skeleton_core/canon_audit_route.py
- routes python -m tools.skeleton_core.cli canon-audit
- reads only predefined allowlisted canon/core files
- scans issue body and canon bundle for secret patterns before Gemini handoff
- posts Gemini canon audit report as a GitHub issue comment
- transitions labels from agent:audited to agent:audit-complete
- creates no PR during route execution
- writes no local files during route execution

Safety:
- allowlist-only canon reads
- fail-closed on non-allowlisted paths
- fail-closed on secret patterns
- no local file writes
- no canon changes
- no merge/deploy
- no autonomous approval
- no .env or runtime JSON in PR

Validation:
- pytest: 332 passed
- ruff: passed
- black --check: passed
- validate-state: ok true

Boundary:
This PR implements the route only.
First real canon-audit execution must be a separate audited issue after merge.