### PR TITLE
Add OpenHands repo dirty scope guard

### DIFF
--- a/tests/skeleton_core/test_openhands_result_collector.py
+++ b/tests/skeleton_core/test_openhands_result_collector.py
@@ -76,6 +76,7 @@ def test_blocks_when_no_allowed_file_changes(tmp_path: Path) -> None:
     assert report.changed_files == []
     assert report.artifact_paths == []
     assert report.diff_artifact_written is False
+    assert report.outside_allowed_changes == []
     assert report.result.result.status == "blocked"
     assert report.result.result.stop_reason == "no_allowed_file_changes"
     assert report.result.result_validation.status == "valid_adapter_result"
@@ -101,7 +102,7 @@ def test_invalid_packet_blocks_without_git_calls(tmp_path: Path) -> None:
     assert "missing_allowed_files" in report.result.result_validation.blocked_reasons
 
 
-def test_status_outside_allowed_is_ignored(tmp_path: Path) -> None:
+def test_status_outside_allowed_is_blocked(tmp_path: Path) -> None:
     def git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
         if "status" in command and "--short" in command:
             return subprocess.CompletedProcess(
@@ -117,4 +118,42 @@ def test_status_outside_allowed_is_ignored(tmp_path: Path) -> None:
 
     assert report.changed_files == []
     assert report.result.result.status == "blocked"
-    assert report.result.result.stop_reason == "no_allowed_file_changes"
+    assert report.result.result.stop_reason == "outside_allowed_changes"
+    assert report.outside_allowed_changes == ["tools/skeleton_core/other.py"]
+
+
+def test_blocks_outside_allowed_changes_even_when_allowed_file_changed(tmp_path: Path) -> None:
+    artifact_file = tmp_path / "openhands-result.diff"
+
+    def git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if "status" in command and "--short" in command and "--" not in command:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    " M tools/skeleton_core/openhands_result_collector.py\n"
+                    " M tools/skeleton_core/other.py\n"
+                ),
+                stderr="",
+            )
+        if "status" in command and "--short" in command:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=" M tools/skeleton_core/openhands_result_collector.py\n",
+                stderr="",
+            )
+        if "diff" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="+change\n", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected command")
+
+    report = collect_openhands_result(
+        valid_packet(),
+        config=OpenHandsResultCollectorConfig(diff_artifact_file=artifact_file),
+        git_runner=git_runner,
+    )
+
+    assert report.changed_files == ["tools/skeleton_core/openhands_result_collector.py"]
+    assert report.outside_allowed_changes == ["tools/skeleton_core/other.py"]
+    assert report.result.result.status == "blocked"
+    assert report.result.result.stop_reason == "outside_allowed_changes"

--- a/tools/skeleton_core/openhands_result_collector.py
+++ b/tools/skeleton_core/openhands_result_collector.py
@@ -40,7 +40,9 @@ class OpenHandsResultCollectorReport(BaseModel):
     collector_version: str = OPENHANDS_RESULT_COLLECTOR_VERSION
     changed_files: list[str] = Field(default_factory=list)
     artifact_paths: list[str] = Field(default_factory=list)
+    outside_allowed_changes: list[str] = Field(default_factory=list)
     git_status_short: dict[str, str] = Field(default_factory=dict)
+    full_git_status_short: str = ""
     diff_artifact_written: bool = False
     result: OpenHandsValidatedResult
 
@@ -113,6 +115,40 @@ def _changed_files_from_status(
     return sorted(set(changed))
 
 
+def _full_status(
+    *,
+    repo_root: Path,
+    git_runner: GitRunner,
+) -> str:
+    command = ["git", "-C", str(repo_root), "status", "--short"]
+    completed = git_runner(command)
+    if completed.returncode != 0:
+        raise RuntimeError(f"git status failed: {completed.stderr}")
+    return completed.stdout.strip()
+
+
+def _all_changed_paths_from_status(status_output: str) -> list[str]:
+    paths: list[str] = []
+    for line in status_output.splitlines():
+        path = _status_path_from_line(line)
+        if path:
+            paths.append(path)
+    return sorted(set(paths))
+
+
+def _outside_allowed_changes(
+    *,
+    full_status_output: str,
+    allowed_files: list[str],
+) -> list[str]:
+    allowed_set = set(allowed_files)
+    return [
+        path
+        for path in _all_changed_paths_from_status(full_status_output)
+        if path not in allowed_set
+    ]
+
+
 def _diff_for_file(
     *,
     repo_root: Path,
@@ -166,11 +202,19 @@ def collect_openhands_result(
     task_validation = validate_task_packet(packet)
 
     status_by_file: dict[str, str] = {}
+    full_status_output = ""
+    outside_changes: list[str] = []
     changed_files: list[str] = []
     artifact_paths: list[str] = []
     artifact_written = False
 
     if task_validation.status == "valid_task_packet":
+        full_status_output = _full_status(repo_root=resolved.repo_root, git_runner=git_runner)
+        outside_changes = _outside_allowed_changes(
+            full_status_output=full_status_output,
+            allowed_files=task_validation.normalized_allowed_files,
+        )
+
         for allowed_file in task_validation.normalized_allowed_files:
             status_by_file[allowed_file] = _status_for_allowed_file(
                 repo_root=resolved.repo_root,
@@ -196,6 +240,10 @@ def collect_openhands_result(
         executor_status = "blocked"
         validation_status = "blocked"
         stop_reason = "task_packet_blocked"
+    elif outside_changes:
+        executor_status = "blocked"
+        validation_status = "blocked"
+        stop_reason = "outside_allowed_changes"
     elif not changed_files:
         executor_status = "blocked"
         validation_status = "blocked"
@@ -218,7 +266,9 @@ def collect_openhands_result(
     return OpenHandsResultCollectorReport(
         changed_files=changed_files,
         artifact_paths=artifact_paths,
+        outside_allowed_changes=outside_changes,
         git_status_short=status_by_file,
+        full_git_status_short=full_status_output,
         diff_artifact_written=artifact_written,
         result=result,
     )


### PR DESCRIPTION
## Summary

Adds repo dirty scope guard for OpenHands result collection.

Before guarded headless runs, the collector now checks full git status and blocks if any changed file is outside packet.allowed_files.

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
#199 — Add adapter task instructions
#200 — Add OpenHands result collector v0
#201 — Integrate OpenHands runner route with result collector
#202 — Detect OpenHands interactive confirmation
#203 — Add OpenHands runner timeout guard
#204 — Add explicit OpenHands headless JSON config
```

## Changed files

```text
tools/skeleton_core/openhands_result_collector.py
tests/skeleton_core/test_openhands_result_collector.py
```

## What changed

```text
Collector records full git status
Collector reports outside_allowed_changes
Collector blocks result when files outside packet.allowed_files are dirty
Allowed-file diff collection remains bounded
```

## Validation

```text
pytest tests/skeleton_core/test_openhands_result_collector.py tests/skeleton_core/test_openhands_runner_route.py: 13 passed
```

## Safety

```text
protects guarded headless runs from hidden out-of-scope changes
does not call GitHub API
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR adds repository dirty-scope detection only. Guarded headless smoke remains a separate follow-up.