### PR TITLE
feat(skeleton): add runner status check module

### DIFF
--- a/tests/fixtures/runner_status_check_completed_unknown.json
+++ b/tests/fixtures/runner_status_check_completed_unknown.json
@@ -1,0 +1,14 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 48,
+  "runner_name": "hetzner-agent-runner-1",
+  "issue_labels": ["agent:running", "risk:yellow", "runner:hetzner"],
+  "running_since": "2026-05-12T12:00:00Z",
+  "current_time": "2026-05-12T12:10:00Z",
+  "latest_run_id": "run-48",
+  "latest_event_status": "completed",
+  "latest_event_at": "2026-05-12T12:09:00Z",
+  "completion_evidence_seen": true,
+  "final_report_seen": false,
+  "logs_summary": "processing appears complete but final GitHub report is missing"
+}

--- a/tests/fixtures/runner_status_check_failed.json
+++ b/tests/fixtures/runner_status_check_failed.json
@@ -1,0 +1,14 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 48,
+  "runner_name": "hetzner-agent-runner-1",
+  "issue_labels": ["agent:running", "risk:yellow", "runner:hetzner"],
+  "running_since": "2026-05-12T12:00:00Z",
+  "current_time": "2026-05-12T12:10:00Z",
+  "lock_file_seen": false,
+  "latest_run_id": "run-48",
+  "latest_event_status": "failed",
+  "latest_event_at": "2026-05-12T12:09:00Z",
+  "logs_summary": "public-safe summary: command failed with nonzero exit",
+  "blocker_summary": "validation failed"
+}

--- a/tests/fixtures/runner_status_check_running.json
+++ b/tests/fixtures/runner_status_check_running.json
@@ -1,0 +1,17 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 48,
+  "runner_name": "hetzner-agent-runner-1",
+  "issue_labels": ["agent:running", "risk:yellow", "runner:hetzner"],
+  "running_since": "2026-05-12T12:00:00Z",
+  "current_time": "2026-05-12T12:10:00Z",
+  "stale_after_seconds": 3600,
+  "lock_file_seen": true,
+  "lock_pid": 12345,
+  "lock_pid_alive": true,
+  "latest_run_id": "run-48",
+  "latest_event_status": "running",
+  "latest_event_at": "2026-05-12T12:09:00Z",
+  "related_subprocesses_seen": ["codex"],
+  "logs_summary": "runner is processing issue 48"
+}

--- a/tests/fixtures/runner_status_check_stale.json
+++ b/tests/fixtures/runner_status_check_stale.json
@@ -1,0 +1,16 @@
+{
+  "repository": "alanua/bauclock",
+  "issue_number": 48,
+  "runner_name": "hetzner-agent-runner-1",
+  "issue_labels": ["agent:running", "risk:yellow", "runner:hetzner"],
+  "running_since": "2026-05-12T10:00:00Z",
+  "current_time": "2026-05-12T12:30:00Z",
+  "stale_after_seconds": 3600,
+  "lock_file_seen": true,
+  "lock_pid": 12345,
+  "lock_pid_alive": false,
+  "latest_run_id": "run-48",
+  "latest_event_status": "running",
+  "latest_event_at": "2026-05-12T10:05:00Z",
+  "logs_summary": "last known runner event was old"
+}

--- a/tests/skeleton_core/test_runner_status_check.py
+++ b/tests/skeleton_core/test_runner_status_check.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.skeleton_core.runner_status_check import (
+    RunnerStatusCheckInput,
+    build_runner_status_check,
+    build_runner_status_check_from_json,
+    build_unavailable_live_check,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def _load_fixture(name: str):
+    return build_runner_status_check_from_json((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_running_issue_with_live_pid_returns_running() -> None:
+    result = _load_fixture("runner_status_check_running.json")
+
+    assert result.status == "running"
+    assert result.lock_file_seen is True
+    assert result.lock_pid_alive is True
+    assert result.recommended_queue_action == "wait_for_runner"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_old_running_issue_with_dead_pid_returns_stale() -> None:
+    result = _load_fixture("runner_status_check_stale.json")
+
+    assert result.status == "stale"
+    assert "PID" in result.staleness_reason
+    assert result.recommended_queue_action == "run_manual_health_check"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_failed_event_returns_failed() -> None:
+    result = _load_fixture("runner_status_check_failed.json")
+
+    assert result.status == "failed"
+    assert result.blocker_summary == "validation failed"
+    assert result.recommended_queue_action == "review_blocker_report"
+
+
+def test_completion_evidence_without_report_returns_completed_unknown() -> None:
+    result = _load_fixture("runner_status_check_completed_unknown.json")
+
+    assert result.status == "completed_unknown"
+    assert result.recommended_queue_action == "review_final_report"
+
+
+def test_missing_or_ambiguous_evidence_returns_needs_manual_review() -> None:
+    result = build_runner_status_check(
+        RunnerStatusCheckInput(repository="alanua/bauclock", issue_number=48)
+    )
+
+    assert result.status == "needs_manual_review"
+    assert result.recommended_queue_action == "needs_manual_review"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_secret_like_text_is_blocked_and_redacted() -> None:
+    result = build_runner_status_check(
+        RunnerStatusCheckInput(
+            repository="alanua/bauclock",
+            issue_number=48,
+            logs_summary="token=abc123 appeared in log summary",
+        )
+    )
+
+    assert result.status == "needs_manual_review"
+    assert result.blocker_summary == "secret-like text detected in runner status evidence"
+    assert "abc123" not in result.blocker_summary
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False
+
+
+def test_unavailable_live_check_fails_closed() -> None:
+    result = build_unavailable_live_check(repository="alanua/bauclock", issue_number=48)
+
+    assert result.status == "needs_manual_review"
+    assert result.repository == "alanua/bauclock"
+    assert result.issue_number == 48
+    assert result.recommended_queue_action == "needs_manual_review"
+    assert result.merge_allowed is False
+    assert result.deploy_allowed is False

--- a/tools/skeleton_core/runner_status_check.py
+++ b/tools/skeleton_core/runner_status_check.py
@@ -8,7 +8,7 @@ It must not mutate GitHub labels, restart services, kill processes, merge, or de
 from __future__ import annotations
 
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -56,7 +56,12 @@ FAILURE_WORDS = (
 COMPLETION_STATUSES = {"complete", "completed", "done", "success", "succeeded", "audit_complete"}
 FAILED_STATUSES = {"failed", "failure", "error", "crashed", "blocked"}
 RUNNING_LABELS = {"agent:running", "agent:executing", "agent:auditing", "agent:queued"}
-FINAL_LABELS = {"agent:executed", "agent:audit-complete", "agent:blocked", "agent:needs-revision"}
+FINAL_LABELS = {
+    "agent:executed",
+    "agent:audit-complete",
+    "agent:blocked",
+    "agent:needs-revision",
+}
 
 
 class RunnerStatusCheckInput(BaseModel):
@@ -129,8 +134,8 @@ def _parse_datetime(value: str | None) -> datetime | None:
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def _contains_secret_like_text(*values: str) -> bool:
@@ -149,7 +154,7 @@ def _age_seconds(start_value: str | None, now_value: str | None) -> int | None:
     start = _parse_datetime(start_value)
     if start is None:
         return None
-    now = _parse_datetime(now_value) or datetime.now(timezone.utc)
+    now = _parse_datetime(now_value) or datetime.now(UTC)
     return max(0, int((now - start).total_seconds()))
 
 
@@ -189,9 +194,16 @@ def _staleness_reason(packet: RunnerStatusCheckInput) -> str:
     if running_age is not None and running_age > packet.stale_after_seconds:
         return f"running evidence is older than {packet.stale_after_seconds} seconds"
     event_age = _age_seconds(packet.latest_event_at, packet.current_time)
-    if event_age is not None and _has_running_label(packet.issue_labels):
-        if event_age > packet.stale_after_seconds and packet.lock_pid_alive is not True:
-            return f"latest event is older than {packet.stale_after_seconds} seconds without live PID evidence"
+    if (
+        event_age is not None
+        and _has_running_label(packet.issue_labels)
+        and event_age > packet.stale_after_seconds
+        and packet.lock_pid_alive is not True
+    ):
+        return (
+            f"latest event is older than {packet.stale_after_seconds} seconds "
+            "without live PID evidence"
+        )
     return ""
 
 
@@ -282,6 +294,9 @@ def build_unavailable_live_check(*, repository: str, issue_number: int | None) -
         RunnerStatusCheckInput(
             repository=repository,
             issue_number=issue_number,
-            blocker_summary="live runner-status-check collection is not configured; provide --input fixture or a bounded collector",
+            blocker_summary=(
+                "live runner-status-check collection is not configured; provide --input "
+                "fixture or a bounded collector"
+            ),
         )
     )

--- a/tools/skeleton_core/runner_status_check.py
+++ b/tools/skeleton_core/runner_status_check.py
@@ -1,0 +1,287 @@
+"""Read-only runner/task status diagnostics for Skeleton queues.
+
+This module is intentionally separate from ``yellow_runnerd.py``.
+It inspects public-safe status evidence and returns a recommendation packet.
+It must not mutate GitHub labels, restart services, kill processes, merge, or deploy.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+RunnerStatus = Literal[
+    "running",
+    "stale",
+    "failed",
+    "completed_unknown",
+    "needs_manual_review",
+]
+RecommendedQueueAction = Literal[
+    "wait_for_runner",
+    "review_blocker_report",
+    "run_manual_health_check",
+    "review_final_report",
+    "safe_to_consider_next_queue_item",
+    "needs_manual_review",
+]
+
+DEFAULT_STALE_AFTER_SECONDS = 60 * 60
+SECRET_LIKE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"api[_-]?key\s*[:=]",
+        r"token\s*[:=]",
+        r"bearer\s+[a-z0-9._\-]+",
+        r"private[_-]?key",
+        r"password\s*[:=]",
+        r"secret\s*[:=]",
+        r"ghp_[a-z0-9_]+",
+        r"github_pat_[a-z0-9_]+",
+        r"AIza[0-9A-Za-z_\-]{20,}",
+    ]
+]
+FAILURE_WORDS = (
+    "traceback",
+    "exception",
+    "failed",
+    "failure",
+    "error",
+    "crash",
+    "blocked",
+)
+COMPLETION_STATUSES = {"complete", "completed", "done", "success", "succeeded", "audit_complete"}
+FAILED_STATUSES = {"failed", "failure", "error", "crashed", "blocked"}
+RUNNING_LABELS = {"agent:running", "agent:executing", "agent:auditing", "agent:queued"}
+FINAL_LABELS = {"agent:executed", "agent:audit-complete", "agent:blocked", "agent:needs-revision"}
+
+
+class RunnerStatusCheckInput(BaseModel):
+    """Public-safe runner status evidence.
+
+    Live collectors should reduce local state into this shape before calling
+    ``build_runner_status_check``. Raw logs/secrets/private paths must not be
+    passed here; any summaries that contain secret-like text are fail-closed.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    repository: str = ""
+    issue_number: int | None = None
+    runner_name: str = ""
+    issue_labels: list[str] = Field(default_factory=list)
+    running_since: str | None = None
+    last_comment_at: str | None = None
+    current_time: str | None = None
+    stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS
+    lock_file_seen: bool = False
+    lock_pid: int | None = None
+    lock_pid_alive: bool | None = None
+    latest_run_id: str | None = None
+    latest_event_status: str | None = None
+    latest_event_at: str | None = None
+    latest_event_summary: str = ""
+    logs_summary: str = ""
+    related_subprocesses_seen: list[str] = Field(default_factory=list)
+    final_report_seen: bool = False
+    completion_evidence_seen: bool = False
+    blocker_summary: str = ""
+
+
+class RunnerStatusCheckPacket(BaseModel):
+    """Public-safe runner status packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: RunnerStatus
+    repository: str = ""
+    issue_number: int | None = None
+    runner_name: str = ""
+    issue_labels: list[str] = Field(default_factory=list)
+    running_since: str | None = None
+    last_comment_at: str | None = None
+    lock_file_seen: bool = False
+    lock_pid: int | None = None
+    lock_pid_alive: bool | None = None
+    latest_run_id: str | None = None
+    latest_event_status: str | None = None
+    related_subprocesses_seen: list[str] = Field(default_factory=list)
+    staleness_reason: str = ""
+    blocker_summary: str = ""
+    recommended_queue_action: RecommendedQueueAction
+    merge_allowed: bool = False
+    deploy_allowed: bool = False
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _contains_secret_like_text(*values: str) -> bool:
+    haystack = "\n".join(value for value in values if value)
+    return any(pattern.search(haystack) for pattern in SECRET_LIKE_PATTERNS)
+
+
+def _redact_secret_like_text(value: str) -> str:
+    redacted = value
+    for pattern in SECRET_LIKE_PATTERNS:
+        redacted = pattern.sub("<redacted-secret-like>", redacted)
+    return redacted
+
+
+def _age_seconds(start_value: str | None, now_value: str | None) -> int | None:
+    start = _parse_datetime(start_value)
+    if start is None:
+        return None
+    now = _parse_datetime(now_value) or datetime.now(timezone.utc)
+    return max(0, int((now - start).total_seconds()))
+
+
+def _has_running_label(labels: list[str]) -> bool:
+    normalized = {label.casefold() for label in labels}
+    return bool(normalized & RUNNING_LABELS)
+
+
+def _has_final_label(labels: list[str]) -> bool:
+    normalized = {label.casefold() for label in labels}
+    return bool(normalized & FINAL_LABELS)
+
+
+def _has_failure_text(packet: RunnerStatusCheckInput) -> bool:
+    event_status = (packet.latest_event_status or "").casefold()
+    if event_status in FAILED_STATUSES:
+        return True
+    text = f"{packet.latest_event_summary}\n{packet.logs_summary}\n{packet.blocker_summary}".casefold()
+    return any(word in text for word in FAILURE_WORDS)
+
+
+def _has_completion_evidence(packet: RunnerStatusCheckInput) -> bool:
+    event_status = (packet.latest_event_status or "").casefold()
+    return (
+        packet.completion_evidence_seen
+        or event_status in COMPLETION_STATUSES
+        or _has_final_label(packet.issue_labels)
+    )
+
+
+def _staleness_reason(packet: RunnerStatusCheckInput) -> str:
+    if packet.lock_file_seen and packet.lock_pid is not None and packet.lock_pid_alive is False:
+        return "lock PID is not alive"
+    if packet.lock_file_seen and packet.lock_pid is None:
+        return "lock file exists but contains no PID"
+    running_age = _age_seconds(packet.running_since, packet.current_time)
+    if running_age is not None and running_age > packet.stale_after_seconds:
+        return f"running evidence is older than {packet.stale_after_seconds} seconds"
+    event_age = _age_seconds(packet.latest_event_at, packet.current_time)
+    if event_age is not None and _has_running_label(packet.issue_labels):
+        if event_age > packet.stale_after_seconds and packet.lock_pid_alive is not True:
+            return f"latest event is older than {packet.stale_after_seconds} seconds without live PID evidence"
+    return ""
+
+
+def _blocker_summary(packet: RunnerStatusCheckInput, *, secret_like: bool) -> str:
+    if secret_like:
+        return "secret-like text detected in runner status evidence"
+    if packet.blocker_summary:
+        return _redact_secret_like_text(packet.blocker_summary)
+    return ""
+
+
+def _infer_status(packet: RunnerStatusCheckInput) -> tuple[RunnerStatus, str, RecommendedQueueAction]:
+    secret_like = _contains_secret_like_text(
+        packet.logs_summary,
+        packet.latest_event_summary,
+        packet.blocker_summary,
+    )
+    if secret_like:
+        return "needs_manual_review", "", "needs_manual_review"
+
+    if _has_failure_text(packet):
+        return "failed", "", "review_blocker_report"
+
+    stale_reason = _staleness_reason(packet)
+    if stale_reason:
+        return "stale", stale_reason, "run_manual_health_check"
+
+    completion_evidence = _has_completion_evidence(packet)
+    if completion_evidence and not packet.final_report_seen:
+        return "completed_unknown", "", "review_final_report"
+
+    if completion_evidence and packet.final_report_seen:
+        return "completed_unknown", "", "safe_to_consider_next_queue_item"
+
+    live_runner_evidence = (
+        packet.lock_pid_alive is True
+        or bool(packet.related_subprocesses_seen)
+        or bool(packet.latest_run_id and _has_running_label(packet.issue_labels))
+    )
+    if _has_running_label(packet.issue_labels) and live_runner_evidence:
+        return "running", "", "wait_for_runner"
+
+    return "needs_manual_review", "", "needs_manual_review"
+
+
+def build_runner_status_check(packet: RunnerStatusCheckInput) -> RunnerStatusCheckPacket:
+    """Build a public-safe runner status packet.
+
+    The function is deterministic and side-effect free.
+    """
+    status, staleness_reason, action = _infer_status(packet)
+    secret_like = _contains_secret_like_text(
+        packet.logs_summary,
+        packet.latest_event_summary,
+        packet.blocker_summary,
+    )
+
+    return RunnerStatusCheckPacket(
+        status=status,
+        repository=packet.repository,
+        issue_number=packet.issue_number,
+        runner_name=packet.runner_name,
+        issue_labels=packet.issue_labels,
+        running_since=packet.running_since,
+        last_comment_at=packet.last_comment_at,
+        lock_file_seen=packet.lock_file_seen,
+        lock_pid=packet.lock_pid,
+        lock_pid_alive=packet.lock_pid_alive,
+        latest_run_id=packet.latest_run_id,
+        latest_event_status=packet.latest_event_status,
+        related_subprocesses_seen=packet.related_subprocesses_seen,
+        staleness_reason=staleness_reason,
+        blocker_summary=_blocker_summary(packet, secret_like=secret_like),
+        recommended_queue_action=action,
+        merge_allowed=False,
+        deploy_allowed=False,
+    )
+
+
+def build_runner_status_check_from_json(raw_json: str) -> RunnerStatusCheckPacket:
+    """Validate public-safe JSON and build a runner status packet."""
+    return build_runner_status_check(RunnerStatusCheckInput.model_validate_json(raw_json))
+
+
+def build_unavailable_live_check(*, repository: str, issue_number: int | None) -> RunnerStatusCheckPacket:
+    """Return a fail-closed packet when live collection is not configured."""
+    return build_runner_status_check(
+        RunnerStatusCheckInput(
+            repository=repository,
+            issue_number=issue_number,
+            blocker_summary="live runner-status-check collection is not configured; provide --input fixture or a bounded collector",
+        )
+    )

--- a/tools/skeleton_core/runner_status_check.py
+++ b/tools/skeleton_core/runner_status_check.py
@@ -172,7 +172,9 @@ def _has_failure_text(packet: RunnerStatusCheckInput) -> bool:
     event_status = (packet.latest_event_status or "").casefold()
     if event_status in FAILED_STATUSES:
         return True
-    text = f"{packet.latest_event_summary}\n{packet.logs_summary}\n{packet.blocker_summary}".casefold()
+    text = (
+        f"{packet.latest_event_summary}\n{packet.logs_summary}\n{packet.blocker_summary}".casefold()
+    )
     return any(word in text for word in FAILURE_WORDS)
 
 
@@ -215,7 +217,9 @@ def _blocker_summary(packet: RunnerStatusCheckInput, *, secret_like: bool) -> st
     return ""
 
 
-def _infer_status(packet: RunnerStatusCheckInput) -> tuple[RunnerStatus, str, RecommendedQueueAction]:
+def _infer_status(
+    packet: RunnerStatusCheckInput,
+) -> tuple[RunnerStatus, str, RecommendedQueueAction]:
     secret_like = _contains_secret_like_text(
         packet.logs_summary,
         packet.latest_event_summary,
@@ -288,7 +292,9 @@ def build_runner_status_check_from_json(raw_json: str) -> RunnerStatusCheckPacke
     return build_runner_status_check(RunnerStatusCheckInput.model_validate_json(raw_json))
 
 
-def build_unavailable_live_check(*, repository: str, issue_number: int | None) -> RunnerStatusCheckPacket:
+def build_unavailable_live_check(
+    *, repository: str, issue_number: int | None
+) -> RunnerStatusCheckPacket:
     """Return a fail-closed packet when live collection is not configured."""
     return build_runner_status_check(
         RunnerStatusCheckInput(


### PR DESCRIPTION
## Summary

Implements the core `runner_status_check` module for #146.

Added:

```text
tools/skeleton_core/runner_status_check.py
tests/skeleton_core/test_runner_status_check.py
tests/fixtures/runner_status_check_running.json
tests/fixtures/runner_status_check_stale.json
tests/fixtures/runner_status_check_failed.json
tests/fixtures/runner_status_check_completed_unknown.json
```

## Scope

This PR implements the side-effect-free, fixture/offline-first status classifier.

It does **not** modify `yellow_runnerd.py`.

It does **not yet** modify `tools/skeleton_core/cli.py` because the GitHub API output available in ChatGPT was truncated for that large file. The CLI hook should be added as a very small follow-up patch or by the runner using a local working tree patch.

## Implemented statuses

```text
running
stale
failed
completed_unknown
needs_manual_review
```

## Implemented safety behavior

- deterministic and side-effect free;
- no label mutation;
- no issue closure;
- no service restart;
- no process kill;
- no merge/deploy;
- no direct `.env` reads;
- secret-like log/event/blocker text forces `needs_manual_review`;
- `merge_allowed=false` and `deploy_allowed=false` always.

## Tests included

Tests cover:

- running issue + live PID -> `running`;
- old running issue + dead PID -> `stale`;
- failed event/log -> `failed`;
- completion evidence without final report -> `completed_unknown`;
- ambiguous/missing evidence -> `needs_manual_review`;
- secret-like text -> fail closed/redacted;
- unavailable live check -> fail closed;
- merge/deploy always false.

## Known follow-up required

Add CLI hook:

```bash
python -m tools.skeleton_core.cli runner-status-check --input tests/fixtures/runner_status_check_running.json
```

Suggested minimal CLI integration:

- import `RunnerStatusCheckInput`, `build_runner_status_check`, `build_unavailable_live_check`;
- add `runner-status-check` to `SUBCOMMANDS`;
- add subparser with `--input`, optional `--repo`, optional `--issue`;
- add `_run_runner_status_check` that outputs packet JSON;
- dispatch in `main()`.

## Validation needed

Run on runner:

```bash
python -m pytest -q tests/skeleton_core/test_runner_status_check.py
python -m ruff check tools/skeleton_core/runner_status_check.py tests/skeleton_core/test_runner_status_check.py
python -m black --check tools/skeleton_core/runner_status_check.py tests/skeleton_core/test_runner_status_check.py
```

Then run full suite if narrow validation passes.

## Safety

```text
Private data used: no
Secrets printed: no
Daemon changed: no
Service changed: no
BauClock changed: no
Merge/deploy: no
```

## Related

Implements core of #146.

Needs Gemini/canon-audit review before merge.