### PR TITLE
Add adapter task instructions

### DIFF
--- a/tests/skeleton_core/test_adapter_contract.py
+++ b/tests/skeleton_core/test_adapter_contract.py
@@ -19,6 +19,7 @@ def valid_packet() -> AdapterTaskPacket:
         authority_level="level_2_local_diff",
         risk_level="yellow",
         expected_artifact="diff",
+        task_instructions="Create a bounded adapter contract patch.",
         fuel_policy=FuelPolicy(provider="none"),
     )
 
@@ -49,6 +50,15 @@ def test_missing_allowed_files_blocks() -> None:
 
     assert result.status == "blocked"
     assert "missing_allowed_files" in result.blocked_reasons
+
+
+def test_missing_task_instructions_blocks() -> None:
+    packet = valid_packet().model_copy(update={"task_instructions": ""})
+
+    result = validate_task_packet(packet)
+
+    assert result.status == "blocked"
+    assert "missing_task_instructions" in result.blocked_reasons
 
 
 def test_env_allowed_file_blocks() -> None:

--- a/tests/skeleton_core/test_openhands_adapter.py
+++ b/tests/skeleton_core/test_openhands_adapter.py
@@ -21,6 +21,7 @@ def valid_packet() -> AdapterTaskPacket:
         authority_level="level_2_local_diff",
         risk_level="yellow",
         expected_artifact="diff",
+        task_instructions="Create OpenHands adapter v0.",
         fuel_policy=FuelPolicy(
             provider="openrouter",
             model="deepseek/deepseek-v4-flash:free",
@@ -50,6 +51,7 @@ def test_task_text_contains_scope_and_boundaries() -> None:
     text = build_openhands_task_text(valid_packet())
 
     assert "tools/skeleton_core/openhands_adapter.py" in text
+    assert "Create OpenHands adapter v0." in text
     assert ".env" in text
     assert "Do not read .env, .git, .ssh" in text
     assert "Do not install packages" in text

--- a/tests/skeleton_core/test_openhands_dispatch_cli_hook.py
+++ b/tests/skeleton_core/test_openhands_dispatch_cli_hook.py
@@ -46,8 +46,7 @@ def run_cli(payload_path: Path) -> subprocess.CompletedProcess[str]:
             str(payload_path),
         ],
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
 

--- a/tests/skeleton_core/test_openhands_dispatch_cli_hook.py
+++ b/tests/skeleton_core/test_openhands_dispatch_cli_hook.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def valid_payload() -> dict:
+    return {
+        "issue_number": 198,
+        "repo": "alanua/jeeves",
+        "title": "Add OpenHands dispatch CLI hook v0",
+        "body": "bounded CLI hook test payload",
+        "labels": [
+            "agent:task",
+            "agent:audited",
+            "agent:plan-ready",
+            "runner:openhands",
+            "risk:yellow",
+        ],
+        "allowed_files": ["tools/skeleton_core/cli.py"],
+        "expected_artifact": "diff",
+        "authority_level": "level_2_local_diff",
+        "risk_level": "yellow",
+        "fuel_provider": "openrouter",
+        "fuel_model": "deepseek/deepseek-v4-flash:free",
+        "fuel_max_usd": 1.0,
+    }
+
+
+def write_payload(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "payload.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def run_cli(payload_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tools.skeleton_core.cli",
+            "openhands-dispatch",
+            "--input",
+            str(payload_path),
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_main_cli_openhands_dispatch_valid_payload(tmp_path: Path) -> None:
+    payload_path = write_payload(tmp_path, valid_payload())
+
+    completed = run_cli(payload_path)
+
+    assert completed.returncode == 0
+    output = json.loads(completed.stdout)
+    assert output["cli_version"] == "openhands_dispatch_cli.v0"
+    assert output["status"] == "dispatched"
+    assert output["packet"]["task_id"] == "issue-198-openhands"
+
+
+def test_main_cli_openhands_dispatch_blocked_payload(tmp_path: Path) -> None:
+    payload = valid_payload()
+    payload["labels"].remove("agent:audited")
+    payload_path = write_payload(tmp_path, payload)
+
+    completed = run_cli(payload_path)
+
+    assert completed.returncode == 1
+    output = json.loads(completed.stdout)
+    assert output["status"] == "blocked"
+    assert "missing_label:agent:audited" in output["blocked_reasons"]

--- a/tests/skeleton_core/test_openhands_runner_route.py
+++ b/tests/skeleton_core/test_openhands_runner_route.py
@@ -22,6 +22,7 @@ def valid_packet() -> AdapterTaskPacket:
         authority_level="level_2_local_diff",
         risk_level="yellow",
         expected_artifact="diff",
+        task_instructions="Update the OpenHands runner route in a bounded way.",
         fuel_policy=FuelPolicy(
             provider="openrouter",
             model="deepseek/deepseek-v4-flash:free",

--- a/tools/skeleton_core/adapter_contract.py
+++ b/tools/skeleton_core/adapter_contract.py
@@ -84,6 +84,7 @@ class AdapterTaskPacket(BaseModel):
     authority_level: AuthorityLevel
     risk_level: RiskLevel
     expected_artifact: str
+    task_instructions: str = ""
     fuel_policy: FuelPolicy = Field(default_factory=FuelPolicy)
 
 
@@ -213,6 +214,8 @@ def validate_task_packet(
         blocked.append("missing_allowed_files")
     if not task.expected_artifact.strip():
         blocked.append("missing_expected_artifact")
+    if not task.task_instructions.strip():
+        blocked.append("missing_task_instructions")
     if task.authority_level == "level_5_forbidden":
         blocked.append("authority_level_forbidden")
 

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -24,6 +24,11 @@ if len(sys.argv) > 1 and sys.argv[1] == "canon-audit":
 
     raise SystemExit(_canon_audit_main(sys.argv[2:]))
 
+if len(sys.argv) > 1 and sys.argv[1] == "openhands-dispatch":
+    from tools.skeleton_core.openhands_dispatch_cli import main as _openhands_dispatch_main
+
+    raise SystemExit(_openhands_dispatch_main(sys.argv[2:]))
+
 import argparse
 import json
 import sys

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -88,6 +88,9 @@ Risk level:
 Expected artifact:
 {task.expected_artifact}
 
+Task instructions:
+{task.task_instructions}
+
 Allowed files:
 {_format_list(task.allowed_files)}
 

--- a/tools/skeleton_core/openhands_issue_dispatch.py
+++ b/tools/skeleton_core/openhands_issue_dispatch.py
@@ -139,6 +139,7 @@ def build_packet_from_issue(
         authority_level=issue.authority_level,
         risk_level=issue.risk_level,
         expected_artifact=issue.expected_artifact,
+        task_instructions=f"{issue.title}\n\n{issue.body}".strip(),
         fuel_policy=FuelPolicy(
             provider=issue.fuel_provider,
             model=issue.fuel_model,


### PR DESCRIPTION
## Summary

Adds explicit task instructions to AdapterTaskPacket and carries them into the OpenHands task text.

This fixes the gap found during dry-run stack validation: the route had scope, fuel, and safety boundaries, but no concrete task text for OpenHands.

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
```

## Changed files

```text
tools/skeleton_core/adapter_contract.py
tools/skeleton_core/openhands_adapter.py
tools/skeleton_core/openhands_issue_dispatch.py
tests/skeleton_core/test_adapter_contract.py
tests/skeleton_core/test_openhands_adapter.py
```

## What changed

```text
AdapterTaskPacket.task_instructions added
validate_task_packet blocks missing task_instructions
OpenHands task text now includes Task instructions
issue dispatch maps issue title/body into task_instructions
tests updated
```

## Validation

```text
black: passed
ruff: passed
pytest selected OpenHands/adapter stack tests: 34 passed
```

## Safety

```text
no real OpenHands run
no GitHub API calls from module
no label mutation
no secret reads
no API key printing
no deploy
no merge
no production/server/DB access
```

## Boundary

This PR only adds task instructions to the adapter packet and OpenHands task rendering. Real --run validation is a separate follow-up.