### PR TITLE
Add OpenHands dispatch CLI v0

### DIFF
--- a/tests/skeleton_core/test_openhands_dispatch_cli.py
+++ b/tests/skeleton_core/test_openhands_dispatch_cli.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.skeleton_core.openhands_dispatch_cli import (
+    OPENHANDS_DISPATCH_CLI_VERSION,
+    main,
+)
+
+
+def valid_payload() -> dict:
+    return {
+        "issue_number": 197,
+        "repo": "alanua/jeeves",
+        "title": "Add OpenHands dispatch CLI v0",
+        "body": "bounded test payload",
+        "labels": [
+            "agent:task",
+            "agent:audited",
+            "agent:plan-ready",
+            "runner:openhands",
+            "risk:yellow",
+        ],
+        "allowed_files": ["tools/skeleton_core/openhands_dispatch_cli.py"],
+        "expected_artifact": "diff",
+        "authority_level": "level_2_local_diff",
+        "risk_level": "yellow",
+        "fuel_provider": "openrouter",
+        "fuel_model": "deepseek/deepseek-v4-flash:free",
+        "fuel_max_usd": 1.0,
+    }
+
+
+def write_payload(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "payload.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_cli_dry_run_valid_payload_outputs_dispatched_report(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    path = write_payload(tmp_path, valid_payload())
+
+    code = main(["--input", str(path)])
+
+    assert code == 0
+    captured = json.loads(capsys.readouterr().out)
+    assert captured["cli_version"] == OPENHANDS_DISPATCH_CLI_VERSION
+    assert captured["status"] == "dispatched"
+    assert captured["packet"]["task_id"] == "issue-197-openhands"
+    assert captured["route_report"] is None
+
+
+def test_cli_dry_run_blocked_payload_returns_one(tmp_path: Path, capsys) -> None:
+    payload = valid_payload()
+    payload["labels"].remove("agent:audited")
+    path = write_payload(tmp_path, payload)
+
+    code = main(["--input", str(path)])
+
+    assert code == 1
+    captured = json.loads(capsys.readouterr().out)
+    assert captured["status"] == "blocked"
+    assert "missing_label:agent:audited" in captured["blocked_reasons"]
+
+
+def test_cli_invalid_json_returns_error(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{bad", encoding="utf-8")
+
+    code = main(["--input", str(path)])
+
+    assert code == 2
+    captured = json.loads(capsys.readouterr().out)
+    assert captured["status"] == "error"
+    assert captured["error_type"] == "JSONDecodeError"
+
+
+def test_cli_pretty_outputs_json(tmp_path: Path, capsys) -> None:
+    path = write_payload(tmp_path, valid_payload())
+
+    code = main(["--input", str(path), "--pretty"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "\n  " in output
+    assert json.loads(output)["status"] == "dispatched"

--- a/tools/skeleton_core/openhands_dispatch_cli.py
+++ b/tools/skeleton_core/openhands_dispatch_cli.py
@@ -1,0 +1,104 @@
+"""CLI wrapper for OpenHands issue dispatch v0.
+
+This module reads a public-safe issue payload JSON file and emits a public-safe
+dispatch report JSON. It does not call GitHub, mutate labels, merge, deploy, or
+restart services.
+
+The default mode is dry-run so the CLI can validate payloads without launching
+OpenHands. Real route execution requires --run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from tools.skeleton_core.openhands_issue_dispatch import (
+    OpenHandsIssueDispatchReport,
+    build_packet_from_issue,
+    dispatch_openhands_issue,
+    validate_issue_payload,
+)
+from tools.skeleton_core.openhands_runner_route import run_openhands_route
+
+OPENHANDS_DISPATCH_CLI_VERSION = "openhands_dispatch_cli.v0"
+
+
+def _load_payload(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_dry_run_report(payload: dict) -> OpenHandsIssueDispatchReport:
+    """Validate payload and build packet without running the route."""
+
+    blocked = validate_issue_payload(payload)
+    if blocked:
+        return OpenHandsIssueDispatchReport(
+            status="blocked",
+            blocked_reasons=blocked,
+            next_safe_step="Stop and fix issue labels/scope before dispatch.",
+        )
+
+    packet = build_packet_from_issue(payload)
+    return OpenHandsIssueDispatchReport(
+        status="dispatched",
+        packet=packet,
+        route_report=None,
+        next_safe_step="Dry-run only. Review packet before running OpenHands route.",
+    )
+
+
+def build_run_report(payload: dict) -> OpenHandsIssueDispatchReport:
+    """Run the real OpenHands route.
+
+    This expects runner-local secret configuration to already exist. It still
+    does not call GitHub or mutate labels.
+    """
+
+    return dispatch_openhands_issue(payload, route=lambda packet: run_openhands_route(packet))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run OpenHands issue dispatch v0")
+    parser.add_argument("--input", required=True, help="Path to issue payload JSON")
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run OpenHands route instead of dry-run validation",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        payload = _load_payload(Path(args.input))
+        report = build_run_report(payload) if args.run else build_dry_run_report(payload)
+    except Exception as exc:
+        error = {
+            "cli_version": OPENHANDS_DISPATCH_CLI_VERSION,
+            "status": "error",
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+        }
+        print(json.dumps(error, indent=2 if args.pretty else None, sort_keys=True))
+        return 2
+
+    output = report.model_dump(mode="json")
+    output["cli_version"] = OPENHANDS_DISPATCH_CLI_VERSION
+    print(json.dumps(output, indent=2 if args.pretty else None, sort_keys=True))
+    return 0 if report.status != "blocked" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/skeleton_core/openhands_dispatch_cli.py
+++ b/tools/skeleton_core/openhands_dispatch_cli.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 from tools.skeleton_core.openhands_issue_dispatch import (
     OpenHandsIssueDispatchReport,


### PR DESCRIPTION
## Summary

Adds OpenHands Dispatch CLI v0 on top of OpenHands Issue Dispatch v0 from #196.

This creates a runner-callable CLI layer:

```text
issue payload JSON
-> CLI
-> dry-run payload validation
-> AdapterTaskPacket
-> optional --run OpenHands route
-> public-safe JSON report
```

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
```

## Changed files

```text
tools/skeleton_core/openhands_dispatch_cli.py
tests/skeleton_core/test_openhands_dispatch_cli.py
```

## What this adds

```text
OPENHANDS_DISPATCH_CLI_VERSION = openhands_dispatch_cli.v0
build_dry_run_report()
build_run_report()
build_parser()
main()
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_dispatch_cli.py: 4 passed
```

## Safety

```text
default mode is dry-run
does not call GitHub API
does not mutate labels
does not launch OpenHands unless --run is passed
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR adds a CLI wrapper only. Daemon polling / real GitHub issue integration is a separate follow-up.