### PR TITLE
Add OpenHands adapter v0

### DIFF
--- a/tests/skeleton_core/test_openhands_adapter.py
+++ b/tests/skeleton_core/test_openhands_adapter.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from tools.skeleton_core.adapter_contract import AdapterTaskPacket, FuelPolicy
+from tools.skeleton_core.openhands_adapter import (
+    OPENHANDS_ADAPTER_VERSION,
+    OpenHandsAdapterConfig,
+    build_openhands_command,
+    build_openhands_env,
+    build_openhands_result,
+    build_openhands_task_text,
+    prepare_openhands_task,
+)
+
+
+def valid_packet() -> AdapterTaskPacket:
+    return AdapterTaskPacket(
+        task_id="openhands-adapter-v0",
+        repo="alanua/jeeves",
+        allowed_files=["tools/skeleton_core/openhands_adapter.py"],
+        forbidden_paths=[".env", ".git", ".ssh", "secrets", "tokens"],
+        authority_level="level_2_local_diff",
+        risk_level="yellow",
+        expected_artifact="diff",
+        fuel_policy=FuelPolicy(
+            provider="openrouter",
+            model="deepseek/deepseek-v4-flash:free",
+            max_usd=1.0,
+        ),
+    )
+
+
+def test_valid_packet_prepares_task() -> None:
+    prepared = prepare_openhands_task(valid_packet(), "/tmp/task.md")
+
+    assert prepared.adapter_version == OPENHANDS_ADAPTER_VERSION
+    assert prepared.task_validation.status == "valid_task_packet"
+    assert prepared.command[-2:] == ["-f", "/tmp/task.md"]
+
+
+def test_invalid_packet_returns_blocked_task_validation() -> None:
+    packet = valid_packet().model_copy(update={"allowed_files": []})
+
+    prepared = prepare_openhands_task(packet, "/tmp/task.md")
+
+    assert prepared.task_validation.status == "blocked"
+    assert "missing_allowed_files" in prepared.task_validation.blocked_reasons
+
+
+def test_task_text_contains_scope_and_boundaries() -> None:
+    text = build_openhands_task_text(valid_packet())
+
+    assert "tools/skeleton_core/openhands_adapter.py" in text
+    assert ".env" in text
+    assert "Do not read .env, .git, .ssh" in text
+    assert "Do not install packages" in text
+    assert "Do not push, merge, deploy" in text
+
+
+def test_command_is_exact_openhands_command() -> None:
+    config = OpenHandsAdapterConfig(executable="/bin/openhands")
+
+    command = build_openhands_command("/tmp/task.md", config)
+
+    assert command == ["/bin/openhands", "--override-with-envs", "-f", "/tmp/task.md"]
+
+
+def test_env_builder_keeps_secret_out_of_prepared_metadata() -> None:
+    config = OpenHandsAdapterConfig(model="test/model", base_url="https://example.test/v1")
+
+    env = build_openhands_env("sk-or-secret-value", config)
+    prepared = prepare_openhands_task(valid_packet(), "/tmp/task.md", config)
+
+    assert env["LLM_API_KEY"] == "sk-or-secret-value"
+    assert env["LLM_MODEL"] == "test/model"
+    assert env["LLM_BASE_URL"] == "https://example.test/v1"
+    assert "OPENHANDS_SUPPRESS_BANNER" in env
+    assert "LLM_API_KEY" in prepared.env_keys
+    assert "sk-or-secret-value" not in str(prepared.model_dump())
+
+
+def test_result_builder_validates_success_result() -> None:
+    result = build_openhands_result(
+        valid_packet(),
+        executor_status="success",
+        changed_files=["tools/skeleton_core/openhands_adapter.py"],
+        artifact_paths=["artifacts/openhands-adapter-v0.diff"],
+        validation_status="passed",
+        risk_flags=[],
+        stop_reason="done",
+    )
+
+    assert result.result.status == "success"
+    assert result.result_validation.status == "valid_adapter_result"
+
+
+def test_result_builder_blocks_changed_file_outside_allowed_scope() -> None:
+    result = build_openhands_result(
+        valid_packet(),
+        executor_status="success",
+        changed_files=["tools/skeleton_core/other.py"],
+        artifact_paths=["artifacts/openhands-adapter-v0.diff"],
+        validation_status="passed",
+        risk_flags=[],
+        stop_reason="done",
+    )
+
+    assert result.result_validation.status == "blocked"
+    assert "changed_file_outside_allowed_scope" in result.result_validation.blocked_reasons
+
+
+def test_result_builder_blocks_secret_risk_flag() -> None:
+    result = build_openhands_result(
+        valid_packet(),
+        executor_status="success",
+        changed_files=["tools/skeleton_core/openhands_adapter.py"],
+        artifact_paths=["artifacts/openhands-adapter-v0.diff"],
+        validation_status="passed",
+        risk_flags=["secret"],
+        stop_reason="done",
+    )
+
+    assert result.result_validation.status == "blocked"
+    assert "blocking_risk_flag_present" in result.result_validation.blocked_reasons
+
+
+def test_result_builder_blocks_success_without_artifact() -> None:
+    result = build_openhands_result(
+        valid_packet(),
+        executor_status="success",
+        changed_files=["tools/skeleton_core/openhands_adapter.py"],
+        artifact_paths=[],
+        validation_status="passed",
+        risk_flags=[],
+        stop_reason="done",
+    )
+
+    assert result.result_validation.status == "blocked"
+    assert "success_without_artifact" in result.result_validation.blocked_reasons

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -1,0 +1,192 @@
+"""OpenHands adapter v0 for Skeleton.
+
+This module prepares bounded OpenHands tasks and validates returned artifacts
+through the Skeleton adapter contract. It does not run OpenHands by itself,
+read secrets, create branches, push, merge, deploy, or access production.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.adapter_contract import (
+    AdapterExecutionResult,
+    AdapterTaskPacket,
+    ContractValidationResult,
+    validate_adapter_result,
+    validate_task_packet,
+)
+
+OPENHANDS_ADAPTER_VERSION = "openhands_adapter.v0"
+
+
+class OpenHandsAdapterConfig(BaseModel):
+    """Runtime configuration for an OpenHands invocation wrapper."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    executable: str = "/home/agent/.local/bin/openhands"
+    model: str = "deepseek/deepseek-v4-flash:free"
+    base_url: str = "https://openrouter.ai/api/v1"
+    suppress_banner: bool = True
+
+
+class OpenHandsPreparedTask(BaseModel):
+    """Public-safe prepared task metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    adapter_version: str = OPENHANDS_ADAPTER_VERSION
+    task_text: str
+    command: list[str]
+    env_keys: list[str]
+    task_validation: ContractValidationResult
+
+
+class OpenHandsValidatedResult(BaseModel):
+    """Executor result plus Skeleton contract validation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    adapter_version: str = OPENHANDS_ADAPTER_VERSION
+    result: AdapterExecutionResult
+    result_validation: ContractValidationResult
+
+
+def _format_list(values: list[str]) -> str:
+    if not values:
+        return "- none"
+    return "\n".join(f"- {value}" for value in values)
+
+
+def build_openhands_task_text(packet: AdapterTaskPacket | dict[str, Any]) -> str:
+    """Render a bounded OpenHands task file from an adapter task packet."""
+
+    task = (
+        packet
+        if isinstance(packet, AdapterTaskPacket)
+        else AdapterTaskPacket.model_validate(packet)
+    )
+    fuel = task.fuel_policy
+
+    return f"""You are a bounded coding executor inside the Skeleton project.
+
+Task id:
+{task.task_id}
+
+Repository:
+{task.repo}
+
+Authority level:
+{task.authority_level}
+
+Risk level:
+{task.risk_level}
+
+Expected artifact:
+{task.expected_artifact}
+
+Allowed files:
+{_format_list(task.allowed_files)}
+
+Forbidden paths:
+{_format_list(task.forbidden_paths)}
+
+Fuel policy:
+- provider: {fuel.provider}
+- model: {fuel.model}
+- max_usd: {fuel.max_usd}
+- allow_free_models: {fuel.allow_free_models}
+
+Hard boundaries:
+- Do not read .env, .git, .ssh, secrets, tokens, SSH keys, server config, DB, or production.
+- Do not install packages.
+- Do not push, merge, deploy, restart services, or change labels.
+- Do not read or edit files outside the allowed files list.
+- Return changed files, validation result, git diff summary, and stop.
+"""
+
+
+def build_openhands_command(
+    task_file: str,
+    config: OpenHandsAdapterConfig | None = None,
+) -> list[str]:
+    """Build the OpenHands CLI command."""
+
+    resolved = config or OpenHandsAdapterConfig()
+    return [
+        resolved.executable,
+        "--override-with-envs",
+        "-f",
+        task_file,
+    ]
+
+
+def build_openhands_env(
+    api_key: str,
+    config: OpenHandsAdapterConfig | None = None,
+) -> dict[str, str]:
+    """Build the OpenHands LLM environment.
+
+    The returned environment contains the secret value because the process needs
+    it. Public metadata must expose only key names, never values.
+    """
+
+    resolved = config or OpenHandsAdapterConfig()
+    env = {
+        "LLM_API_KEY": api_key,
+        "LLM_MODEL": resolved.model,
+        "LLM_BASE_URL": resolved.base_url,
+    }
+    if resolved.suppress_banner:
+        env["OPENHANDS_SUPPRESS_BANNER"] = "1"
+    return env
+
+
+def prepare_openhands_task(
+    packet: AdapterTaskPacket | dict[str, Any],
+    task_file: str,
+    config: OpenHandsAdapterConfig | None = None,
+) -> OpenHandsPreparedTask:
+    """Prepare public-safe OpenHands task metadata."""
+
+    resolved = config or OpenHandsAdapterConfig()
+    task_validation = validate_task_packet(packet)
+    env_keys = sorted(build_openhands_env("__redacted__", resolved).keys())
+
+    return OpenHandsPreparedTask(
+        task_text=build_openhands_task_text(packet),
+        command=build_openhands_command(task_file, resolved),
+        env_keys=env_keys,
+        task_validation=task_validation,
+    )
+
+
+def build_openhands_result(
+    packet: AdapterTaskPacket | dict[str, Any],
+    *,
+    executor_status: str,
+    changed_files: list[str],
+    artifact_paths: list[str],
+    validation_status: str,
+    risk_flags: list[str],
+    stop_reason: str,
+) -> OpenHandsValidatedResult:
+    """Build and validate an OpenHands adapter result."""
+
+    result = AdapterExecutionResult(
+        status=executor_status,
+        executor=OPENHANDS_ADAPTER_VERSION,
+        changed_files=changed_files,
+        artifact_paths=artifact_paths,
+        validation_status=validation_status,
+        risk_flags=risk_flags,
+        stop_reason=stop_reason,
+    )
+
+    return OpenHandsValidatedResult(
+        result=result,
+        result_validation=validate_adapter_result(packet, result),
+    )

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from tools.skeleton_core.adapter_contract import (
     AdapterExecutionResult,


### PR DESCRIPTION
## Summary

Adds OpenHands Adapter v0 on top of the Skeleton adapter contract from #193.

This creates the next Skeleton port layer:

```text
AdapterTaskPacket
-> OpenHands task/env/command preparation
-> AdapterExecutionResult
-> validate_adapter_result()
```

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
```

## Changed files

```text
tools/skeleton_core/openhands_adapter.py
tests/skeleton_core/test_openhands_adapter.py
```

## What this adds

```text
OPENHANDS_ADAPTER_VERSION = openhands_adapter.v0
OpenHandsAdapterConfig
OpenHandsPreparedTask
OpenHandsValidatedResult
build_openhands_task_text()
build_openhands_command()
build_openhands_env()
prepare_openhands_task()
build_openhands_result()
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_adapter.py: 9 passed
```

## Safety

```text
does not run OpenHands by itself
does not read secrets
does not print API keys
does not push/merge/deploy
does not touch production/server/DB
does not modify runner route yet
```

## Boundary

This PR creates the adapter preparation/validation layer only. Runner integration is a separate follow-up.