### PR TITLE
Add OpenHands runner route v0

### DIFF
--- a/tests/skeleton_core/test_openhands_runner_route.py
+++ b/tests/skeleton_core/test_openhands_runner_route.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.skeleton_core.adapter_contract import AdapterTaskPacket, FuelPolicy
+from tools.skeleton_core.openhands_runner_route import (
+    OpenHandsRunnerRouteConfig,
+    load_openrouter_key,
+    run_openhands_route,
+)
+
+
+def valid_packet() -> AdapterTaskPacket:
+    return AdapterTaskPacket(
+        task_id="openhands-runner-route-v0",
+        repo="alanua/jeeves",
+        allowed_files=["tools/skeleton_core/openhands_runner_route.py"],
+        forbidden_paths=[".env", ".git", ".ssh", "secrets", "tokens"],
+        authority_level="level_2_local_diff",
+        risk_level="yellow",
+        expected_artifact="diff",
+        fuel_policy=FuelPolicy(
+            provider="openrouter",
+            model="deepseek/deepseek-v4-flash:free",
+            max_usd=1.0,
+        ),
+    )
+
+
+def test_load_openrouter_key_reads_runner_secret_file(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    assert load_openrouter_key(secret_file) == "sk-or-test-value"
+
+
+def test_load_openrouter_key_blocks_corrupted_secret_file(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    secret_file.write_text("OPENROUTER_API_KEY='cat > /tmp/bad.sh'\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="corrupted"):
+        load_openrouter_key(secret_file)
+
+
+def test_route_writes_task_and_runs_injected_runner(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    calls: list[tuple[list[str], dict[str, str]]] = []
+
+    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        calls.append((command, env))
+        return subprocess.CompletedProcess(command, 0, stdout="done", stderr="")
+
+    report = run_openhands_route(
+        valid_packet(),
+        config=OpenHandsRunnerRouteConfig(task_file=task_file, secret_file=secret_file),
+        runner=fake_runner,
+        changed_files=["tools/skeleton_core/openhands_runner_route.py"],
+        artifact_paths=["artifacts/openhands-runner-route-v0.diff"],
+    )
+
+    assert task_file.exists()
+    assert "openhands-runner-route-v0" in task_file.read_text(encoding="utf-8")
+    assert calls
+    assert calls[0][1]["LLM_API_KEY"] == "sk-or-test-value"
+    assert "sk-or-test-value" not in report.model_dump_json()
+    assert report.returncode == 0
+    assert report.result.result_validation.status == "valid_adapter_result"
+
+
+def test_route_blocks_success_without_artifact(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout="done", stderr="")
+
+    report = run_openhands_route(
+        valid_packet(),
+        config=OpenHandsRunnerRouteConfig(task_file=task_file, secret_file=secret_file),
+        runner=fake_runner,
+        changed_files=["tools/skeleton_core/openhands_runner_route.py"],
+        artifact_paths=[],
+    )
+
+    assert report.result.result_validation.status == "blocked"
+    assert "success_without_artifact" in report.result.result_validation.blocked_reasons
+
+
+def test_route_failed_runner_returns_failed_result(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 2, stdout="", stderr="failed")
+
+    report = run_openhands_route(
+        valid_packet(),
+        config=OpenHandsRunnerRouteConfig(task_file=task_file, secret_file=secret_file),
+        runner=fake_runner,
+        changed_files=[],
+        artifact_paths=[],
+    )
+
+    assert report.returncode == 2
+    assert report.result.result.status == "failed"
+    assert report.result.result_validation.status == "valid_adapter_result"
+    assert report.stderr_tail == "failed"

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -98,8 +98,7 @@ def default_runner(command: list[str], env: dict[str, str]) -> subprocess.Comple
         command,
         env=merged_env,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
 

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -1,0 +1,149 @@
+"""OpenHands runner route v0 for Skeleton.
+
+This module bridges the OpenHands adapter to an injectable process runner.
+It is designed so tests can validate behavior without launching real OpenHands.
+
+It does not merge, deploy, restart services, mutate GitHub labels, or read .env.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.adapter_contract import AdapterTaskPacket
+from tools.skeleton_core.openhands_adapter import (
+    OpenHandsAdapterConfig,
+    OpenHandsPreparedTask,
+    OpenHandsValidatedResult,
+    build_openhands_env,
+    build_openhands_result,
+    prepare_openhands_task,
+)
+
+OPENHANDS_RUNNER_ROUTE_VERSION = "openhands_runner_route.v0"
+
+DEFAULT_SECRET_FILE = Path("/home/agent/agent-dev/runner-secrets/openrouter.env")
+
+
+class OpenHandsRunnerRouteConfig(BaseModel):
+    """Configuration for the OpenHands runner route."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    task_file: Path = Path("/tmp/skeleton-openhands-task.md")
+    secret_file: Path = DEFAULT_SECRET_FILE
+    adapter_config: OpenHandsAdapterConfig = Field(default_factory=OpenHandsAdapterConfig)
+
+
+class OpenHandsRunnerRouteReport(BaseModel):
+    """Public-safe route report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    route_version: str = OPENHANDS_RUNNER_ROUTE_VERSION
+    prepared: OpenHandsPreparedTask
+    result: OpenHandsValidatedResult
+    returncode: int
+    stdout_tail: str = ""
+    stderr_tail: str = ""
+
+
+RunnerFn = Callable[[list[str], dict[str, str]], subprocess.CompletedProcess[str]]
+
+
+def _tail(value: str, limit: int = 4000) -> str:
+    return value[-limit:]
+
+
+def load_openrouter_key(secret_file: Path = DEFAULT_SECRET_FILE) -> str:
+    """Load OPENROUTER_API_KEY from a runner-local secret file.
+
+    The returned value is a secret and must not be printed or placed in public
+    reports.
+    """
+
+    if not secret_file.exists():
+        raise FileNotFoundError(f"OpenRouter secret file not found: {secret_file}")
+
+    values: dict[str, str] = {}
+    for raw_line in secret_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip("'").strip('"')
+
+    api_key = values.get("OPENROUTER_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError("OPENROUTER_API_KEY missing from secret file")
+    if any(token in api_key for token in ("cat >", "export ", "\n", "\r", "\t")):
+        raise ValueError("OPENROUTER_API_KEY secret file looks corrupted")
+
+    return api_key
+
+
+def default_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run OpenHands command with a merged environment."""
+
+    merged_env = os.environ.copy()
+    merged_env.update(env)
+    return subprocess.run(
+        command,
+        env=merged_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def run_openhands_route(
+    packet: AdapterTaskPacket,
+    *,
+    config: OpenHandsRunnerRouteConfig | None = None,
+    runner: RunnerFn = default_runner,
+    changed_files: list[str] | None = None,
+    artifact_paths: list[str] | None = None,
+) -> OpenHandsRunnerRouteReport:
+    """Prepare, run, and validate a bounded OpenHands task.
+
+    `changed_files` and `artifact_paths` are supplied by the caller or a later
+    collector layer. This v0 route intentionally avoids scanning arbitrary files.
+    """
+
+    resolved = config or OpenHandsRunnerRouteConfig()
+    prepared = prepare_openhands_task(packet, str(resolved.task_file), resolved.adapter_config)
+
+    resolved.task_file.write_text(prepared.task_text, encoding="utf-8")
+
+    api_key = load_openrouter_key(resolved.secret_file)
+    env = build_openhands_env(api_key, resolved.adapter_config)
+    completed = runner(prepared.command, env)
+
+    executor_status = "success" if completed.returncode == 0 else "failed"
+    validation_status = "passed" if completed.returncode == 0 else "failed"
+
+    validated = build_openhands_result(
+        packet,
+        executor_status=executor_status,
+        changed_files=changed_files or [],
+        artifact_paths=artifact_paths or [],
+        validation_status=validation_status,
+        risk_flags=[],
+        stop_reason=f"openhands_returncode={completed.returncode}",
+    )
+
+    return OpenHandsRunnerRouteReport(
+        prepared=prepared,
+        result=validated,
+        returncode=completed.returncode,
+        stdout_tail=_tail(completed.stdout or ""),
+        stderr_tail=_tail(completed.stderr or ""),
+    )


### PR DESCRIPTION
## Summary

Adds OpenHands Runner Route v0 on top of the OpenHands Adapter v0 from #194.

This creates the next Skeleton execution layer:

```text
AdapterTaskPacket
-> prepare OpenHands task
-> write task file
-> load runner-local OpenRouter key
-> run injected OpenHands command
-> build AdapterExecutionResult
-> validate_adapter_result()
-> public-safe route report
```

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
```

## Changed files

```text
tools/skeleton_core/openhands_runner_route.py
tests/skeleton_core/test_openhands_runner_route.py
```

## What this adds

```text
OPENHANDS_RUNNER_ROUTE_VERSION = openhands_runner_route.v0
OpenHandsRunnerRouteConfig
OpenHandsRunnerRouteReport
load_openrouter_key()
default_runner()
run_openhands_route()
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_runner_route.py: 5 passed
```

## Safety

```text
tests use injected fake runner
does not launch real OpenHands in tests
does not print API keys
does not read .env
loads only explicit runner-local secret file when route is called
does not push/merge/deploy
does not touch production/server/DB
does not mutate GitHub labels
```

## Boundary

This PR creates the route module only. GitHub issue dispatch / daemon integration is a separate follow-up.