### PR TITLE
docs(skeleton): add agent worktree protocol

### DIFF
--- a/knowledge_base/WORKING_PROTOCOL.md
+++ b/knowledge_base/WORKING_PROTOCOL.md
@@ -127,6 +127,24 @@ For Skeleton tasks, prefer:
 knowledge_base/chatgpt_exoskeleton/SKELETON_RUNNER_TASK_TEMPLATE.md
 ```
 
+## Agent worktree protocol
+
+For parallel or long-running agent development work, use:
+
+```text
+knowledge_base/chatgpt_exoskeleton/AGENT_WORKTREE_PROTOCOL.md
+```
+
+Core rule:
+
+```text
+One issue = one branch = one worktree = one reviewable PR/diff.
+```
+
+Git worktrees isolate Git working directories and branch state only. They do not isolate runtime resources such as databases, ports, Docker, Redis, caches, `.venv`, secrets, or environment variables.
+
+Read-only audits do not require a worktree when they only read GitHub/files and post a report. Test-only and code-changing tasks require a worktree.
+
 ## Response compression rule
 
 For direct chat with Oleksii, use one short human Ukrainian sentence by default: what changed, what matters, or the next step.

--- a/knowledge_base/chatgpt_exoskeleton/AGENT_WORKTREE_PROTOCOL.md
+++ b/knowledge_base/chatgpt_exoskeleton/AGENT_WORKTREE_PROTOCOL.md
@@ -1,0 +1,119 @@
+# Agent Worktree Protocol
+
+Status: LIKELY_NEEDS_REVIEW
+Scope: Skeleton / ChatGPT Exoskeleton protocol for parallel AI-agent development
+Created: 2026-05-12
+Source issue: #165
+
+## Purpose
+
+This protocol defines how Skeleton should use Git worktrees for parallel AI-agent development.
+
+The goal is to keep the main control checkout clean while allowing bounded executor tasks to work in isolated Git working directories.
+
+This is a Skeleton protocol. It is not Jeeves runtime behavior and does not grant merge, deploy, production, server, database, or secret access.
+
+## Core rule
+
+```text
+One issue = one branch = one worktree = one reviewable PR/diff.
+```
+
+The main checkout remains the control plane. Executors work inside task-specific worktrees.
+
+## Control checkout vs task worktree
+
+```text
+Control checkout
+-> runner/orchestrator state
+-> queue inspection
+-> PR review
+-> coordination
+-> must stay clean
+
+Task worktree
+-> one bounded issue task
+-> one branch
+-> one reviewable diff or PR
+-> removable after completion
+```
+
+Do not run code-modifying executor tasks directly in the main control checkout.
+
+## Isolation limits
+
+Git worktrees isolate Git working directories and branch state. They reduce checkout-level conflicts, but do **not** isolate runtime resources, secrets, databases, ports, processes, caches, or virtual environments.
+
+Worktree isolation is not sandboxing. Any task that starts services, tests with shared databases, uses Docker, touches Redis, uses shared caches, or depends on `.venv`/environment state needs separate runtime isolation rules.
+
+## Read-only audits
+
+Read-only audits do not require a worktree when they only read GitHub/files and post a report.
+
+Use a temporary read-only checkout or worktree only if local tests, static analysis, grep, or tool execution needs a filesystem tree.
+
+Pure audits do not create branches or PRs.
+
+## Test-only and code tasks
+
+Worktree use is mandatory for test-only and code-changing tasks.
+
+Test-only tasks must remain test-only. If a production bug is discovered during a test-only task, the executor must stop and report the bug instead of fixing production code in the same task.
+
+## Cleanup safety
+
+After a PR is opened and the worktree is no longer needed:
+
+```bash
+git worktree remove <task-worktree-path>
+git worktree prune
+git branch -d <local-task-branch>
+```
+
+Use `git branch -d`, not `git branch -D`, unless it has been explicitly verified that all local-only commits were pushed or intentionally discarded.
+
+Delete the local branch only after the PR branch is pushed and no local-only commits remain.
+
+## Forbidden actions
+
+```text
+No nested worktrees.
+No `.env` copying, symlinking, committing, or printing.
+No secrets in repository files, prompts, logs, or public reports.
+No direct merge from a worktree.
+No deploy from a worktree.
+No production/server/database access because a worktree exists.
+No out-of-scope fixes inside a worktree task.
+No treating worktree isolation as runtime/container isolation.
+```
+
+## Recommended naming
+
+```text
+Branch: docs/issue-<number>-<short-topic>
+Branch: test/issue-<number>-<short-topic>
+Branch: fix/issue-<number>-<short-topic>
+
+Worktree path: ../agent-worktrees/<repo>-issue-<number>-<short-topic>
+```
+
+Use the issue number in the branch and worktree path so stale worktrees can be audited and cleaned.
+
+## Pre-PR checklist
+
+Before opening a PR from a worktree:
+
+```text
+[ ] Scope matches the issue.
+[ ] Main/control checkout was not mutated.
+[ ] No runtime/production/server action was performed unless explicitly authorized.
+[ ] No secrets, `.env`, tokens, private infrastructure data, or credentials appear in the diff or report.
+[ ] Validation ran, or skipped validation is explained.
+[ ] PR body lists changed files, validation, and safety confirmation.
+```
+
+## Relationship to runner implementation
+
+This document is a protocol only. Runner code must not be changed merely because this file exists.
+
+A separate reviewed implementation task is required before `yellow_runnerd` or any runner wrapper starts creating worktrees automatically.

--- a/knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
+++ b/knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
@@ -2,7 +2,7 @@
 
 Status: CONFIRMED_CANON
 Scope: short public-safe handoff for the next ChatGPT branch working on СК / Skeleton
-Last updated: 2026-05-09
+Last updated: 2026-05-12
 
 ## Active project
 
@@ -65,6 +65,17 @@ semi_automatic_construction_takeoff_with_gemini
 semi_automatic_construction_takeoff_gemini_task_template
 gemini_auditor_node
 gemini_auditor_adapter
+agent_worktree_protocol
+```
+
+Agent Worktree Protocol status:
+
+```text
+Priority: HIGH
+Status: LIKELY_NEEDS_REVIEW
+Public GitHub: docs-only protocol in knowledge_base/chatgpt_exoskeleton/AGENT_WORKTREE_PROTOCOL.md via #166
+Purpose: define one issue = one branch = one worktree = one reviewable PR/diff for parallel agent work
+Runner behavior: not implemented; separate reviewed implementation task required before yellow_runnerd or runner wrappers create worktrees automatically
 ```
 
 Gemini Auditor Node status:

--- a/knowledge_base/chatgpt_exoskeleton/SKELETON_RUNNER_TASK_TEMPLATE.md
+++ b/knowledge_base/chatgpt_exoskeleton/SKELETON_RUNNER_TASK_TEMPLATE.md
@@ -43,7 +43,14 @@ Forbidden:
 - knowledge_base/chatgpt_exoskeleton/START_HERE.md
 - knowledge_base/CHATGPT_EXOSKELETON.md
 - knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md
+- knowledge_base/chatgpt_exoskeleton/AGENT_WORKTREE_PROTOCOL.md, if the task is test-only, code-changing, parallel, or long-running
 - <target file / issue if relevant>
+
+## Worktree requirement
+
+For test-only or code-changing tasks, use one issue = one branch = one worktree = one reviewable PR/diff.
+
+Read-only audits do not require a worktree when they only read GitHub/files and post a report.
 
 ## Work to perform
 
@@ -75,3 +82,5 @@ Prefer one small task that can be verified over a large ambiguous task.
 Use GitHub Issues/PRs as task queue and audit trail, but keep bureaucracy at the safe minimum.
 
 Do not create a separate issue for every tiny step unless it improves safety, auditability, or delegation.
+
+For parallel agent work, follow `knowledge_base/chatgpt_exoskeleton/AGENT_WORKTREE_PROTOCOL.md`. A worktree isolates Git working directories and branch state only; it does not isolate runtime resources, secrets, databases, ports, processes, caches, or virtual environments.


### PR DESCRIPTION
## Summary

Implements #165.

Adds the initial Skeleton Git worktree protocol for parallel AI-agent development.

## Changed files

```text
knowledge_base/chatgpt_exoskeleton/AGENT_WORKTREE_PROTOCOL.md
knowledge_base/WORKING_PROTOCOL.md
knowledge_base/chatgpt_exoskeleton/SKELETON_RUNNER_TASK_TEMPLATE.md
knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
```

## What changed

```text
- Added AGENT_WORKTREE_PROTOCOL.md.
- Documented the core rule: one issue = one branch = one worktree = one reviewable PR/diff.
- Documented isolation limits: worktrees isolate Git working directories and branch state only, not runtime resources.
- Documented read-only audit behavior.
- Documented mandatory worktree use for test-only and code-changing tasks.
- Documented cleanup safety: prefer git branch -d, not -D, after worktree removal/prune and only after branch safety is verified.
- Added references from WORKING_PROTOCOL.md, SKELETON_RUNNER_TASK_TEMPLATE.md, and CURRENT_STATE.md.
```

## Validation

```text
GitHub compare verified only documentation files changed.
No local pytest/ruff/black/validate-state was run from this chat-side API path.
```

## Safety confirmation

```text
Code changes: no
Runtime/runner changes: no
Tools/tests/app/api/bot/db changes: no
Secrets used or printed: no
.env read: no
Deploy/merge: no
Service restart: no
```

## Next safe step

Human review. If acceptable, merge after review or run local docs/validation checks first if desired.