### PR TITLE
feat(skeleton): add bounded live runner status collector

### DIFF
--- a/tests/skeleton_core/test_runner_status_check.py
+++ b/tests/skeleton_core/test_runner_status_check.py
@@ -88,3 +88,82 @@ def test_unavailable_live_check_fails_closed() -> None:
     assert result.recommended_queue_action == "needs_manual_review"
     assert result.merge_allowed is False
     assert result.deploy_allowed is False
+
+
+def test_live_runner_status_check_detects_dead_lock_pid_and_log(tmp_path) -> None:
+    from tools.skeleton_core.runner_status_check import live_runner_status_check
+
+    lock_file = tmp_path / "runner-state" / "yellow_runnerd.lock"
+    lock_file.parent.mkdir()
+    lock_file.write_text("99999999\n", encoding="utf-8")
+
+    run_id = "20260512-091344-yellow-alanua-bauclock-48"
+    run_dir = tmp_path / "agent-runs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "log.txt").write_text(
+        "=== YELLOW AGENT RUN START ===\n"
+        "Run ID: 20260512-091344-yellow-alanua-bauclock-48\n"
+        "ERROR: unknown YELLOW task mapping\n",
+        encoding="utf-8",
+    )
+
+    packet = live_runner_status_check(
+        repository="alanua/bauclock",
+        issue_number=48,
+        run_id=run_id,
+        lock_file_path=lock_file,
+        agent_runs_dir=tmp_path / "agent-runs",
+        logs_dir=tmp_path / "logs",
+    )
+
+    assert packet.status == "failed"
+    assert packet.lock_file_seen is True
+    assert packet.lock_pid == 99999999
+    assert packet.lock_pid_alive is False
+    assert packet.latest_run_id == run_id
+    assert "unknown YELLOW task mapping" in packet.logs_summary
+    assert packet.merge_allowed is False
+    assert packet.deploy_allowed is False
+
+
+def test_live_runner_status_check_fails_closed_without_evidence(tmp_path) -> None:
+    from tools.skeleton_core.runner_status_check import live_runner_status_check
+
+    packet = live_runner_status_check(
+        repository="alanua/jeeves",
+        issue_number=161,
+        lock_file_path=tmp_path / "missing.lock",
+        agent_runs_dir=tmp_path / "agent-runs",
+        logs_dir=tmp_path / "logs",
+    )
+
+    assert packet.status == "needs_manual_review"
+    assert packet.recommended_queue_action == "needs_manual_review"
+    assert packet.blocker_summary == "no live runner evidence found"
+    assert packet.merge_allowed is False
+    assert packet.deploy_allowed is False
+
+
+def test_live_runner_status_check_redacts_secret_like_log_tail(tmp_path) -> None:
+    from tools.skeleton_core.runner_status_check import live_runner_status_check
+
+    run_id = "20260512-150545-yellow-alanua-jeeves-156"
+    run_dir = tmp_path / "agent-runs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "log.txt").write_text(
+        "token=abc123\n" "normal public-safe line\n",
+        encoding="utf-8",
+    )
+
+    packet = live_runner_status_check(
+        repository="alanua/jeeves",
+        issue_number=156,
+        run_id=run_id,
+        lock_file_path=tmp_path / "missing.lock",
+        agent_runs_dir=tmp_path / "agent-runs",
+        logs_dir=tmp_path / "logs",
+    )
+
+    assert "abc123" not in packet.logs_summary
+    assert "<redacted-secret-like>" in packet.logs_summary
+    assert packet.status == "needs_manual_review"

--- a/tests/skeleton_core/test_runner_status_cli.py
+++ b/tests/skeleton_core/test_runner_status_cli.py
@@ -47,3 +47,36 @@ def test_runner_status_check_cli_no_input_fails_closed() -> None:
     assert payload["recommended_queue_action"] == "needs_manual_review"
     assert payload["merge_allowed"] is False
     assert payload["deploy_allowed"] is False
+
+
+def test_runner_status_check_cli_live_with_temp_run_dir(tmp_path) -> None:
+    run_id = "20260512-091344-yellow-alanua-bauclock-48"
+    run_dir = tmp_path / "agent-runs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "log.txt").write_text(
+        "=== YELLOW AGENT RUN START ===\n" "Run ID: 20260512-091344-yellow-alanua-bauclock-48\n",
+        encoding="utf-8",
+    )
+
+    payload = _run_cli(
+        "runner-status-check",
+        "--repo",
+        "alanua/bauclock",
+        "--issue",
+        "48",
+        "--run-id",
+        run_id,
+        "--live",
+        "--lock-file",
+        str(tmp_path / "missing.lock"),
+        "--agent-runs-dir",
+        str(tmp_path / "agent-runs"),
+        "--logs-dir",
+        str(tmp_path / "logs"),
+    )
+
+    assert payload["repository"] == "alanua/bauclock"
+    assert payload["issue_number"] == 48
+    assert payload["latest_run_id"] == run_id
+    assert payload["merge_allowed"] is False
+    assert payload["deploy_allowed"] is False

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -77,9 +77,13 @@ from tools.skeleton_core.runner_env_check import (
 )
 from tools.skeleton_core.runner_report_ingest import ingest_runner_report_file_content
 from tools.skeleton_core.runner_status_check import (
+    DEFAULT_AGENT_RUNS_DIR,
+    DEFAULT_LOCK_FILE_PATH,
+    DEFAULT_LOGS_DIR,
     RunnerStatusCheckInput,
     build_runner_status_check,
     build_unavailable_live_check,
+    live_runner_status_check,
 )
 from tools.skeleton_core.state_validator import validate_state
 from tools.skeleton_core.task_lifecycle import build_task_lifecycle_packet
@@ -530,6 +534,34 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         default=None,
         help="Issue number for fail-closed live placeholder",
     )
+    runner_status_parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional bounded runner run id for live inspection",
+    )
+    runner_status_parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Enable bounded read-only live inspection",
+    )
+    runner_status_parser.add_argument(
+        "--lock-file",
+        type=Path,
+        default=Path(DEFAULT_LOCK_FILE_PATH),
+        help="Runner lock file path for live inspection",
+    )
+    runner_status_parser.add_argument(
+        "--agent-runs-dir",
+        type=Path,
+        default=Path(DEFAULT_AGENT_RUNS_DIR),
+        help="Bounded agent-runs directory for live inspection",
+    )
+    runner_status_parser.add_argument(
+        "--logs-dir",
+        type=Path,
+        default=Path(DEFAULT_LOGS_DIR),
+        help="Bounded logs directory for live inspection",
+    )
 
     queue_state_parser = subparsers.add_parser(
         "queue-state",
@@ -824,6 +856,15 @@ def _run_runner_status_check(args: argparse.Namespace) -> int:
     try:
         if args.input is not None:
             result = build_runner_status_check(load_runner_status_check_input(args.input))
+        elif args.live:
+            result = live_runner_status_check(
+                repository=args.repo or "",
+                issue_number=args.issue,
+                run_id=args.run_id,
+                lock_file_path=args.lock_file,
+                agent_runs_dir=args.agent_runs_dir,
+                logs_dir=args.logs_dir,
+            )
         else:
             result = build_unavailable_live_check(
                 repository=args.repo or "",

--- a/tools/skeleton_core/runner_status_check.py
+++ b/tools/skeleton_core/runner_status_check.py
@@ -7,8 +7,10 @@ It must not mutate GitHub labels, restart services, kill processes, merge, or de
 
 from __future__ import annotations
 
+import os
 import re
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -30,15 +32,22 @@ RecommendedQueueAction = Literal[
 ]
 
 DEFAULT_STALE_AFTER_SECONDS = 60 * 60
+DEFAULT_LOCK_FILE_PATH = "/home/agent/agent-dev/runner-state/yellow_runnerd.lock"
+DEFAULT_AGENT_RUNS_DIR = "/home/agent/agent-dev/agent-runs"
+DEFAULT_LOGS_DIR = "/home/agent/agent-dev/logs"
+DEFAULT_LOG_TAIL_LINES = 80
+DEFAULT_LOG_TAIL_BYTES = 20_000
+MAX_LIVE_LOG_FILES = 5
+SAFE_PROCESS_WORDS = ("yellow_runnerd", "agent-run", "python", "codex", "gemini", "pytest", "git")
 SECRET_LIKE_PATTERNS = [
     re.compile(pattern, re.IGNORECASE)
     for pattern in [
-        r"api[_-]?key\s*[:=]",
-        r"token\s*[:=]",
+        r"api[_-]?key\s*[:=]\s*[^\s]+",
+        r"token\s*[:=]\s*[^\s]+",
         r"bearer\s+[a-z0-9._\-]+",
-        r"private[_-]?key",
-        r"password\s*[:=]",
-        r"secret\s*[:=]",
+        r"private[_-]?key\s*[:=]?\s*[^\s]*",
+        r"password\s*[:=]\s*[^\s]+",
+        r"secret\s*[:=]\s*[^\s]+",
         r"ghp_[a-z0-9_]+",
         r"github_pat_[a-z0-9_]+",
         r"AIza[0-9A-Za-z_\-]{20,}",
@@ -91,6 +100,7 @@ class RunnerStatusCheckInput(BaseModel):
     latest_event_summary: str = ""
     logs_summary: str = ""
     related_subprocesses_seen: list[str] = Field(default_factory=list)
+    process_command_summary: str = ""
     final_report_seen: bool = False
     completion_evidence_seen: bool = False
     blocker_summary: str = ""
@@ -114,6 +124,9 @@ class RunnerStatusCheckPacket(BaseModel):
     latest_run_id: str | None = None
     latest_event_status: str | None = None
     related_subprocesses_seen: list[str] = Field(default_factory=list)
+    process_command_summary: str = ""
+    latest_event_summary: str = ""
+    logs_summary: str = ""
     staleness_reason: str = ""
     blocker_summary: str = ""
     recommended_queue_action: RecommendedQueueAction
@@ -225,7 +238,7 @@ def _infer_status(
         packet.latest_event_summary,
         packet.blocker_summary,
     )
-    if secret_like:
+    if secret_like or packet.blocker_summary == "secret-like text detected in runner log tail":
         return "needs_manual_review", "", "needs_manual_review"
 
     if _has_failure_text(packet):
@@ -279,6 +292,9 @@ def build_runner_status_check(packet: RunnerStatusCheckInput) -> RunnerStatusChe
         latest_run_id=packet.latest_run_id,
         latest_event_status=packet.latest_event_status,
         related_subprocesses_seen=packet.related_subprocesses_seen,
+        process_command_summary=_redact_secret_like_text(packet.process_command_summary),
+        latest_event_summary=_redact_secret_like_text(packet.latest_event_summary),
+        logs_summary=_redact_secret_like_text(packet.logs_summary),
         staleness_reason=staleness_reason,
         blocker_summary=_blocker_summary(packet, secret_like=secret_like),
         recommended_queue_action=action,
@@ -290,6 +306,234 @@ def build_runner_status_check(packet: RunnerStatusCheckInput) -> RunnerStatusChe
 def build_runner_status_check_from_json(raw_json: str) -> RunnerStatusCheckPacket:
     """Validate public-safe JSON and build a runner status packet."""
     return build_runner_status_check(RunnerStatusCheckInput.model_validate_json(raw_json))
+
+
+def _parse_lock_pid(lock_file: Path) -> int | None:
+    try:
+        raw_value = lock_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    try:
+        pid = int(raw_value)
+    except ValueError:
+        return None
+    return pid if pid > 0 else None
+
+
+def _pid_alive(pid: int | None) -> bool | None:
+    if pid is None:
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _safe_process_command_summary(pid: int | None) -> str:
+    if pid is None:
+        return ""
+    cmdline = Path("/proc") / str(pid) / "cmdline"
+    try:
+        raw = cmdline.read_bytes()
+    except OSError:
+        return ""
+    parts = [part.decode("utf-8", errors="replace") for part in raw.split(b"\0") if part]
+    if not parts:
+        return ""
+    summary = " ".join(parts[:8])
+    return _redact_secret_like_text(summary[:500])
+
+
+def _safe_process_names() -> list[str]:
+    names: set[str] = set()
+    proc_root = Path("/proc")
+    try:
+        entries = list(proc_root.iterdir())
+    except OSError:
+        return []
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            comm = (entry / "comm").read_text(encoding="utf-8", errors="replace").strip()
+            cmdline = (
+                (entry / "cmdline")
+                .read_bytes()
+                .decode("utf-8", errors="replace")
+                .replace("\0", " ")
+            )
+        except OSError:
+            continue
+        haystack = f"{comm} {cmdline}".casefold()
+        for word in SAFE_PROCESS_WORDS:
+            if word in haystack:
+                names.add(word)
+    return sorted(names)
+
+
+def _safe_tail(
+    path: Path,
+    *,
+    max_lines: int = DEFAULT_LOG_TAIL_LINES,
+    max_bytes: int = DEFAULT_LOG_TAIL_BYTES,
+) -> tuple[str, bool]:
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - max_bytes))
+            raw = handle.read(max_bytes)
+    except OSError:
+        return "", False
+
+    text = raw.decode("utf-8", errors="replace")
+    lines = text.splitlines()[-max_lines:]
+    tail = "\n".join(lines)
+    secret_like = _contains_secret_like_text(tail)
+    return _redact_secret_like_text(tail), secret_like
+
+
+def _candidate_run_dirs(
+    *,
+    agent_runs_dir: Path,
+    repository: str,
+    issue_number: int | None,
+    run_id: str | None,
+) -> list[Path]:
+    if run_id:
+        candidate = agent_runs_dir / run_id
+        return [candidate] if candidate.exists() and candidate.is_dir() else []
+
+    if not agent_runs_dir.exists() or not agent_runs_dir.is_dir():
+        return []
+
+    repo_slug = repository.replace("/", "-")
+    issue_suffix = f"-{issue_number}" if issue_number is not None else ""
+    candidates: list[Path] = []
+    try:
+        for entry in agent_runs_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            name = entry.name
+            if repo_slug and repo_slug not in name:
+                continue
+            if issue_suffix and not name.endswith(issue_suffix):
+                continue
+            candidates.append(entry)
+    except OSError:
+        return []
+
+    return sorted(candidates, key=lambda item: item.stat().st_mtime, reverse=True)[
+        :MAX_LIVE_LOG_FILES
+    ]
+
+
+def _candidate_log_files(
+    *,
+    run_dirs: list[Path],
+    logs_dir: Path,
+    run_id: str | None,
+) -> list[Path]:
+    files: list[Path] = []
+    for run_dir in run_dirs:
+        log_file = run_dir / "log.txt"
+        if log_file.exists() and log_file.is_file():
+            files.append(log_file)
+
+    if logs_dir.exists() and logs_dir.is_dir() and run_id:
+        try:
+            for entry in logs_dir.iterdir():
+                if entry.is_file() and run_id in entry.name:
+                    files.append(entry)
+        except OSError:
+            pass
+
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for file_path in files:
+        resolved = file_path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(file_path)
+    return unique[:MAX_LIVE_LOG_FILES]
+
+
+def live_runner_status_check(
+    *,
+    repository: str,
+    issue_number: int | None,
+    run_id: str | None = None,
+    lock_file_path: Path | str = DEFAULT_LOCK_FILE_PATH,
+    agent_runs_dir: Path | str = DEFAULT_AGENT_RUNS_DIR,
+    logs_dir: Path | str = DEFAULT_LOGS_DIR,
+    stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+    current_time: str | None = None,
+) -> RunnerStatusCheckPacket:
+    """Collect bounded public-safe local runner status evidence.
+
+    This function is read-only. It does not read environment variables, does not
+    inspect .env files, does not kill/restart processes, and does not mutate
+    GitHub state.
+    """
+    lock_file = Path(lock_file_path)
+    runs_dir = Path(agent_runs_dir)
+    safe_logs_dir = Path(logs_dir)
+
+    lock_file_seen = lock_file.exists()
+    lock_pid = _parse_lock_pid(lock_file) if lock_file_seen else None
+    lock_pid_alive = _pid_alive(lock_pid)
+
+    run_dirs = _candidate_run_dirs(
+        agent_runs_dir=runs_dir,
+        repository=repository,
+        issue_number=issue_number,
+        run_id=run_id,
+    )
+    latest_run_id = run_id or (run_dirs[0].name if run_dirs else None)
+    log_files = _candidate_log_files(
+        run_dirs=run_dirs, logs_dir=safe_logs_dir, run_id=latest_run_id
+    )
+
+    log_tails = []
+    secret_like_log_seen = False
+    for log_file in log_files:
+        tail, tail_secret_like = _safe_tail(log_file)
+        secret_like_log_seen = secret_like_log_seen or tail_secret_like
+        if tail:
+            log_tails.append(f"== {log_file.name} ==\n{tail}")
+
+    logs_summary = "\n\n".join(log_tails)
+    latest_event_summary = ""
+    if logs_summary:
+        latest_event_summary = logs_summary.splitlines()[-1][:500]
+
+    packet = RunnerStatusCheckInput(
+        repository=repository,
+        issue_number=issue_number,
+        issue_labels=["agent:running"] if latest_run_id or lock_pid_alive else [],
+        stale_after_seconds=stale_after_seconds,
+        current_time=current_time,
+        lock_file_seen=lock_file_seen,
+        lock_pid=lock_pid,
+        lock_pid_alive=lock_pid_alive,
+        latest_run_id=latest_run_id,
+        latest_event_summary=latest_event_summary,
+        logs_summary=logs_summary,
+        related_subprocesses_seen=_safe_process_names(),
+        process_command_summary=_safe_process_command_summary(lock_pid),
+        blocker_summary=(
+            "secret-like text detected in runner log tail"
+            if secret_like_log_seen
+            else "" if latest_run_id or lock_file_seen else "no live runner evidence found"
+        ),
+    )
+    return build_runner_status_check(packet)
 
 
 def build_unavailable_live_check(


### PR DESCRIPTION
## Summary

Implements #161.

Adds bounded read-only live mode to existing `runner-status-check`.

## Changed files

```text
tools/skeleton_core/runner_status_check.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_runner_status_check.py
tests/skeleton_core/test_runner_status_cli.py
```

## New CLI mode

```bash
python -m tools.skeleton_core.cli runner-status-check --repo alanua/bauclock --issue 48 --run-id 20260512-091344-yellow-alanua-bauclock-48 --live
```

Optional bounded test paths:

```text
--lock-file
--agent-runs-dir
--logs-dir
```

## Validation

```text
narrow pytest: 13 passed
narrow ruff: passed
narrow black: passed
full pytest: 357 passed, 7 existing warnings
full ruff: passed
full black: passed
```

## Safety

```text
read-only only
does not read .env
does not print environment variables
does not kill or restart processes
does not restart services
does not mutate GitHub
does not change BauClock
does not change host-local wrapper scripts
does not change yellow_runnerd daemon
merge_allowed=false
deploy_allowed=false
```

## Notes

This PR adds diagnostics only. It does not fix BauClock #48 directly. Unknown YELLOW task mapping remains tracked separately in #157.