### PR TITLE
fix(skeleton): declare google-genai dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "tenacity>=8.3.0",
     "structlog>=24.1.0",
     "python-dotenv>=1.0.0",
+    "google-genai>=2.0.1",
     "greenlet>=3.0.0",
 ]
 


### PR DESCRIPTION
## Summary

Declares `google-genai>=2.0.1` in `pyproject.toml` so live Gemini routes can import:

```python
from google import genai
```

without a manual pip install in the runner venv.

## Why

#149 exposed a real runner dependency gap. The live canon-audit route failed with:

```text
ModuleNotFoundError: No module named 'google'
```

After manually installing `google-genai` in the Hetzner venv, the same route completed #147 successfully. This PR makes that dependency reproducible.

## Files changed

```text
pyproject.toml
```

## Validation

Verified by re-reading `pyproject.toml` on the branch after the update.

Manual runner validation already performed before this PR:

```bash
python -m pip install google-genai
python - <<'PY'
from google import genai
print("google-genai import ok")
PY
python -m tools.skeleton_core.cli canon-audit --repo alanua/jeeves --issue 147
```

Result:

```text
ok: true
audit_complete
writes_files: false
creates_pr: false
merge_allowed: false
deploy_allowed: false
canon_changed: false
```

Full validation still expected from runner/CI before merge:

```bash
python -m pip install -e .[dev]
python - <<'PY'
from google import genai
print("google-genai import ok")
PY
python -m pytest -q
python -m ruff check tools/skeleton_core tests/skeleton_core
python -m black --check tools/skeleton_core tests/skeleton_core
```

## Safety

```text
Secrets printed: no
Runtime/service changes: no
Daemon changes: no
Gemini key changes: no
BauClock changes: no
Merge/deploy: no
```

## Related

Closes after review: #149

## Next safe step

Run validation, then review. After this dependency fix is accepted, continue with #146 runner-status-check implementation.