### PR TITLE
Add OpenHands result collector v0

### DIFF
--- a/tests/skeleton_core/test_openhands_result_collector.py
+++ b/tests/skeleton_core/test_openhands_result_collector.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from tools.skeleton_core.adapter_contract import AdapterTaskPacket, FuelPolicy
+from tools.skeleton_core.openhands_result_collector import (
+    OPENHANDS_RESULT_COLLECTOR_VERSION,
+    OpenHandsResultCollectorConfig,
+    collect_openhands_result,
+)
+
+
+def valid_packet() -> AdapterTaskPacket:
+    return AdapterTaskPacket(
+        task_id="openhands-result-collector-v0",
+        repo="alanua/jeeves",
+        allowed_files=["tools/skeleton_core/openhands_result_collector.py"],
+        forbidden_paths=[".env", ".git", ".ssh", "secrets", "tokens"],
+        authority_level="level_2_local_diff",
+        risk_level="yellow",
+        expected_artifact="diff",
+        task_instructions="Collect bounded OpenHands result.",
+        fuel_policy=FuelPolicy(
+            provider="openrouter",
+            model="deepseek/deepseek-v4-flash:free",
+            max_usd=1.0,
+        ),
+    )
+
+
+def fake_git_runner_with_change(command: list[str]) -> subprocess.CompletedProcess[str]:
+    if "status" in command and "--short" in command:
+        return subprocess.CompletedProcess(
+            command, 0, stdout=" M tools/skeleton_core/openhands_result_collector.py\n", stderr=""
+        )
+    if "diff" in command:
+        return subprocess.CompletedProcess(
+            command, 0, stdout="diff --git a/file b/file\n+change\n", stderr=""
+        )
+    return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected command")
+
+
+def fake_git_runner_no_change(command: list[str]) -> subprocess.CompletedProcess[str]:
+    if "status" in command and "--short" in command:
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+    return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected command")
+
+
+def test_collects_allowed_change_and_writes_artifact(tmp_path: Path) -> None:
+    artifact_file = tmp_path / "openhands-result.diff"
+
+    report = collect_openhands_result(
+        valid_packet(),
+        config=OpenHandsResultCollectorConfig(diff_artifact_file=artifact_file),
+        git_runner=fake_git_runner_with_change,
+    )
+
+    assert report.collector_version == OPENHANDS_RESULT_COLLECTOR_VERSION
+    assert report.changed_files == ["tools/skeleton_core/openhands_result_collector.py"]
+    assert report.artifact_paths == ["artifacts/openhands-result.diff"]
+    assert report.diff_artifact_written is True
+    assert artifact_file.exists()
+    assert "+change" in artifact_file.read_text(encoding="utf-8")
+    assert report.result.result.status == "success"
+    assert report.result.result_validation.status == "valid_adapter_result"
+
+
+def test_blocks_when_no_allowed_file_changes(tmp_path: Path) -> None:
+    report = collect_openhands_result(
+        valid_packet(),
+        config=OpenHandsResultCollectorConfig(diff_artifact_file=tmp_path / "result.diff"),
+        git_runner=fake_git_runner_no_change,
+    )
+
+    assert report.changed_files == []
+    assert report.artifact_paths == []
+    assert report.diff_artifact_written is False
+    assert report.result.result.status == "blocked"
+    assert report.result.result.stop_reason == "no_allowed_file_changes"
+    assert report.result.result_validation.status == "valid_adapter_result"
+
+
+def test_invalid_packet_blocks_without_git_calls(tmp_path: Path) -> None:
+    packet = valid_packet().model_copy(update={"allowed_files": []})
+    called = False
+
+    def git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        nonlocal called
+        called = True
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="must not run")
+
+    report = collect_openhands_result(
+        packet,
+        config=OpenHandsResultCollectorConfig(diff_artifact_file=tmp_path / "result.diff"),
+        git_runner=git_runner,
+    )
+
+    assert called is False
+    assert report.result.result.status == "blocked"
+    assert "missing_allowed_files" in report.result.result_validation.blocked_reasons
+
+
+def test_status_outside_allowed_is_ignored(tmp_path: Path) -> None:
+    def git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if "status" in command and "--short" in command:
+            return subprocess.CompletedProcess(
+                command, 0, stdout=" M tools/skeleton_core/other.py\n", stderr=""
+            )
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected command")
+
+    report = collect_openhands_result(
+        valid_packet(),
+        config=OpenHandsResultCollectorConfig(diff_artifact_file=tmp_path / "result.diff"),
+        git_runner=git_runner,
+    )
+
+    assert report.changed_files == []
+    assert report.result.result.status == "blocked"
+    assert report.result.result.stop_reason == "no_allowed_file_changes"

--- a/tools/skeleton_core/openhands_result_collector.py
+++ b/tools/skeleton_core/openhands_result_collector.py
@@ -8,8 +8,8 @@ restart services, or read secrets.
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -54,8 +54,7 @@ def default_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
 

--- a/tools/skeleton_core/openhands_result_collector.py
+++ b/tools/skeleton_core/openhands_result_collector.py
@@ -1,0 +1,224 @@
+"""Bounded OpenHands result collector v0.
+
+This module collects only explicitly allowed file changes and builds a public-safe
+adapter result. It does not scan the whole repository, call GitHub, merge, deploy,
+restart services, or read secrets.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.adapter_contract import AdapterTaskPacket, validate_task_packet
+from tools.skeleton_core.openhands_adapter import (
+    OpenHandsValidatedResult,
+    build_openhands_result,
+)
+
+OPENHANDS_RESULT_COLLECTOR_VERSION = "openhands_result_collector.v0"
+
+
+class OpenHandsResultCollectorConfig(BaseModel):
+    """Configuration for bounded result collection."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    repo_root: Path = Path(".")
+    diff_artifact_file: Path = Path("/tmp/skeleton-openhands-artifacts/openhands-result.diff")
+    public_artifact_path: str = "artifacts/openhands-result.diff"
+
+
+class OpenHandsResultCollectorReport(BaseModel):
+    """Public-safe collector report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    collector_version: str = OPENHANDS_RESULT_COLLECTOR_VERSION
+    changed_files: list[str] = Field(default_factory=list)
+    artifact_paths: list[str] = Field(default_factory=list)
+    git_status_short: dict[str, str] = Field(default_factory=dict)
+    diff_artifact_written: bool = False
+    result: OpenHandsValidatedResult
+
+
+GitRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def default_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a bounded git command."""
+
+    return subprocess.run(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def _status_path_from_line(line: str) -> str:
+    """Extract a path from `git status --short` output.
+
+    Git short status uses two status columns followed by a space and a path.
+    Examples:
+    - " M path/to/file.py"
+    - "?? path/to/file.py"
+    - "R  old.py -> new.py"
+    """
+    value = line[2:].strip() if len(line) >= 2 else ""
+    if " -> " in value:
+        value = value.split(" -> ", 1)[1].strip()
+    return value
+
+
+def _status_for_allowed_file(
+    *,
+    repo_root: Path,
+    allowed_file: str,
+    git_runner: GitRunner,
+) -> str:
+    command = [
+        "git",
+        "-C",
+        str(repo_root),
+        "status",
+        "--short",
+        "--",
+        allowed_file,
+    ]
+    completed = git_runner(command)
+    if completed.returncode != 0:
+        raise RuntimeError(f"git status failed for {allowed_file}: {completed.stderr}")
+    return completed.stdout.strip()
+
+
+def _changed_files_from_status(
+    *,
+    allowed_files: list[str],
+    status_by_file: dict[str, str],
+) -> list[str]:
+    allowed_set = set(allowed_files)
+    changed: list[str] = []
+
+    for status_output in status_by_file.values():
+        for line in status_output.splitlines():
+            path = _status_path_from_line(line)
+            if path in allowed_set:
+                changed.append(path)
+
+    return sorted(set(changed))
+
+
+def _diff_for_file(
+    *,
+    repo_root: Path,
+    changed_file: str,
+    git_runner: GitRunner,
+) -> str:
+    command = [
+        "git",
+        "-C",
+        str(repo_root),
+        "diff",
+        "--",
+        changed_file,
+    ]
+    completed = git_runner(command)
+    if completed.returncode != 0:
+        raise RuntimeError(f"git diff failed for {changed_file}: {completed.stderr}")
+    return completed.stdout
+
+
+def _write_diff_artifact(
+    *,
+    repo_root: Path,
+    changed_files: list[str],
+    artifact_file: Path,
+    git_runner: GitRunner,
+) -> bool:
+    artifact_file.parent.mkdir(parents=True, exist_ok=True)
+
+    chunks: list[str] = []
+    for changed_file in changed_files:
+        chunks.append(f"# diff for {changed_file}\n")
+        chunks.append(
+            _diff_for_file(repo_root=repo_root, changed_file=changed_file, git_runner=git_runner)
+        )
+        chunks.append("\n")
+
+    artifact_file.write_text("".join(chunks), encoding="utf-8")
+    return True
+
+
+def collect_openhands_result(
+    packet: AdapterTaskPacket,
+    *,
+    config: OpenHandsResultCollectorConfig | None = None,
+    git_runner: GitRunner = default_git_runner,
+) -> OpenHandsResultCollectorReport:
+    """Collect changed allowed files and build a validated adapter result."""
+
+    resolved = config or OpenHandsResultCollectorConfig()
+    task_validation = validate_task_packet(packet)
+
+    status_by_file: dict[str, str] = {}
+    changed_files: list[str] = []
+    artifact_paths: list[str] = []
+    artifact_written = False
+
+    if task_validation.status == "valid_task_packet":
+        for allowed_file in task_validation.normalized_allowed_files:
+            status_by_file[allowed_file] = _status_for_allowed_file(
+                repo_root=resolved.repo_root,
+                allowed_file=allowed_file,
+                git_runner=git_runner,
+            )
+
+        changed_files = _changed_files_from_status(
+            allowed_files=task_validation.normalized_allowed_files,
+            status_by_file=status_by_file,
+        )
+
+        if changed_files:
+            artifact_written = _write_diff_artifact(
+                repo_root=resolved.repo_root,
+                changed_files=changed_files,
+                artifact_file=resolved.diff_artifact_file,
+                git_runner=git_runner,
+            )
+            artifact_paths = [resolved.public_artifact_path]
+
+    if task_validation.status != "valid_task_packet":
+        executor_status = "blocked"
+        validation_status = "blocked"
+        stop_reason = "task_packet_blocked"
+    elif not changed_files:
+        executor_status = "blocked"
+        validation_status = "blocked"
+        stop_reason = "no_allowed_file_changes"
+    else:
+        executor_status = "success"
+        validation_status = "passed"
+        stop_reason = "allowed_file_changes_collected"
+
+    result = build_openhands_result(
+        packet,
+        executor_status=executor_status,
+        changed_files=changed_files,
+        artifact_paths=artifact_paths,
+        validation_status=validation_status,
+        risk_flags=[],
+        stop_reason=stop_reason,
+    )
+
+    return OpenHandsResultCollectorReport(
+        changed_files=changed_files,
+        artifact_paths=artifact_paths,
+        git_status_short=status_by_file,
+        diff_artifact_written=artifact_written,
+        result=result,
+    )


### PR DESCRIPTION
## Summary

Adds Bounded OpenHands Result Collector v0.

This adds the missing post-run layer:

```text
OpenHands run
-> collect only allowed file status
-> write bounded diff artifact
-> build AdapterExecutionResult
-> validate_adapter_result()
-> public-safe collector report
```

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
#199 — Add adapter task instructions
```

## Changed files

```text
tools/skeleton_core/openhands_result_collector.py
tests/skeleton_core/test_openhands_result_collector.py
```

## What this adds

```text
OPENHANDS_RESULT_COLLECTOR_VERSION = openhands_result_collector.v0
OpenHandsResultCollectorConfig
OpenHandsResultCollectorReport
collect_openhands_result()
bounded allowed-file status collection
bounded diff artifact writing
validated AdapterExecutionResult
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_result_collector.py: 4 passed
```

## Safety

```text
collects only explicitly allowed files
does not scan the whole repository
does not call GitHub API
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR adds bounded post-run result collection only. Real --run smoke validation and daemon integration are separate follow-ups.