### PR TITLE
feat(skeleton): add deep diff audit evidence packet builder

### DIFF
--- a/tests/skeleton_core/test_deep_diff_audit_pack.py
+++ b/tests/skeleton_core/test_deep_diff_audit_pack.py
@@ -1,0 +1,146 @@
+import json
+
+from tools.skeleton_core.deep_diff_audit_pack import (
+    DEFAULT_SCHEMA_VERSION,
+    DeepDiffEvidenceInput,
+    DeepDiffSourceInput,
+    DeepDiffSubject,
+    build_deep_diff_audit_pack,
+    build_deep_diff_audit_pack_from_json,
+    contains_secret_like_text,
+    packet_to_json_dict,
+)
+
+
+def test_deep_diff_audit_pack_builds_required_structure() -> None:
+    packet = build_deep_diff_audit_pack(
+        DeepDiffEvidenceInput(
+            subject=DeepDiffSubject(
+                repo="alanua/jeeves",
+                issue_number=175,
+                title="Add Skeleton branch continuity state guardrail",
+            ),
+            sources=[
+                DeepDiffSourceInput(
+                    source_type="issue_body",
+                    source_ref="alanua/jeeves#175",
+                    content="Proposed continuity guardrail.",
+                ),
+                DeepDiffSourceInput(
+                    source_type="repo_file_excerpt",
+                    source_ref="knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md",
+                    content="Existing current state excerpt.",
+                ),
+            ],
+        )
+    )
+
+    payload = packet_to_json_dict(packet)
+
+    assert payload["schema_version"] == DEFAULT_SCHEMA_VERSION
+    assert payload["subject"]["repo"] == "alanua/jeeves"
+    assert payload["subject"]["issue_number"] == 175
+    assert len(payload["sources"]) == 2
+    assert payload["sources"][0]["source_type"] == "issue_body"
+    assert payload["sources"][1]["source_type"] == "repo_file_excerpt"
+    assert "questions" in payload
+    assert "expected_matrix_schema" in payload
+    assert payload["expected_matrix_schema"]["required_fields"] == [
+        "proposed_item",
+        "existing_source",
+        "status",
+        "recommendation",
+        "confidence",
+    ]
+
+
+def test_deep_diff_audit_pack_truncates_long_excerpt() -> None:
+    packet = build_deep_diff_audit_pack(
+        DeepDiffEvidenceInput(
+            subject=DeepDiffSubject(repo="alanua/jeeves"),
+            sources=[
+                DeepDiffSourceInput(
+                    source_type="manual_excerpt",
+                    source_ref="manual:test",
+                    content="x" * 250,
+                    max_excerpt_chars=100,
+                )
+            ],
+        )
+    )
+
+    source = packet.sources[0]
+
+    assert source.truncated is True
+    assert source.chars_original == 250
+    assert source.excerpt.endswith("<truncated>")
+    assert "excerpt_truncated_to_100_chars" in source.limits_applied
+
+
+def test_deep_diff_audit_pack_redacts_secret_like_content() -> None:
+    assert contains_secret_like_text("token=abc123") is True
+
+    packet = build_deep_diff_audit_pack(
+        DeepDiffEvidenceInput(
+            subject=DeepDiffSubject(repo="alanua/jeeves"),
+            sources=[
+                DeepDiffSourceInput(
+                    source_type="manual_excerpt",
+                    source_ref="manual:bad",
+                    content="token=abc123\nnormal line",
+                )
+            ],
+        )
+    )
+
+    source = packet.sources[0]
+
+    assert source.secret_like_redaction_applied is True
+    assert source.excerpt == "<redacted-secret-like-content>"
+    assert "abc123" not in source.excerpt
+    assert "secret_like_content_redacted" in source.limits_applied
+
+
+def test_deep_diff_audit_pack_from_json() -> None:
+    raw = json.dumps(
+        {
+            "subject": {
+                "repo": "alanua/jeeves",
+                "issue_number": 178,
+                "title": "Add Skeleton deep-diff audit evidence packet builder",
+            },
+            "sources": [
+                {
+                    "source_type": "issue_body",
+                    "source_ref": "alanua/jeeves#178",
+                    "content": "Deep audit without evidence packet is shallow audit.",
+                }
+            ],
+            "questions": ["Is this duplicate, overlap, gap, conflict, or new?"],
+        }
+    )
+
+    packet = build_deep_diff_audit_pack_from_json(raw)
+
+    assert packet.subject.issue_number == 178
+    assert packet.questions == ["Is this duplicate, overlap, gap, conflict, or new?"]
+    assert packet.sources[0].source_ref == "alanua/jeeves#178"
+
+
+def test_deep_diff_audit_pack_marks_builder_limits() -> None:
+    packet = build_deep_diff_audit_pack(
+        DeepDiffEvidenceInput(
+            subject=DeepDiffSubject(repo="alanua/jeeves"),
+            sources=[
+                DeepDiffSourceInput(
+                    source_type="pr_changed_files",
+                    source_ref="alanua/Knowledge-base#178",
+                    content="scripts/agent-host-wrapper-reference/README.md",
+                    limits_applied=["changed_filenames_only"],
+                )
+            ],
+        )
+    )
+
+    assert "changed_filenames_only" in packet.sources[0].limits_applied
+    assert any("does not fetch GitHub" in note for note in packet.safety_notes)

--- a/tools/skeleton_core/deep_diff_audit_pack.py
+++ b/tools/skeleton_core/deep_diff_audit_pack.py
@@ -1,0 +1,232 @@
+"""Public-safe evidence packet builder for deep-diff audits.
+
+This module does not fetch GitHub, read private files, inspect host runtime,
+read environment variables, or call external services. It only structures
+already-supplied public-safe evidence into a bounded packet suitable for a
+future Gemini deep-diff audit.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+SourceType = Literal[
+    "issue_body",
+    "issue_comments",
+    "pr_metadata",
+    "pr_changed_files",
+    "repo_file_excerpt",
+    "manual_excerpt",
+]
+
+DeepDiffStatus = Literal[
+    "duplicate",
+    "overlap",
+    "gap",
+    "conflict",
+    "new",
+    "unknown",
+]
+
+DEFAULT_MAX_EXCERPT_CHARS = 4_000
+DEFAULT_SCHEMA_VERSION = "deep-diff-evidence-packet/v1"
+
+_SECRET_LIKE_PATTERNS = (
+    re.compile(r"(?i)\bapi[_-]?key\s*[:=]\s*\S+"),
+    re.compile(r"(?i)\btoken\s*[:=]\s*\S+"),
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._\-]+"),
+    re.compile(r"(?i)\bpassword\s*[:=]\s*\S+"),
+    re.compile(r"(?i)\bsecret\s*[:=]\s*\S+"),
+    re.compile(r"(?i)\bprivate[_-]?key\s*[:=]?\s*\S*"),
+)
+
+
+class DeepDiffSubject(BaseModel):
+    """The proposed work being audited."""
+
+    repo: str = Field(..., min_length=1)
+    issue_number: int | None = None
+    title: str = ""
+    summary: str = ""
+
+
+class DeepDiffSourceInput(BaseModel):
+    """Already-collected public-safe source material."""
+
+    source_type: SourceType
+    source_ref: str = Field(..., min_length=1)
+    content: str = ""
+    retrieved_at: str | None = None
+    limits_applied: list[str] = Field(default_factory=list)
+    max_excerpt_chars: int = Field(default=DEFAULT_MAX_EXCERPT_CHARS, ge=100, le=20_000)
+
+
+class DeepDiffSource(BaseModel):
+    """Bounded source excerpt included in the packet."""
+
+    source_type: SourceType
+    source_ref: str
+    retrieved_at: str
+    excerpt: str
+    limits_applied: list[str] = Field(default_factory=list)
+    chars_original: int
+    chars_included: int
+    truncated: bool
+    secret_like_redaction_applied: bool = False
+
+
+class ExpectedMatrixSchema(BaseModel):
+    """Required Gemini answer shape for a real deep-diff audit."""
+
+    required_fields: list[str] = Field(
+        default_factory=lambda: [
+            "proposed_item",
+            "existing_source",
+            "status",
+            "recommendation",
+            "confidence",
+        ]
+    )
+    allowed_statuses: list[DeepDiffStatus] = Field(
+        default_factory=lambda: [
+            "duplicate",
+            "overlap",
+            "gap",
+            "conflict",
+            "new",
+            "unknown",
+        ]
+    )
+
+
+class DeepDiffEvidencePacket(BaseModel):
+    """Public-safe bounded evidence packet."""
+
+    schema_version: str = DEFAULT_SCHEMA_VERSION
+    subject: DeepDiffSubject
+    sources: list[DeepDiffSource]
+    questions: list[str]
+    expected_matrix_schema: ExpectedMatrixSchema = Field(default_factory=ExpectedMatrixSchema)
+    safety_notes: list[str]
+    created_at: str
+
+
+class DeepDiffEvidenceInput(BaseModel):
+    """Input model for building a deep-diff evidence packet."""
+
+    subject: DeepDiffSubject
+    sources: list[DeepDiffSourceInput]
+    questions: list[str] | None = None
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def contains_secret_like_text(text: str) -> bool:
+    """Return True when text resembles a secret/key/token/password."""
+
+    return any(pattern.search(text) for pattern in _SECRET_LIKE_PATTERNS)
+
+
+def _redact_or_truncate(content: str, *, max_chars: int) -> tuple[str, bool, bool]:
+    secret_like = contains_secret_like_text(content)
+    if secret_like:
+        return "<redacted-secret-like-content>", False, True
+
+    truncated = len(content) > max_chars
+    if not truncated:
+        return content, False, False
+
+    return content[:max_chars].rstrip() + "\n<truncated>", True, False
+
+
+def build_deep_diff_source(
+    source: DeepDiffSourceInput,
+    *,
+    default_time: str | None = None,
+) -> DeepDiffSource:
+    """Build one bounded source excerpt."""
+
+    retrieved_at = source.retrieved_at or default_time or _utc_now()
+    excerpt, truncated, secret_like = _redact_or_truncate(
+        source.content,
+        max_chars=source.max_excerpt_chars,
+    )
+
+    limits = list(source.limits_applied)
+    if truncated:
+        limits.append(f"excerpt_truncated_to_{source.max_excerpt_chars}_chars")
+    if secret_like:
+        limits.append("secret_like_content_redacted")
+
+    return DeepDiffSource(
+        source_type=source.source_type,
+        source_ref=source.source_ref,
+        retrieved_at=retrieved_at,
+        excerpt=excerpt,
+        limits_applied=limits,
+        chars_original=len(source.content),
+        chars_included=len(excerpt),
+        truncated=truncated,
+        secret_like_redaction_applied=secret_like,
+    )
+
+
+def default_deep_diff_questions() -> list[str]:
+    """Questions every deep-diff audit should answer."""
+
+    return [
+        "Which proposed items duplicate existing sources?",
+        "Which proposed items overlap existing sources but still need a smaller patch?",
+        "Which proposed items are genuine gaps?",
+        "Which proposed items conflict with existing canon or current state?",
+        "Which target file or existing issue/PR should be used next?",
+        "What is the smallest safe next action?",
+    ]
+
+
+def default_safety_notes() -> list[str]:
+    """Safety notes carried with every packet."""
+
+    return [
+        "This packet is public-safe evidence only.",
+        "The builder does not fetch GitHub or browse sources by itself.",
+        "The builder does not read private Drive, .env files, secrets, or host-local runtime paths.",
+        "Gemini should analyze only the supplied evidence packet.",
+        "A deep audit is incomplete if the required matrix fields are missing.",
+    ]
+
+
+def build_deep_diff_audit_pack(
+    input_packet: DeepDiffEvidenceInput,
+) -> DeepDiffEvidencePacket:
+    """Build a public-safe deep-diff evidence packet."""
+
+    created_at = _utc_now()
+    return DeepDiffEvidencePacket(
+        subject=input_packet.subject,
+        sources=[
+            build_deep_diff_source(source, default_time=created_at)
+            for source in input_packet.sources
+        ],
+        questions=input_packet.questions or default_deep_diff_questions(),
+        safety_notes=default_safety_notes(),
+        created_at=created_at,
+    )
+
+
+def build_deep_diff_audit_pack_from_json(raw_json: str) -> DeepDiffEvidencePacket:
+    """Validate JSON and build a deep-diff evidence packet."""
+
+    return build_deep_diff_audit_pack(DeepDiffEvidenceInput.model_validate_json(raw_json))
+
+
+def packet_to_json_dict(packet: DeepDiffEvidencePacket) -> dict[str, Any]:
+    """Return a JSON-ready packet dict."""
+
+    return packet.model_dump(mode="json")


### PR DESCRIPTION
Implements the first controlled code step for #178.

Adds a pure public-safe deep-diff evidence packet builder.

Scope:
- adds tools/skeleton_core/deep_diff_audit_pack.py
- adds tests for packet structure, truncation, secret-like redaction, JSON input, and safety notes
- no CLI wiring yet
- no GitHub fetching
- no runner execution
- no host-local script reads
- no systemd changes
- no env/secret reads
- no external calls
- no deploy

This prepares the core packet model before a later reviewed CLI/GitHub-source collection step.