### PR TITLE
Integrate OpenHands runner route with result collector

### DIFF
--- a/tests/skeleton_core/test_openhands_runner_route.py
+++ b/tests/skeleton_core/test_openhands_runner_route.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from tools.skeleton_core.adapter_contract import AdapterTaskPacket, FuelPolicy
+from tools.skeleton_core.openhands_result_collector import OpenHandsResultCollectorConfig
 from tools.skeleton_core.openhands_runner_route import (
     OpenHandsRunnerRouteConfig,
     load_openrouter_key,
@@ -22,6 +23,7 @@ def valid_packet() -> AdapterTaskPacket:
         authority_level="level_2_local_diff",
         risk_level="yellow",
         expected_artifact="diff",
+        task_instructions="Run bounded OpenHands runner route v0.",
         fuel_policy=FuelPolicy(
             provider="openrouter",
             model="deepseek/deepseek-v4-flash:free",
@@ -113,3 +115,45 @@ def test_route_failed_runner_returns_failed_result(tmp_path: Path) -> None:
     assert report.result.result.status == "failed"
     assert report.result.result_validation.status == "valid_adapter_result"
     assert report.stderr_tail == "failed"
+
+
+def test_route_uses_collector_when_no_explicit_changed_files(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    artifact_file = tmp_path / "result.diff"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout="done", stderr="")
+
+    def fake_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if "status" in command and "--short" in command:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=" M tools/skeleton_core/openhands_runner_route.py\n",
+                stderr="",
+            )
+        if "diff" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="+route change\n", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected command")
+
+    packet = valid_packet().model_copy(
+        update={"allowed_files": ["tools/skeleton_core/openhands_runner_route.py"]}
+    )
+
+    report = run_openhands_route(
+        packet,
+        config=OpenHandsRunnerRouteConfig(task_file=task_file, secret_file=secret_file),
+        runner=fake_runner,
+        collector_config=OpenHandsResultCollectorConfig(diff_artifact_file=artifact_file),
+        git_runner=fake_git_runner,
+    )
+
+    assert report.collector_report is not None
+    assert report.collector_report.changed_files == [
+        "tools/skeleton_core/openhands_runner_route.py"
+    ]
+    assert report.collector_report.diff_artifact_written is True
+    assert artifact_file.exists()
+    assert report.result.result_validation.status == "valid_adapter_result"

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -24,6 +24,12 @@ from tools.skeleton_core.openhands_adapter import (
     build_openhands_result,
     prepare_openhands_task,
 )
+from tools.skeleton_core.openhands_result_collector import (
+    GitRunner,
+    OpenHandsResultCollectorConfig,
+    OpenHandsResultCollectorReport,
+    collect_openhands_result,
+)
 
 OPENHANDS_RUNNER_ROUTE_VERSION = "openhands_runner_route.v0"
 
@@ -51,6 +57,7 @@ class OpenHandsRunnerRouteReport(BaseModel):
     returncode: int
     stdout_tail: str = ""
     stderr_tail: str = ""
+    collector_report: OpenHandsResultCollectorReport | None = None
 
 
 RunnerFn = Callable[[list[str], dict[str, str]], subprocess.CompletedProcess[str]]
@@ -111,11 +118,13 @@ def run_openhands_route(
     runner: RunnerFn = default_runner,
     changed_files: list[str] | None = None,
     artifact_paths: list[str] | None = None,
+    collector_config: OpenHandsResultCollectorConfig | None = None,
+    git_runner: GitRunner | None = None,
 ) -> OpenHandsRunnerRouteReport:
-    """Prepare, run, and validate a bounded OpenHands task.
+    """Prepare, run, collect, and validate a bounded OpenHands task.
 
-    `changed_files` and `artifact_paths` are supplied by the caller or a later
-    collector layer. This v0 route intentionally avoids scanning arbitrary files.
+    If `changed_files` or `artifact_paths` are supplied, they are used directly.
+    Otherwise, a bounded result collector inspects only packet.allowed_files.
     """
 
     resolved = config or OpenHandsRunnerRouteConfig()
@@ -127,18 +136,29 @@ def run_openhands_route(
     env = build_openhands_env(api_key, resolved.adapter_config)
     completed = runner(prepared.command, env)
 
-    executor_status = "success" if completed.returncode == 0 else "failed"
-    validation_status = "passed" if completed.returncode == 0 else "failed"
+    collector_report = None
+    if changed_files is None and artifact_paths is None:
+        collector_kwargs = {}
+        if collector_config is not None:
+            collector_kwargs["config"] = collector_config
+        if git_runner is not None:
+            collector_kwargs["git_runner"] = git_runner
 
-    validated = build_openhands_result(
-        packet,
-        executor_status=executor_status,
-        changed_files=changed_files or [],
-        artifact_paths=artifact_paths or [],
-        validation_status=validation_status,
-        risk_flags=[],
-        stop_reason=f"openhands_returncode={completed.returncode}",
-    )
+        collector_report = collect_openhands_result(packet, **collector_kwargs)
+        validated = collector_report.result
+    else:
+        executor_status = "success" if completed.returncode == 0 else "failed"
+        validation_status = "passed" if completed.returncode == 0 else "failed"
+
+        validated = build_openhands_result(
+            packet,
+            executor_status=executor_status,
+            changed_files=changed_files or [],
+            artifact_paths=artifact_paths or [],
+            validation_status=validation_status,
+            risk_flags=[],
+            stop_reason=f"openhands_returncode={completed.returncode}",
+        )
 
     return OpenHandsRunnerRouteReport(
         prepared=prepared,
@@ -146,4 +166,5 @@ def run_openhands_route(
         returncode=completed.returncode,
         stdout_tail=_tail(completed.stdout or ""),
         stderr_tail=_tail(completed.stderr or ""),
+        collector_report=collector_report,
     )


### PR DESCRIPTION
## Summary

Integrates OpenHands Runner Route v0 with Bounded OpenHands Result Collector v0.

This connects the post-run collection layer into the route:

```text
OpenHands route
-> run OpenHands command
-> collect allowed file changes
-> write bounded diff artifact
-> return validated public-safe route report
```

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
#199 — Add adapter task instructions
#200 — Add OpenHands result collector v0
```

## Changed files

```text
tools/skeleton_core/openhands_runner_route.py
tests/skeleton_core/test_openhands_runner_route.py
```

## What changed

```text
run_openhands_route() now calls collect_openhands_result() when explicit changed_files/artifact_paths are not supplied
OpenHandsRunnerRouteReport now includes collector_report
tests cover collector integration through fake runner/fake git runner
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_runner_route.py tests/skeleton_core/test_openhands_result_collector.py: 10 passed
```

## Safety

```text
tests use fake runner and fake git runner
collector only checks packet.allowed_files
does not scan the whole repository
does not call GitHub API
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR connects route and collector only. Real --run smoke validation and daemon integration remain separate follow-ups.