### PR TITLE
Add OpenHands issue dispatch v0

### DIFF
--- a/tests/skeleton_core/test_openhands_issue_dispatch.py
+++ b/tests/skeleton_core/test_openhands_issue_dispatch.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from tools.skeleton_core.adapter_contract import AdapterTaskPacket
+from tools.skeleton_core.openhands_issue_dispatch import (
+    OPENHANDS_ISSUE_DISPATCH_VERSION,
+    build_packet_from_issue,
+    dispatch_openhands_issue,
+    validate_issue_payload,
+)
+from tools.skeleton_core.openhands_runner_route import (
+    OpenHandsRunnerRouteConfig,
+    run_openhands_route,
+)
+
+
+def valid_payload(tmp_path: Path) -> dict:
+    return {
+        "issue_number": 196,
+        "repo": "alanua/jeeves",
+        "title": "Add OpenHands issue dispatch v0",
+        "body": "bounded test payload",
+        "labels": [
+            "agent:task",
+            "agent:audited",
+            "agent:plan-ready",
+            "runner:openhands",
+            "risk:yellow",
+        ],
+        "allowed_files": ["tools/skeleton_core/openhands_issue_dispatch.py"],
+        "expected_artifact": "diff",
+        "authority_level": "level_2_local_diff",
+        "risk_level": "yellow",
+        "fuel_provider": "openrouter",
+        "fuel_model": "deepseek/deepseek-v4-flash:free",
+        "fuel_max_usd": 1.0,
+    }
+
+
+def test_valid_issue_payload_passes(tmp_path: Path) -> None:
+    assert validate_issue_payload(valid_payload(tmp_path)) == []
+
+
+def test_missing_required_label_blocks(tmp_path: Path) -> None:
+    payload = valid_payload(tmp_path)
+    payload["labels"].remove("agent:audited")
+
+    blocked = validate_issue_payload(payload)
+
+    assert "missing_label:agent:audited" in blocked
+
+
+def test_forbidden_running_label_blocks(tmp_path: Path) -> None:
+    payload = valid_payload(tmp_path)
+    payload["labels"].append("agent:running")
+
+    blocked = validate_issue_payload(payload)
+
+    assert "forbidden_label:agent:running" in blocked
+
+
+def test_build_packet_from_issue_maps_scope_and_fuel(tmp_path: Path) -> None:
+    packet = build_packet_from_issue(valid_payload(tmp_path))
+
+    assert packet.task_id == "issue-196-openhands"
+    assert packet.repo == "alanua/jeeves"
+    assert packet.allowed_files == ["tools/skeleton_core/openhands_issue_dispatch.py"]
+    assert ".env" in packet.forbidden_paths
+    assert packet.fuel_policy.provider == "openrouter"
+    assert packet.fuel_policy.max_usd == 1.0
+
+
+def test_dispatch_blocks_invalid_issue_before_route(tmp_path: Path) -> None:
+    payload = valid_payload(tmp_path)
+    payload["allowed_files"] = []
+    route_called = False
+
+    def route(packet: AdapterTaskPacket):
+        nonlocal route_called
+        route_called = True
+        raise AssertionError("route must not be called")
+
+    report = dispatch_openhands_issue(payload, route=route)
+
+    assert report.status == "blocked"
+    assert "missing_allowed_files" in report.blocked_reasons
+    assert route_called is False
+    assert report.route_report is None
+
+
+def test_dispatch_calls_injected_route_for_valid_issue(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    def route(packet: AdapterTaskPacket):
+        return run_openhands_route(
+            packet,
+            config=OpenHandsRunnerRouteConfig(task_file=task_file, secret_file=secret_file),
+            runner=fake_runner,
+            changed_files=["tools/skeleton_core/openhands_issue_dispatch.py"],
+            artifact_paths=["artifacts/openhands-issue-dispatch-v0.diff"],
+        )
+
+    report = dispatch_openhands_issue(valid_payload(tmp_path), route=route)
+
+    assert report.dispatch_version == OPENHANDS_ISSUE_DISPATCH_VERSION
+    assert report.status == "dispatched"
+    assert report.packet is not None
+    assert report.route_report is not None
+    assert report.route_report.result.result_validation.status == "valid_adapter_result"
+    assert "sk-or-test-value" not in report.model_dump_json()

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from tools.skeleton_core.adapter_contract import (
     AdapterExecutionResult,

--- a/tools/skeleton_core/openhands_issue_dispatch.py
+++ b/tools/skeleton_core/openhands_issue_dispatch.py
@@ -1,0 +1,179 @@
+"""OpenHands issue dispatch v0 for Skeleton.
+
+This module converts an issue-like payload into a bounded AdapterTaskPacket and
+calls an injected OpenHands runner route.
+
+It does not call GitHub, mutate labels, merge, deploy, restart services, or
+launch OpenHands directly in tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.adapter_contract import AdapterTaskPacket, FuelPolicy
+from tools.skeleton_core.openhands_runner_route import OpenHandsRunnerRouteReport
+
+OPENHANDS_ISSUE_DISPATCH_VERSION = "openhands_issue_dispatch.v0"
+
+REQUIRED_LABELS = {
+    "agent:task",
+    "agent:audited",
+    "agent:plan-ready",
+    "runner:openhands",
+    "risk:yellow",
+}
+
+FORBIDDEN_LABELS = {
+    "agent:running",
+    "agent:blocked",
+    "agent:executed",
+    "risk:red",
+}
+
+DEFAULT_FORBIDDEN_PATHS = [
+    ".env",
+    ".git",
+    ".ssh",
+    "secrets",
+    "tokens",
+    "server",
+    "production",
+    "db",
+]
+
+
+class OpenHandsIssuePayload(BaseModel):
+    """Public-safe issue-like dispatch payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    issue_number: int
+    repo: str
+    title: str
+    body: str = ""
+    labels: list[str]
+    allowed_files: list[str]
+    expected_artifact: str = "diff"
+    authority_level: str = "level_2_local_diff"
+    risk_level: str = "yellow"
+    fuel_provider: str = "openrouter"
+    fuel_model: str = "deepseek/deepseek-v4-flash:free"
+    fuel_max_usd: float = 1.0
+
+
+class OpenHandsIssueDispatchReport(BaseModel):
+    """Public-safe issue dispatch report."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    dispatch_version: str = OPENHANDS_ISSUE_DISPATCH_VERSION
+    status: str
+    blocked_reasons: list[str] = Field(default_factory=list)
+    packet: AdapterTaskPacket | None = None
+    route_report: OpenHandsRunnerRouteReport | None = None
+    next_safe_step: str = ""
+
+
+RouteFn = Callable[[AdapterTaskPacket], OpenHandsRunnerRouteReport]
+
+
+def validate_issue_payload(payload: OpenHandsIssuePayload | dict[str, Any]) -> list[str]:
+    """Validate labels and minimal dispatch scope."""
+
+    issue = (
+        payload
+        if isinstance(payload, OpenHandsIssuePayload)
+        else OpenHandsIssuePayload.model_validate(payload)
+    )
+
+    blocked: list[str] = []
+    labels = set(issue.labels)
+
+    missing = sorted(REQUIRED_LABELS - labels)
+    blocked.extend(f"missing_label:{label}" for label in missing)
+
+    forbidden = sorted(FORBIDDEN_LABELS & labels)
+    blocked.extend(f"forbidden_label:{label}" for label in forbidden)
+
+    if issue.issue_number <= 0:
+        blocked.append("invalid_issue_number")
+    if not issue.repo.strip():
+        blocked.append("missing_repo")
+    if not issue.title.strip():
+        blocked.append("missing_title")
+    if not issue.allowed_files:
+        blocked.append("missing_allowed_files")
+    if issue.risk_level != "yellow":
+        blocked.append("risk_level_must_be_yellow_for_v0")
+    if issue.authority_level == "level_5_forbidden":
+        blocked.append("authority_level_forbidden")
+    if issue.fuel_provider != "openrouter":
+        blocked.append("fuel_provider_must_be_openrouter_for_v0")
+    if not issue.fuel_model.strip():
+        blocked.append("missing_fuel_model")
+    if issue.fuel_max_usd < 0:
+        blocked.append("negative_fuel_max_usd")
+
+    return sorted(set(blocked))
+
+
+def build_packet_from_issue(
+    payload: OpenHandsIssuePayload | dict[str, Any],
+) -> AdapterTaskPacket:
+    """Build a bounded AdapterTaskPacket from an issue-like payload."""
+
+    issue = (
+        payload
+        if isinstance(payload, OpenHandsIssuePayload)
+        else OpenHandsIssuePayload.model_validate(payload)
+    )
+
+    return AdapterTaskPacket(
+        task_id=f"issue-{issue.issue_number}-openhands",
+        repo=issue.repo,
+        allowed_files=issue.allowed_files,
+        forbidden_paths=DEFAULT_FORBIDDEN_PATHS,
+        authority_level=issue.authority_level,
+        risk_level=issue.risk_level,
+        expected_artifact=issue.expected_artifact,
+        fuel_policy=FuelPolicy(
+            provider=issue.fuel_provider,
+            model=issue.fuel_model,
+            max_usd=issue.fuel_max_usd,
+        ),
+    )
+
+
+def dispatch_openhands_issue(
+    payload: OpenHandsIssuePayload | dict[str, Any],
+    *,
+    route: RouteFn,
+) -> OpenHandsIssueDispatchReport:
+    """Validate an issue-like payload and call an injected route if safe."""
+
+    issue = (
+        payload
+        if isinstance(payload, OpenHandsIssuePayload)
+        else OpenHandsIssuePayload.model_validate(payload)
+    )
+
+    blocked = validate_issue_payload(issue)
+    if blocked:
+        return OpenHandsIssueDispatchReport(
+            status="blocked",
+            blocked_reasons=blocked,
+            next_safe_step="Stop and fix issue labels/scope before dispatch.",
+        )
+
+    packet = build_packet_from_issue(issue)
+    route_report = route(packet)
+
+    return OpenHandsIssueDispatchReport(
+        status="dispatched",
+        packet=packet,
+        route_report=route_report,
+        next_safe_step="Review route report before any PR, merge, deploy, or label mutation.",
+    )

--- a/tools/skeleton_core/openhands_issue_dispatch.py
+++ b/tools/skeleton_core/openhands_issue_dispatch.py
@@ -9,7 +9,8 @@ launch OpenHands directly in tests.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -98,8 +98,7 @@ def default_runner(command: list[str], env: dict[str, str]) -> subprocess.Comple
         command,
         env=merged_env,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
 


### PR DESCRIPTION
## Summary

Adds OpenHands Issue Dispatch v0 on top of the OpenHands Runner Route v0 from #195.

This creates the next Skeleton control layer:

```text
GitHub issue-like payload
-> label/scope validation
-> AdapterTaskPacket
-> injected OpenHands runner route
-> public-safe dispatch report
```

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
```

## Changed files

```text
tools/skeleton_core/openhands_issue_dispatch.py
tests/skeleton_core/test_openhands_issue_dispatch.py
```

## What this adds

```text
OPENHANDS_ISSUE_DISPATCH_VERSION = openhands_issue_dispatch.v0
OpenHandsIssuePayload
OpenHandsIssueDispatchReport
validate_issue_payload()
build_packet_from_issue()
dispatch_openhands_issue()
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_issue_dispatch.py: 6 passed
```

## Safety

```text
tests use injected route/fake runner
does not call GitHub API
does not mutate labels
does not launch real OpenHands in tests
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR creates issue-payload dispatch logic only. Daemon polling / real GitHub issue integration is a separate follow-up.