### PR TITLE
Add OpenHands runner timeout guard

### DIFF
--- a/tests/skeleton_core/test_openhands_runner_route.py
+++ b/tests/skeleton_core/test_openhands_runner_route.py
@@ -54,7 +54,11 @@ def test_route_writes_task_and_runs_injected_runner(tmp_path: Path) -> None:
 
     calls: list[tuple[list[str], dict[str, str]]] = []
 
-    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    def fake_runner(
+        command: list[str],
+        env: dict[str, str],
+        timeout_seconds: int = 300,
+    ) -> subprocess.CompletedProcess[str]:
         calls.append((command, env))
         return subprocess.CompletedProcess(command, 0, stdout="done", stderr="")
 
@@ -80,7 +84,11 @@ def test_route_blocks_success_without_artifact(tmp_path: Path) -> None:
     task_file = tmp_path / "task.md"
     secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
 
-    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    def fake_runner(
+        command: list[str],
+        env: dict[str, str],
+        timeout_seconds: int = 300,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 0, stdout="done", stderr="")
 
     report = run_openhands_route(
@@ -100,7 +108,11 @@ def test_route_failed_runner_returns_failed_result(tmp_path: Path) -> None:
     task_file = tmp_path / "task.md"
     secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
 
-    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    def fake_runner(
+        command: list[str],
+        env: dict[str, str],
+        timeout_seconds: int = 300,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 2, stdout="", stderr="failed")
 
     report = run_openhands_route(
@@ -123,7 +135,11 @@ def test_route_uses_collector_when_no_explicit_changed_files(tmp_path: Path) -> 
     artifact_file = tmp_path / "result.diff"
     secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
 
-    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    def fake_runner(
+        command: list[str],
+        env: dict[str, str],
+        timeout_seconds: int = 300,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 0, stdout="done", stderr="")
 
     def fake_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -164,7 +180,11 @@ def test_route_blocks_interactive_confirmation_without_changes(tmp_path: Path) -
     task_file = tmp_path / "task.md"
     secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
 
-    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    def fake_runner(
+        command: list[str],
+        env: dict[str, str],
+        timeout_seconds: int = 300,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
             command,
             0,
@@ -190,4 +210,49 @@ def test_route_blocks_interactive_confirmation_without_changes(tmp_path: Path) -
     assert report.result.result.stop_reason == "interactive_confirmation_required"
     assert report.result.result.validation_status == "blocked"
     assert "interactive_confirmation_required" in report.result.result.risk_flags
+    assert report.result.result_validation.status == "valid_adapter_result"
+
+
+def test_route_blocks_timeout_before_collector(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    git_called = False
+
+    def fake_runner(
+        command: list[str],
+        env: dict[str, str],
+        timeout_seconds: int = 300,
+    ) -> subprocess.CompletedProcess[str]:
+        assert timeout_seconds == 7
+        return subprocess.CompletedProcess(
+            command,
+            124,
+            stdout="",
+            stderr="openhands_timeout_seconds=7",
+        )
+
+    def fake_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        nonlocal git_called
+        git_called = True
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="must not run")
+
+    report = run_openhands_route(
+        valid_packet(),
+        config=OpenHandsRunnerRouteConfig(
+            task_file=task_file,
+            secret_file=secret_file,
+            timeout_seconds=7,
+        ),
+        runner=fake_runner,
+        git_runner=fake_git_runner,
+    )
+
+    assert git_called is False
+    assert report.returncode == 124
+    assert report.collector_report is None
+    assert report.result.result.status == "blocked"
+    assert report.result.result.stop_reason == "openhands_timeout"
+    assert "timeout" in report.result.result.risk_flags
     assert report.result.result_validation.status == "valid_adapter_result"

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -43,6 +43,7 @@ class OpenHandsRunnerRouteConfig(BaseModel):
 
     task_file: Path = Path("/tmp/skeleton-openhands-task.md")
     secret_file: Path = DEFAULT_SECRET_FILE
+    timeout_seconds: int = 300
     adapter_config: OpenHandsAdapterConfig = Field(default_factory=OpenHandsAdapterConfig)
 
 
@@ -60,7 +61,7 @@ class OpenHandsRunnerRouteReport(BaseModel):
     collector_report: OpenHandsResultCollectorReport | None = None
 
 
-RunnerFn = Callable[[list[str], dict[str, str]], subprocess.CompletedProcess[str]]
+RunnerFn = Callable[..., subprocess.CompletedProcess[str]]
 
 INTERACTIVE_CONFIRMATION_MARKERS = (
     "Yes, proceed",
@@ -112,19 +113,42 @@ def load_openrouter_key(secret_file: Path = DEFAULT_SECRET_FILE) -> str:
     return api_key
 
 
-def default_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    """Run OpenHands command with a merged environment."""
+def _timeout_completed_process(
+    command: list[str],
+    timeout_seconds: int,
+    exc: subprocess.TimeoutExpired,
+) -> subprocess.CompletedProcess[str]:
+    stdout = exc.stdout or ""
+    stderr = exc.stderr or ""
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8", errors="replace")
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    stderr = f"{stderr}\nopenhands_timeout_seconds={timeout_seconds}".strip()
+    return subprocess.CompletedProcess(command, 124, stdout=stdout, stderr=stderr)
+
+
+def default_runner(
+    command: list[str],
+    env: dict[str, str],
+    timeout_seconds: int = 300,
+) -> subprocess.CompletedProcess[str]:
+    """Run OpenHands command with a merged environment and timeout."""
 
     merged_env = os.environ.copy()
     merged_env.update(env)
-    return subprocess.run(
-        command,
-        env=merged_env,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
+    try:
+        return subprocess.run(
+            command,
+            env=merged_env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return _timeout_completed_process(command, timeout_seconds, exc)
 
 
 def run_openhands_route(
@@ -150,7 +174,26 @@ def run_openhands_route(
 
     api_key = load_openrouter_key(resolved.secret_file)
     env = build_openhands_env(api_key, resolved.adapter_config)
-    completed = runner(prepared.command, env)
+    completed = runner(prepared.command, env, resolved.timeout_seconds)
+
+    if completed.returncode == 124:
+        validated = build_openhands_result(
+            packet,
+            executor_status="blocked",
+            changed_files=[],
+            artifact_paths=[],
+            validation_status="blocked",
+            risk_flags=["timeout"],
+            stop_reason="openhands_timeout",
+        )
+        return OpenHandsRunnerRouteReport(
+            prepared=prepared,
+            result=validated,
+            returncode=completed.returncode,
+            stdout_tail=_tail(completed.stdout or ""),
+            stderr_tail=_tail(completed.stderr or ""),
+            collector_report=None,
+        )
 
     collector_report = None
     if changed_files is None and artifact_paths is None:


### PR DESCRIPTION
## Summary

Adds OpenHands runner timeout guard v0.

This prevents real OpenHands route execution from hanging indefinitely.

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
#199 — Add adapter task instructions
#200 — Add OpenHands result collector v0
#201 — Integrate OpenHands runner route with result collector
#202 — Detect OpenHands interactive confirmation
```

## Changed files

```text
tools/skeleton_core/openhands_runner_route.py
tests/skeleton_core/test_openhands_runner_route.py
```

## What changed

```text
OpenHandsRunnerRouteConfig.timeout_seconds added
default_runner now applies subprocess timeout
TimeoutExpired is converted into returncode 124
run_openhands_route blocks timeout before collector
timeout result uses:
  status=blocked
  stop_reason=openhands_timeout
  risk_flags=[timeout]
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_runner_route.py tests/skeleton_core/test_openhands_result_collector.py: 12 passed
```

## Safety

```text
prevents indefinite OpenHands hangs
does not enable auto-approve
does not bypass OpenHands confirmation
does not call GitHub API
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR adds timeout handling only. Choosing a safe non-interactive OpenHands execution mode remains a separate follow-up.