### PR TITLE
feat(skeleton): expose runner status check via CLI

### DIFF
--- a/tests/skeleton_core/test_runner_status_cli.py
+++ b/tests/skeleton_core/test_runner_status_cli.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def _run_cli(*args: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-m", "tools.skeleton_core.cli", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_runner_status_check_cli_fixture_mode_returns_running() -> None:
+    payload = _run_cli(
+        "runner-status-check",
+        "--input",
+        str(FIXTURES / "runner_status_check_running.json"),
+    )
+
+    assert payload["status"] == "running"
+    assert payload["repository"] == "alanua/bauclock"
+    assert payload["issue_number"] == 48
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False
+
+
+def test_runner_status_check_cli_no_input_fails_closed() -> None:
+    payload = _run_cli(
+        "runner-status-check",
+        "--repo",
+        "alanua/bauclock",
+        "--issue",
+        "48",
+    )
+
+    assert payload["status"] == "needs_manual_review"
+    assert payload["repository"] == "alanua/bauclock"
+    assert payload["issue_number"] == 48
+    assert payload["recommended_queue_action"] == "needs_manual_review"
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -70,6 +70,11 @@ from tools.skeleton_core.runner_env_check import (
     live_runner_env_check,
 )
 from tools.skeleton_core.runner_report_ingest import ingest_runner_report_file_content
+from tools.skeleton_core.runner_status_check import (
+    RunnerStatusCheckInput,
+    build_runner_status_check,
+    build_unavailable_live_check,
+)
 from tools.skeleton_core.state_validator import validate_state
 from tools.skeleton_core.task_lifecycle import build_task_lifecycle_packet
 from tools.skeleton_core.templates import render_runner_issue
@@ -96,6 +101,7 @@ SUBCOMMANDS = {
     "queue-summary",
     "runner-command-pack",
     "runner-env-check",
+    "runner-status-check",
     "runner-report-from-trace",
     "runner-report-ingest",
     "task-from-text",
@@ -149,6 +155,11 @@ def load_project_skeleton_profile_input(input_path: Path) -> ProjectSkeletonProf
 def load_runner_env_check_input(input_path: Path) -> RunnerEnvCheckInput:
     """Load public-safe runner environment check input from JSON."""
     return RunnerEnvCheckInput.model_validate_json(input_path.read_text(encoding="utf-8"))
+
+
+def load_runner_status_check_input(input_path: Path) -> RunnerStatusCheckInput:
+    """Load public-safe runner status check input from JSON."""
+    return RunnerStatusCheckInput.model_validate_json(input_path.read_text(encoding="utf-8"))
 
 
 def load_workflow_gate_input(input_path: Path) -> WorkflowGateInput:
@@ -474,6 +485,28 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Compatibility flag; output is always JSON",
     )
 
+    runner_status_parser = subparsers.add_parser(
+        "runner-status-check",
+        help="Build a read-only runner status packet from public-safe JSON",
+    )
+    runner_status_parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Path to offline public-safe runner status fixture JSON",
+    )
+    runner_status_parser.add_argument(
+        "--repo",
+        default="",
+        help="Repository for fail-closed live placeholder",
+    )
+    runner_status_parser.add_argument(
+        "--issue",
+        type=int,
+        default=None,
+        help="Issue number for fail-closed live placeholder",
+    )
+
     queue_state_parser = subparsers.add_parser(
         "queue-state",
         help="Determine the next runnable item from public-safe queue state JSON",
@@ -737,6 +770,22 @@ def _run_runner_env_check(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_runner_status_check(args: argparse.Namespace) -> int:
+    try:
+        if args.input is not None:
+            result = build_runner_status_check(load_runner_status_check_input(args.input))
+        else:
+            result = build_unavailable_live_check(
+                repository=args.repo or "",
+                issue_number=args.issue,
+            )
+    except ValidationError as exc:
+        print(exc.json(), flush=True)
+        return 2
+    print(json.dumps(result.model_dump(mode="json"), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
 def _run_queue_state(args: argparse.Namespace) -> int:
     try:
         result = build_queue_state(load_queue_state_input(args.input), project=args.project)
@@ -913,6 +962,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_runner_command_pack(args)
     if args.command == "runner-env-check":
         return _run_runner_env_check(args)
+    if args.command == "runner-status-check":
+        return _run_runner_status_check(args)
     if args.command == "runner-report-ingest":
         return _run_runner_report_ingest(args)
     if args.command == "runner-report-from-trace":


### PR DESCRIPTION
## Summary

Exposes the already-merged runner status check core module through the existing Skeleton CLI.

Implements #153.

## What changed

```text
tools/skeleton_core/cli.py
tests/skeleton_core/test_runner_status_cli.py
```

Added CLI command:

```bash
python -m tools.skeleton_core.cli runner-status-check --input tests/fixtures/runner_status_check_running.json
```

Added fail-closed no-input mode:

```bash
python -m tools.skeleton_core.cli runner-status-check --repo alanua/bauclock --issue 48
```

No-input mode uses `build_unavailable_live_check(...)` and returns `needs_manual_review` rather than inspecting arbitrary live files, logs, locks, PIDs, or GitHub APIs.

## Scope

This PR only exposes the module through CLI.

```text
No yellow_runnerd.py changes.
No daemon-loop diagnostics.
No .env reads.
No arbitrary filesystem inspection.
No GitHub API calls from this CLI hook.
No label mutation.
No issue closure.
No service restart.
No process kill.
No merge/deploy behavior.
No BauClock changes.
```

## Validation

Narrow validation on Hetzner runner:

```text
python -m pytest -q tests/skeleton_core/test_runner_status_check.py tests/skeleton_core/test_runner_status_cli.py
9 passed in 0.51s

python -m ruff check tools/skeleton_core/cli.py tests/skeleton_core/test_runner_status_cli.py
All checks passed

python -m black --check tools/skeleton_core/cli.py tests/skeleton_core/test_runner_status_cli.py
2 files would be left unchanged
```

Full validation on Hetzner runner:

```text
python -m pytest -q
341 passed, 7 warnings in 1.81s

python -m ruff check tools/skeleton_core tests/skeleton_core
All checks passed

python -m black --check tools/skeleton_core tests/skeleton_core
107 files would be left unchanged
```

Warnings:

```text
7 existing ezdxf / pyparsing deprecation warnings from construction_takeoff test.
No failures.
Not caused by this PR.
```

## Safety

```text
Secrets printed: no
Private data used: no
Daemon changed: no
Service changed: no
BauClock changed: no
Merge/deploy: no
Working tree clean after push
```

## Gemini gate

#153 passed base YELLOW Gemini gate:

```text
Outcome: accepted
Adapter status: live_accept
Security flags: []
Blocked reasons: []
```

## Related

- Depends on merged #151
- Implements #153

## Next safe step

Human review. Merge only after review/approval.