### PR TITLE
Add OpenHands dispatch run options

### DIFF
--- a/tests/skeleton_core/test_openhands_dispatch_cli.py
+++ b/tests/skeleton_core/test_openhands_dispatch_cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
 
 from tools.skeleton_core.openhands_dispatch_cli import (

--- a/tests/skeleton_core/test_openhands_dispatch_cli.py
+++ b/tests/skeleton_core/test_openhands_dispatch_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from tools.skeleton_core.openhands_dispatch_cli import (
@@ -88,3 +89,65 @@ def test_cli_pretty_outputs_json(tmp_path: Path, capsys) -> None:
     output = capsys.readouterr().out
     assert "\n  " in output
     assert json.loads(output)["status"] == "dispatched"
+
+
+def test_cli_headless_json_requires_run(tmp_path: Path, capsys) -> None:
+    path = write_payload(tmp_path, valid_payload())
+
+    code = main(["--input", str(path), "--headless-json"])
+
+    assert code == 2
+    captured = json.loads(capsys.readouterr().out)
+    assert captured["status"] == "error"
+    assert "--headless-json requires --run" in captured["error"]
+
+
+def test_cli_run_headless_json_passes_config_to_route(tmp_path: Path, capsys, monkeypatch) -> None:
+    from tools.skeleton_core import openhands_dispatch_cli as cli
+    from tools.skeleton_core.openhands_adapter import (
+        build_openhands_result,
+        prepare_openhands_task,
+    )
+    from tools.skeleton_core.openhands_runner_route import OpenHandsRunnerRouteReport
+
+    captured_config = {}
+
+    def fake_run_openhands_route(packet, *, config):
+        captured_config["timeout_seconds"] = config.timeout_seconds
+        captured_config["headless_json"] = config.adapter_config.headless_json
+        captured_config["model"] = config.adapter_config.model
+
+        return OpenHandsRunnerRouteReport(
+            prepared=prepare_openhands_task(packet, "/tmp/task.md", config.adapter_config),
+            result=build_openhands_result(
+                packet,
+                executor_status="blocked",
+                changed_files=[],
+                artifact_paths=[],
+                validation_status="blocked",
+                risk_flags=[],
+                stop_reason="fake_run",
+            ),
+            returncode=0,
+            stdout_tail="",
+            stderr_tail="",
+            collector_report=None,
+        )
+
+    monkeypatch.setattr(cli, "run_openhands_route", fake_run_openhands_route)
+
+    path = write_payload(tmp_path, valid_payload())
+
+    code = main(["--input", str(path), "--run", "--headless-json", "--timeout", "7"])
+
+    assert code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "dispatched"
+    assert output["route_report"] is not None
+    assert captured_config == {
+        "timeout_seconds": 7,
+        "headless_json": True,
+        "model": "deepseek/deepseek-v4-flash:free",
+    }
+    assert "--headless" in output["route_report"]["prepared"]["command"]
+    assert "--json" in output["route_report"]["prepared"]["command"]

--- a/tests/skeleton_core/test_openhands_dispatch_cli_hook.py
+++ b/tests/skeleton_core/test_openhands_dispatch_cli_hook.py
@@ -46,8 +46,7 @@ def run_cli(payload_path: Path) -> subprocess.CompletedProcess[str]:
             str(payload_path),
         ],
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
 

--- a/tests/skeleton_core/test_openhands_issue_dispatch.py
+++ b/tests/skeleton_core/test_openhands_issue_dispatch.py
@@ -95,7 +95,9 @@ def test_dispatch_calls_injected_route_for_valid_issue(tmp_path: Path) -> None:
     task_file = tmp_path / "task.md"
     secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
 
-    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    def fake_runner(
+        command: list[str], env: dict[str, str], timeout_seconds: int
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
 
     def route(packet: AdapterTaskPacket):

--- a/tests/skeleton_core/test_openhands_runner_route.py
+++ b/tests/skeleton_core/test_openhands_runner_route.py
@@ -213,12 +213,11 @@ def test_route_blocks_interactive_confirmation_without_changes(tmp_path: Path) -
     assert report.result.result_validation.status == "valid_adapter_result"
 
 
-def test_route_blocks_timeout_before_collector(tmp_path: Path) -> None:
+def test_route_timeout_still_collects_allowed_changes(tmp_path: Path) -> None:
     secret_file = tmp_path / "openrouter.env"
     task_file = tmp_path / "task.md"
+    artifact_file = tmp_path / "result.diff"
     secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
-
-    git_called = False
 
     def fake_runner(
         command: list[str],
@@ -234,25 +233,41 @@ def test_route_blocks_timeout_before_collector(tmp_path: Path) -> None:
         )
 
     def fake_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
-        nonlocal git_called
-        git_called = True
-        return subprocess.CompletedProcess(command, 1, stdout="", stderr="must not run")
+        if "status" in command and "--short" in command:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=" M tools/skeleton_core/openhands_runner_route.py\n",
+                stderr="",
+            )
+        if "diff" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="+timeout change\n", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected command")
+
+    packet = valid_packet().model_copy(
+        update={"allowed_files": ["tools/skeleton_core/openhands_runner_route.py"]}
+    )
 
     report = run_openhands_route(
-        valid_packet(),
+        packet,
         config=OpenHandsRunnerRouteConfig(
             task_file=task_file,
             secret_file=secret_file,
             timeout_seconds=7,
         ),
         runner=fake_runner,
+        collector_config=OpenHandsResultCollectorConfig(diff_artifact_file=artifact_file),
         git_runner=fake_git_runner,
     )
 
-    assert git_called is False
     assert report.returncode == 124
-    assert report.collector_report is None
+    assert report.collector_report is not None
+    assert report.collector_report.changed_files == [
+        "tools/skeleton_core/openhands_runner_route.py"
+    ]
     assert report.result.result.status == "blocked"
     assert report.result.result.stop_reason == "openhands_timeout"
+    assert report.result.result.changed_files == ["tools/skeleton_core/openhands_runner_route.py"]
+    assert report.result.result.artifact_paths == ["artifacts/openhands-result.diff"]
     assert "timeout" in report.result.result.risk_flags
     assert report.result.result_validation.status == "valid_adapter_result"

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from tools.skeleton_core.adapter_contract import (
     AdapterExecutionResult,

--- a/tools/skeleton_core/openhands_dispatch_cli.py
+++ b/tools/skeleton_core/openhands_dispatch_cli.py
@@ -16,13 +16,17 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from tools.skeleton_core.openhands_adapter import OpenHandsAdapterConfig
 from tools.skeleton_core.openhands_issue_dispatch import (
     OpenHandsIssueDispatchReport,
     build_packet_from_issue,
     dispatch_openhands_issue,
     validate_issue_payload,
 )
-from tools.skeleton_core.openhands_runner_route import run_openhands_route
+from tools.skeleton_core.openhands_runner_route import (
+    OpenHandsRunnerRouteConfig,
+    run_openhands_route,
+)
 
 OPENHANDS_DISPATCH_CLI_VERSION = "openhands_dispatch_cli.v0"
 
@@ -51,14 +55,31 @@ def build_dry_run_report(payload: dict) -> OpenHandsIssueDispatchReport:
     )
 
 
-def build_run_report(payload: dict) -> OpenHandsIssueDispatchReport:
+def build_run_report(
+    payload: dict,
+    *,
+    headless_json: bool = False,
+    timeout_seconds: int = 300,
+) -> OpenHandsIssueDispatchReport:
     """Run the real OpenHands route.
 
     This expects runner-local secret configuration to already exist. It still
     does not call GitHub or mutate labels.
     """
 
-    return dispatch_openhands_issue(payload, route=lambda packet: run_openhands_route(packet))
+    def route(packet):
+        return run_openhands_route(
+            packet,
+            config=OpenHandsRunnerRouteConfig(
+                timeout_seconds=timeout_seconds,
+                adapter_config=OpenHandsAdapterConfig(
+                    model=packet.fuel_policy.model,
+                    headless_json=headless_json,
+                ),
+            ),
+        )
+
+    return dispatch_openhands_issue(payload, route=route)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -74,6 +95,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Pretty-print JSON output",
     )
+    parser.add_argument(
+        "--headless-json",
+        action="store_true",
+        help="Use OpenHands --headless --json for real --run mode",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Timeout seconds for real --run mode",
+    )
     return parser
 
 
@@ -83,7 +115,20 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         payload = _load_payload(Path(args.input))
-        report = build_run_report(payload) if args.run else build_dry_run_report(payload)
+        if args.headless_json and not args.run:
+            raise ValueError("--headless-json requires --run")
+        if args.timeout <= 0:
+            raise ValueError("--timeout must be positive")
+
+        report = (
+            build_run_report(
+                payload,
+                headless_json=args.headless_json,
+                timeout_seconds=args.timeout,
+            )
+            if args.run
+            else build_dry_run_report(payload)
+        )
     except Exception as exc:
         error = {
             "cli_version": OPENHANDS_DISPATCH_CLI_VERSION,

--- a/tools/skeleton_core/openhands_dispatch_cli.py
+++ b/tools/skeleton_core/openhands_dispatch_cli.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 from tools.skeleton_core.openhands_adapter import OpenHandsAdapterConfig
 from tools.skeleton_core.openhands_issue_dispatch import (

--- a/tools/skeleton_core/openhands_issue_dispatch.py
+++ b/tools/skeleton_core/openhands_issue_dispatch.py
@@ -9,7 +9,8 @@ launch OpenHands directly in tests.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/tools/skeleton_core/openhands_result_collector.py
+++ b/tools/skeleton_core/openhands_result_collector.py
@@ -8,8 +8,8 @@ restart services, or read secrets.
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -56,8 +56,7 @@ def default_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
 

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -176,24 +176,7 @@ def run_openhands_route(
     env = build_openhands_env(api_key, resolved.adapter_config)
     completed = runner(prepared.command, env, resolved.timeout_seconds)
 
-    if completed.returncode == 124:
-        validated = build_openhands_result(
-            packet,
-            executor_status="blocked",
-            changed_files=[],
-            artifact_paths=[],
-            validation_status="blocked",
-            risk_flags=["timeout"],
-            stop_reason="openhands_timeout",
-        )
-        return OpenHandsRunnerRouteReport(
-            prepared=prepared,
-            result=validated,
-            returncode=completed.returncode,
-            stdout_tail=_tail(completed.stdout or ""),
-            stderr_tail=_tail(completed.stderr or ""),
-            collector_report=None,
-        )
+    timeout_occurred = completed.returncode == 124
 
     collector_report = None
     if changed_files is None and artifact_paths is None:
@@ -217,6 +200,30 @@ def run_openhands_route(
             validation_status=validation_status,
             risk_flags=[],
             stop_reason=f"openhands_returncode={completed.returncode}",
+        )
+
+    if timeout_occurred:
+        timeout_changed_files = []
+        timeout_artifact_paths = []
+        timeout_risk_flags = ["timeout"]
+
+        if collector_report is not None:
+            timeout_changed_files = collector_report.changed_files
+            timeout_artifact_paths = collector_report.artifact_paths
+            if collector_report.outside_allowed_changes:
+                timeout_risk_flags.append("outside_allowed_changes")
+        else:
+            timeout_changed_files = changed_files or []
+            timeout_artifact_paths = artifact_paths or []
+
+        validated = build_openhands_result(
+            packet,
+            executor_status="blocked",
+            changed_files=timeout_changed_files,
+            artifact_paths=timeout_artifact_paths,
+            validation_status="blocked",
+            risk_flags=timeout_risk_flags,
+            stop_reason="openhands_timeout",
         )
 
     if (

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -142,8 +142,7 @@ def default_runner(
             command,
             env=merged_env,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=timeout_seconds,
             check=False,
         )


### PR DESCRIPTION
## Summary

Adds explicit run options to the OpenHands dispatch CLI.

This exposes the guarded headless run path through the standard Skeleton CLI:

```bash
python -m tools.skeleton_core.cli openhands-dispatch --input payload.json --run --headless-json --timeout 120
```

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
#199 — Add adapter task instructions
#200 — Add OpenHands result collector v0
#201 — Integrate OpenHands runner route with result collector
#202 — Detect OpenHands interactive confirmation
#203 — Add OpenHands runner timeout guard
#204 — Add explicit OpenHands headless JSON config
#205 — Add OpenHands repo dirty scope guard
```

## Changed files

```text
tools/skeleton_core/openhands_dispatch_cli.py
tests/skeleton_core/test_openhands_dispatch_cli.py
```

## What changed

```text
--headless-json added for explicit real --run mode
--timeout added for real --run mode
--headless-json without --run is rejected
CLI passes timeout/headless config into run_openhands_route()
tests cover config propagation with fake route
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_dispatch_cli.py tests/skeleton_core/test_openhands_dispatch_cli_hook.py tests/skeleton_core/test_openhands_runner_route.py: 16 passed
```

## Safety

```text
headless JSON remains explicit opt-in
--headless-json requires --run
timeout must be positive
repo dirty-scope guard remains in collector layer
does not call GitHub API
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
```

## Boundary

This PR only exposes guarded run options in the CLI. A full CLI-based guarded headless smoke is a separate follow-up.