### PR TITLE
Add OpenHands local queue runner

### DIFF
--- a/tests/skeleton_core/test_openhands_dispatch_cli.py
+++ b/tests/skeleton_core/test_openhands_dispatch_cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
 
 from tools.skeleton_core.openhands_dispatch_cli import (

--- a/tests/skeleton_core/test_openhands_dispatch_cli_hook.py
+++ b/tests/skeleton_core/test_openhands_dispatch_cli_hook.py
@@ -46,8 +46,7 @@ def run_cli(payload_path: Path) -> subprocess.CompletedProcess[str]:
             str(payload_path),
         ],
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
 

--- a/tests/skeleton_core/test_openhands_issue_dispatch.py
+++ b/tests/skeleton_core/test_openhands_issue_dispatch.py
@@ -95,7 +95,9 @@ def test_dispatch_calls_injected_route_for_valid_issue(tmp_path: Path) -> None:
     task_file = tmp_path / "task.md"
     secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
 
-    def fake_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    def fake_runner(
+        command: list[str], env: dict[str, str], timeout_seconds: int
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
 
     def route(packet: AdapterTaskPacket):

--- a/tests/skeleton_core/test_openhands_queue_runner.py
+++ b/tests/skeleton_core/test_openhands_queue_runner.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.skeleton_core.openhands_queue_runner import main, run_queue_once
+
+
+def payload() -> dict:
+    return {
+        "issue_number": 211,
+        "repo": "alanua/jeeves",
+        "title": "Queue runner test payload",
+        "body": "Create one allowed file.",
+        "labels": [
+            "agent:task",
+            "agent:audited",
+            "agent:plan-ready",
+            "runner:openhands",
+            "risk:yellow",
+        ],
+        "allowed_files": ["QUEUE_TEST.md"],
+        "expected_artifact": "diff",
+        "authority_level": "level_2_local_diff",
+        "risk_level": "yellow",
+        "fuel_provider": "openrouter",
+        "fuel_model": "deepseek/deepseek-v4-flash:free",
+        "fuel_max_usd": 1.0,
+    }
+
+
+def fake_dispatch(
+    payload_dict: dict,
+    *,
+    headless_json: bool,
+    timeout_seconds: int,
+    exit_without_confirmation: bool,
+) -> dict:
+    assert payload_dict["issue_number"] == 211
+    assert headless_json is True
+    assert timeout_seconds == 17
+    assert exit_without_confirmation is True
+
+    return {
+        "status": "dispatched",
+        "route_report": {
+            "result": {
+                "result": {
+                    "status": "success",
+                    "stop_reason": "allowed_file_changes_collected",
+                    "changed_files": ["QUEUE_TEST.md"],
+                }
+            },
+            "collector_report": {
+                "outside_allowed_changes": [],
+            },
+        },
+    }
+
+
+def write_payload(queue_dir: Path) -> Path:
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    path = queue_dir / "001-payload.json"
+    path.write_text(json.dumps(payload()), encoding="utf-8")
+    return path
+
+
+def test_run_queue_once_empty_queue(tmp_path: Path) -> None:
+    report = run_queue_once(
+        queue_dir=tmp_path / "queue",
+        report_dir=tmp_path / "reports",
+        dispatch=fake_dispatch,
+    )
+
+    assert report.status == "empty"
+    assert report.payload_file == ""
+
+
+def test_run_queue_once_writes_report_and_summary(tmp_path: Path) -> None:
+    queue_dir = tmp_path / "queue"
+    report_dir = tmp_path / "reports"
+    payload_file = write_payload(queue_dir)
+
+    report = run_queue_once(
+        queue_dir=queue_dir,
+        report_dir=report_dir,
+        headless_json=True,
+        timeout_seconds=17,
+        exit_without_confirmation=True,
+        dispatch=fake_dispatch,
+    )
+
+    assert report.status == "reported"
+    assert report.payload_file == str(payload_file)
+    assert report.dispatch_status == "dispatched"
+    assert report.result_status == "success"
+    assert report.stop_reason == "allowed_file_changes_collected"
+    assert report.changed_files == ["QUEUE_TEST.md"]
+    assert report.outside_allowed_changes == []
+    assert Path(report.report_file).exists()
+
+
+def test_run_queue_once_invalid_json_writes_error_report(tmp_path: Path) -> None:
+    queue_dir = tmp_path / "queue"
+    report_dir = tmp_path / "reports"
+    queue_dir.mkdir(parents=True)
+    bad_payload = queue_dir / "bad.json"
+    bad_payload.write_text("{bad", encoding="utf-8")
+
+    report = run_queue_once(
+        queue_dir=queue_dir,
+        report_dir=report_dir,
+        dispatch=fake_dispatch,
+    )
+
+    assert report.status == "error"
+    assert report.error_type == "JSONDecodeError"
+    assert Path(report.report_file).exists()
+
+
+def test_queue_runner_main_outputs_json(tmp_path: Path, capsys) -> None:
+    queue_dir = tmp_path / "queue"
+    report_dir = tmp_path / "reports"
+    write_payload(queue_dir)
+
+    code = main(
+        [
+            "--queue-dir",
+            str(queue_dir),
+            "--report-dir",
+            str(report_dir),
+            "--headless-json",
+            "--exit-without-confirmation",
+            "--timeout",
+            "17",
+            "--pretty",
+        ],
+        dispatch=fake_dispatch,
+    )
+
+    assert code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "reported"
+    assert output["changed_files"] == ["QUEUE_TEST.md"]
+
+
+def test_queue_runner_main_rejects_invalid_timeout(tmp_path: Path, capsys) -> None:
+    code = main(
+        [
+            "--queue-dir",
+            str(tmp_path / "queue"),
+            "--report-dir",
+            str(tmp_path / "reports"),
+            "--timeout",
+            "0",
+        ],
+        dispatch=fake_dispatch,
+    )
+
+    assert code == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "error"
+    assert "--timeout must be positive" in output["error"]

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -29,6 +29,11 @@ if len(sys.argv) > 1 and sys.argv[1] == "openhands-dispatch":
 
     raise SystemExit(_openhands_dispatch_main(sys.argv[2:]))
 
+if len(sys.argv) > 1 and sys.argv[1] == "openhands-run-queue":
+    from tools.skeleton_core.openhands_queue_runner import main as _openhands_queue_main
+
+    raise SystemExit(_openhands_queue_main(sys.argv[2:]))
+
 import argparse
 import json
 import sys

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from tools.skeleton_core.adapter_contract import (
     AdapterExecutionResult,

--- a/tools/skeleton_core/openhands_dispatch_cli.py
+++ b/tools/skeleton_core/openhands_dispatch_cli.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 from tools.skeleton_core.openhands_adapter import OpenHandsAdapterConfig
 from tools.skeleton_core.openhands_issue_dispatch import (

--- a/tools/skeleton_core/openhands_issue_dispatch.py
+++ b/tools/skeleton_core/openhands_issue_dispatch.py
@@ -9,7 +9,8 @@ launch OpenHands directly in tests.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/tools/skeleton_core/openhands_queue_runner.py
+++ b/tools/skeleton_core/openhands_queue_runner.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/tools/skeleton_core/openhands_queue_runner.py
+++ b/tools/skeleton_core/openhands_queue_runner.py
@@ -1,0 +1,200 @@
+"""Local OpenHands queue runner v0.
+
+Reads one JSON payload from a local queue directory, runs the existing
+OpenHands dispatch path, and writes a public-safe JSON report.
+
+This does not poll GitHub, mutate labels, merge, deploy, restart services,
+or read repo secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tools.skeleton_core.openhands_dispatch_cli import build_run_report
+
+OPENHANDS_QUEUE_RUNNER_VERSION = "openhands_queue_runner.v0"
+
+
+class OpenHandsQueueRunReport(BaseModel):
+    """Public-safe report for one local queue item."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    queue_version: str = OPENHANDS_QUEUE_RUNNER_VERSION
+    status: str
+    payload_file: str = ""
+    report_file: str = ""
+    dispatch_status: str = ""
+    result_status: str = ""
+    stop_reason: str = ""
+    changed_files: list[str] = Field(default_factory=list)
+    outside_allowed_changes: list[str] = Field(default_factory=list)
+    error_type: str = ""
+    error: str = ""
+
+
+DispatchFn = Callable[..., Any]
+
+
+def _default_dispatch(
+    payload: dict[str, Any],
+    *,
+    headless_json: bool,
+    timeout_seconds: int,
+    exit_without_confirmation: bool,
+) -> Any:
+    return build_run_report(
+        payload,
+        headless_json=headless_json,
+        timeout_seconds=timeout_seconds,
+        exit_without_confirmation=exit_without_confirmation,
+    )
+
+
+def _as_jsonable(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return value
+    raise TypeError(f"Unsupported dispatch report type: {type(value).__name__}")
+
+
+def _extract_summary(report: dict[str, Any]) -> dict[str, Any]:
+    route = report.get("route_report") or {}
+    result_packet = route.get("result") or {}
+    result = result_packet.get("result") or {}
+    collector = route.get("collector_report") or {}
+
+    return {
+        "dispatch_status": str(report.get("status") or ""),
+        "result_status": str(result.get("status") or ""),
+        "stop_reason": str(result.get("stop_reason") or ""),
+        "changed_files": list(result.get("changed_files") or []),
+        "outside_allowed_changes": list(collector.get("outside_allowed_changes") or []),
+    }
+
+
+def _first_payload(queue_dir: Path) -> Path | None:
+    payloads = sorted(path for path in queue_dir.glob("*.json") if path.is_file())
+    return payloads[0] if payloads else None
+
+
+def run_queue_once(
+    *,
+    queue_dir: Path,
+    report_dir: Path,
+    headless_json: bool = False,
+    timeout_seconds: int = 300,
+    exit_without_confirmation: bool = False,
+    dispatch: DispatchFn = _default_dispatch,
+) -> OpenHandsQueueRunReport:
+    """Run one local queue payload and write one JSON report."""
+
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    payload_file = _first_payload(queue_dir)
+    if payload_file is None:
+        return OpenHandsQueueRunReport(status="empty")
+
+    report_file = report_dir / f"{payload_file.stem}.report.json"
+
+    try:
+        payload = json.loads(payload_file.read_text(encoding="utf-8"))
+        dispatch_report = dispatch(
+            payload,
+            headless_json=headless_json,
+            timeout_seconds=timeout_seconds,
+            exit_without_confirmation=exit_without_confirmation,
+        )
+        dispatch_json = _as_jsonable(dispatch_report)
+        report_file.write_text(
+            json.dumps(dispatch_json, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+        summary = _extract_summary(dispatch_json)
+        return OpenHandsQueueRunReport(
+            status="reported",
+            payload_file=str(payload_file),
+            report_file=str(report_file),
+            **summary,
+        )
+    except Exception as exc:
+        error_json = {
+            "queue_version": OPENHANDS_QUEUE_RUNNER_VERSION,
+            "status": "error",
+            "payload_file": str(payload_file),
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+        }
+        report_file.write_text(
+            json.dumps(error_json, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        return OpenHandsQueueRunReport(
+            status="error",
+            payload_file=str(payload_file),
+            report_file=str(report_file),
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run one local OpenHands queue item")
+    parser.add_argument("--queue-dir", required=True, help="Directory with JSON payloads")
+    parser.add_argument("--report-dir", required=True, help="Directory for JSON reports")
+    parser.add_argument(
+        "--headless-json", action="store_true", help="Use guarded headless JSON run"
+    )
+    parser.add_argument(
+        "--exit-without-confirmation",
+        action="store_true",
+        help="Pass OpenHands --exit-without-confirmation",
+    )
+    parser.add_argument("--timeout", type=int, default=300, help="OpenHands timeout seconds")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print queue report")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, *, dispatch: DispatchFn = _default_dispatch) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.timeout <= 0:
+        report = OpenHandsQueueRunReport(
+            status="error",
+            error_type="ValueError",
+            error="--timeout must be positive",
+        )
+        print(json.dumps(report.model_dump(mode="json"), sort_keys=True))
+        return 2
+
+    report = run_queue_once(
+        queue_dir=Path(args.queue_dir),
+        report_dir=Path(args.report_dir),
+        headless_json=args.headless_json,
+        timeout_seconds=args.timeout,
+        exit_without_confirmation=args.exit_without_confirmation,
+        dispatch=dispatch,
+    )
+
+    print(
+        json.dumps(
+            report.model_dump(mode="json"),
+            indent=2 if args.pretty else None,
+            sort_keys=True,
+        )
+    )
+    return 2 if report.status == "error" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/skeleton_core/openhands_result_collector.py
+++ b/tools/skeleton_core/openhands_result_collector.py
@@ -8,8 +8,8 @@ restart services, or read secrets.
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -56,8 +56,7 @@ def default_git_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
 

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -142,8 +142,7 @@ def default_runner(
             command,
             env=merged_env,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=timeout_seconds,
             check=False,
         )


### PR DESCRIPTION
## Summary

Adds Local OpenHands Queue Runner v0.

This is the first small daemon-like runner layer:

```text
queue/*.json
-> openhands-run-queue
-> existing openhands-dispatch path
-> reports/*.report.json
```

It lets Skeleton process one local queued task payload and write a public-safe JSON report.

## Depends on

```text
#193 — Add Skeleton adapter contract core v0
#194 — Add OpenHands adapter v0
#195 — Add OpenHands runner route v0
#196 — Add OpenHands issue dispatch v0
#197 — Add OpenHands dispatch CLI v0
#198 — Expose OpenHands dispatch through Skeleton CLI
#199 — Add adapter task instructions
#200 — Add OpenHands result collector v0
#201 — Integrate OpenHands runner route with result collector
#202 — Detect OpenHands interactive confirmation
#203 — Add OpenHands runner timeout guard
#204 — Add explicit OpenHands headless JSON config
#205 — Add OpenHands repo dirty scope guard
#206 — Add OpenHands dispatch run options
#207 — Collect OpenHands results after timeout
#208 — Add OpenHands headless exit option
```

## Changed files

```text
tools/skeleton_core/openhands_queue_runner.py
tools/skeleton_core/cli.py
tests/skeleton_core/test_openhands_queue_runner.py
```

## What changed

```text
OpenHandsQueueRunReport
run_queue_once()
openhands-run-queue CLI hook
writes per-payload report JSON
summarizes dispatch/result/changed_files/outside_allowed_changes
handles empty queue
handles invalid payload JSON with error report
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_queue_runner.py tests/skeleton_core/test_openhands_dispatch_cli.py tests/skeleton_core/test_openhands_dispatch_cli_hook.py: 14 passed
```

## Safety

```text
local queue only
processes one payload at a time
does not poll GitHub
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
uses existing bounded dispatch/collector/scope guards
```

## Boundary

This PR adds a local queue runner only. Moving processed payloads, continuous daemon mode, and GitHub issue bridge are separate follow-ups.