### PR TITLE
docs(skeleton): clarify canon audit labels and diary memory boundary

### DIFF
--- a/docs/dual_brain_state.md
+++ b/docs/dual_brain_state.md
@@ -406,3 +406,63 @@ Current Sprint 7 boundary:
 - `real` mode is implemented but not verified
 - `real` mode must not run automatically
 - `real` mode requires a separate controlled test issue and explicit human approval
+
+
+## Sprint 11B Canon Audit Route State Clarification
+
+Status: verified after Issue #143 and PR #142.
+
+The Canon Audit Layer is now implemented and has passed a first real route test.
+
+Verified route:
+
+- `python -m tools.skeleton_core.cli canon-audit`
+- reads only predefined allowlisted canon/core files
+- scans issue body and canon bundle for secret patterns
+- calls Gemini as an auditor/evidence source only
+- posts the audit report back to the GitHub Issue
+- performs no local file writes
+- creates no PR during route execution
+- performs no merge or deploy
+- does not promote audit findings to canon automatically
+
+### Label state clarification
+
+The label model separates task type from task state.
+
+Task-type label:
+
+- `agent:canon-audit` means the issue is intended for the specialized canon-audit route.
+
+State labels:
+
+- `agent:queued` means the issue is waiting for the base yellow audit daemon.
+- `agent:audited` means the issue passed the base YELLOW Gemini audit gate.
+- `agent:audit-complete` means the specialized canon-audit route completed and posted its audit report.
+
+Important distinction:
+
+- `agent:audited` is not the same as `agent:audit-complete`.
+- `agent:audited` is the precondition produced by the base audit gate.
+- `agent:audit-complete` is the terminal state for the canon-audit route.
+
+### Real-mode verification status
+
+The following bounded real-mode actions have been verified:
+
+- `validate-state`
+- `create-report`
+- `create-pr`
+- `canon-audit`
+
+This does not grant general autonomous execution rights.
+
+The runner still must not:
+
+- execute arbitrary shell commands
+- merge PRs
+- deploy
+- promote canon automatically
+- write secrets
+- modify policy/canon documents without human-reviewed PR flow
+

--- a/knowledge_base/MEMORY_POLICY.md
+++ b/knowledge_base/MEMORY_POLICY.md
@@ -189,3 +189,28 @@ Use:
 - `Jeeves Private Memory - Structured Facts` for structured private indexes and classified facts
 
 A diary/audit entry must be classified before saving.
+
+
+## Skeleton Diary and Canon Writes
+
+`knowledge_base/skeleton_diary.md` is an operational traceability log for Skeleton Core.
+
+It records execution evidence such as:
+
+- `[REAL_EXECUTION]`
+- `[REAL_WRITE]`
+- route completion notes
+- issue-processing traces
+
+These append-only operational entries support the rule that every real action must be traceable.
+
+They are not the same as canon-policy patches.
+
+Canon-policy writes include changes to durable rules, architecture, memory policy, working protocol, or governance documents. Those changes still require human review and PR approval before becoming canon.
+
+Therefore:
+
+- automated append-only diary entries are operational logs;
+- structural changes to the diary format or meaning require review;
+- changes to canon/policy documents require human-reviewed PR flow;
+- audit reports are evidence, not canon, until reviewed and explicitly promoted.


### PR DESCRIPTION
Implements Sprint 11B documentation cleanup after Issue #143.

Scope:
- documents agent:canon-audit as a task-type label
- documents agent:audit-complete as the terminal state for the canon-audit route
- clarifies the difference between agent:audited and agent:audit-complete
- clarifies that skeleton_diary.md is an operational traceability log, not a canon-policy patch
- updates real-mode verification status for validate-state, create-report, create-pr, and canon-audit

Evidence:
- Gemini full canon audit in Issue #140
- Sprint 11 route implementation in PR #142
- first real canon-audit route test in Issue #143
- task scope audit accepted in Issue #144

Safety:
- documentation-only PR
- no code changes
- no tests changed
- no runner permission changes
- no runtime JSON
- no .env
- no skeleton_diary.md mutation
- no new execution powers

Validation:
- pytest passed
- ruff passed
- black --check passed
- validate-state ok