### PR TITLE
Add explicit OpenHands headless JSON config

### DIFF
--- a/tests/skeleton_core/test_openhands_adapter.py
+++ b/tests/skeleton_core/test_openhands_adapter.py
@@ -138,3 +138,22 @@ def test_result_builder_blocks_success_without_artifact() -> None:
 
     assert result.result_validation.status == "blocked"
     assert "success_without_artifact" in result.result_validation.blocked_reasons
+
+
+def test_headless_json_command_is_explicit_opt_in() -> None:
+    safe_default = build_openhands_command("/tmp/task.md", OpenHandsAdapterConfig())
+    headless = build_openhands_command(
+        "/tmp/task.md",
+        OpenHandsAdapterConfig(executable="/bin/openhands", headless_json=True),
+    )
+
+    assert "--headless" not in safe_default
+    assert "--json" not in safe_default
+    assert headless == [
+        "/bin/openhands",
+        "--override-with-envs",
+        "--headless",
+        "--json",
+        "-f",
+        "/tmp/task.md",
+    ]

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -31,6 +31,7 @@ class OpenHandsAdapterConfig(BaseModel):
     model: str = "deepseek/deepseek-v4-flash:free"
     base_url: str = "https://openrouter.ai/api/v1"
     suppress_banner: bool = True
+    headless_json: bool = False
 
 
 class OpenHandsPreparedTask(BaseModel):
@@ -119,12 +120,14 @@ def build_openhands_command(
     """Build the OpenHands CLI command."""
 
     resolved = config or OpenHandsAdapterConfig()
-    return [
+    command = [
         resolved.executable,
         "--override-with-envs",
-        "-f",
-        task_file,
     ]
+    if resolved.headless_json:
+        command.extend(["--headless", "--json"])
+    command.extend(["-f", task_file])
+    return command
 
 
 def build_openhands_env(


### PR DESCRIPTION
## Summary

Adds explicit opt-in support for OpenHands headless JSON command construction.

OpenHands help confirms:

```text
--headless: no UI output, auto-approve actions
--json: JSON output mode for headless operation
```

Because headless implies auto-approve, this PR keeps the default safe mode unchanged and only enables headless JSON when explicitly configured.

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
#199 — Add adapter task instructions
#200 — Add OpenHands result collector v0
#201 — Integrate OpenHands runner route with result collector
#202 — Detect OpenHands interactive confirmation
#203 — Add OpenHands runner timeout guard
```

## Changed files

```text
tools/skeleton_core/openhands_adapter.py
tests/skeleton_core/test_openhands_adapter.py
```

## What changed

```text
OpenHandsAdapterConfig.headless_json added, default false
build_openhands_command() adds --headless --json only when headless_json=True
tests confirm safe default does not include --headless/--json
tests confirm explicit opt-in command shape
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_adapter.py tests/skeleton_core/test_openhands_runner_route.py: 18 passed
```

## Safety

```text
default remains interactive/ask mode
headless JSON is explicit opt-in
does not enable --always-approve or --yolo directly
does not call GitHub API
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR only adds explicit command configuration. A guarded real --run headless smoke test is a separate follow-up.