### PR TITLE
Detect OpenHands interactive confirmation

### DIFF
--- a/tests/skeleton_core/test_openhands_runner_route.py
+++ b/tests/skeleton_core/test_openhands_runner_route.py
@@ -157,3 +157,37 @@ def test_route_uses_collector_when_no_explicit_changed_files(tmp_path: Path) -> 
     assert report.collector_report.diff_artifact_written is True
     assert artifact_file.exists()
     assert report.result.result_validation.status == "valid_adapter_result"
+
+
+def test_route_blocks_interactive_confirmation_without_changes(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="OpenHands CLI terminal UI may not work correctly",
+            stderr="Confirm 1 action? Yes, proceed / No, dismiss",
+        )
+
+    def fake_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if "status" in command and "--short" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected command")
+
+    report = run_openhands_route(
+        valid_packet(),
+        config=OpenHandsRunnerRouteConfig(task_file=task_file, secret_file=secret_file),
+        runner=fake_runner,
+        git_runner=fake_git_runner,
+    )
+
+    assert report.collector_report is not None
+    assert report.collector_report.changed_files == []
+    assert report.result.result.status == "blocked"
+    assert report.result.result.stop_reason == "interactive_confirmation_required"
+    assert report.result.result.validation_status == "blocked"
+    assert "interactive_confirmation_required" in report.result.result.risk_flags
+    assert report.result.result_validation.status == "valid_adapter_result"

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -62,6 +62,22 @@ class OpenHandsRunnerRouteReport(BaseModel):
 
 RunnerFn = Callable[[list[str], dict[str, str]], subprocess.CompletedProcess[str]]
 
+INTERACTIVE_CONFIRMATION_MARKERS = (
+    "Yes, proceed",
+    "No, dismiss",
+    "Confirm",
+    "Confirm 1 action",
+    "Confirm 2 action",
+    "OpenHands CLI terminal UI may not work correctly",
+    "interactive UI may not render correctly",
+    "TTY_INTERACTIVE",
+)
+
+
+def _looks_like_interactive_confirmation(stdout: str, stderr: str) -> bool:
+    combined = f"{stdout}\n{stderr}"
+    return any(marker in combined for marker in INTERACTIVE_CONFIRMATION_MARKERS)
+
 
 def _tail(value: str, limit: int = 4000) -> str:
     return value[-limit:]
@@ -158,6 +174,23 @@ def run_openhands_route(
             validation_status=validation_status,
             risk_flags=[],
             stop_reason=f"openhands_returncode={completed.returncode}",
+        )
+
+    if (
+        collector_report is not None
+        and completed.returncode == 0
+        and validated.result.status == "blocked"
+        and validated.result.stop_reason == "no_allowed_file_changes"
+        and _looks_like_interactive_confirmation(completed.stdout or "", completed.stderr or "")
+    ):
+        validated = build_openhands_result(
+            packet,
+            executor_status="blocked",
+            changed_files=[],
+            artifact_paths=[],
+            validation_status="blocked",
+            risk_flags=["interactive_confirmation_required"],
+            stop_reason="interactive_confirmation_required",
         )
 
     return OpenHandsRunnerRouteReport(


### PR DESCRIPTION
## Summary

Adds OpenHands real-run guard v0.

This detects when a real OpenHands run exits without file changes because the CLI opened an interactive confirmation UI instead of executing the task.

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
#199 — Add adapter task instructions
#200 — Add OpenHands result collector v0
#201 — Integrate OpenHands runner route with result collector
```

## Changed files

```text
tools/skeleton_core/openhands_runner_route.py
tests/skeleton_core/test_openhands_runner_route.py
```

## What changed

```text
Detects OpenHands interactive confirmation markers in stdout/stderr
Converts no-change interactive runs into:
  stop_reason=interactive_confirmation_required
  risk_flags=[interactive_confirmation_required]
  status=blocked
Adds regression test with fake runner/fake git runner
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_runner_route.py tests/skeleton_core/test_openhands_result_collector.py: 11 passed
```

## Safety

```text
does not enable auto-approve
does not bypass OpenHands confirmation
does not call GitHub API
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR only detects interactive confirmation and reports it safely. Choosing a non-interactive OpenHands execution mode remains a separate follow-up.