### PR TITLE
Add OpenHands queue lifecycle

### DIFF
--- a/tests/skeleton_core/test_openhands_queue_runner.py
+++ b/tests/skeleton_core/test_openhands_queue_runner.py
@@ -58,9 +58,19 @@ def fake_dispatch(
     }
 
 
-def write_payload(queue_dir: Path) -> Path:
+def failing_dispatch(
+    payload_dict: dict,
+    *,
+    headless_json: bool,
+    timeout_seconds: int,
+    exit_without_confirmation: bool,
+) -> dict:
+    raise RuntimeError("dispatch failed")
+
+
+def write_payload(queue_dir: Path, name: str = "001-payload.json") -> Path:
     queue_dir.mkdir(parents=True, exist_ok=True)
-    path = queue_dir / "001-payload.json"
+    path = queue_dir / name
     path.write_text(json.dumps(payload()), encoding="utf-8")
     return path
 
@@ -76,32 +86,44 @@ def test_run_queue_once_empty_queue(tmp_path: Path) -> None:
     assert report.payload_file == ""
 
 
-def test_run_queue_once_writes_report_and_summary(tmp_path: Path) -> None:
+def test_run_queue_once_moves_payload_to_done_and_writes_report(tmp_path: Path) -> None:
     queue_dir = tmp_path / "queue"
+    running_dir = tmp_path / "running"
+    done_dir = tmp_path / "done"
+    failed_dir = tmp_path / "failed"
     report_dir = tmp_path / "reports"
     payload_file = write_payload(queue_dir)
 
     report = run_queue_once(
         queue_dir=queue_dir,
         report_dir=report_dir,
+        running_dir=running_dir,
+        done_dir=done_dir,
+        failed_dir=failed_dir,
         headless_json=True,
         timeout_seconds=17,
         exit_without_confirmation=True,
         dispatch=fake_dispatch,
     )
 
-    assert report.status == "reported"
+    assert report.status == "done"
     assert report.payload_file == str(payload_file)
+    assert report.running_file == str(running_dir / payload_file.name)
+    assert report.final_payload_file == str(done_dir / payload_file.name)
     assert report.dispatch_status == "dispatched"
     assert report.result_status == "success"
     assert report.stop_reason == "allowed_file_changes_collected"
     assert report.changed_files == ["QUEUE_TEST.md"]
     assert report.outside_allowed_changes == []
+    assert not payload_file.exists()
+    assert not (running_dir / payload_file.name).exists()
+    assert (done_dir / payload_file.name).exists()
     assert Path(report.report_file).exists()
 
 
-def test_run_queue_once_invalid_json_writes_error_report(tmp_path: Path) -> None:
+def test_run_queue_once_invalid_json_moves_payload_to_failed(tmp_path: Path) -> None:
     queue_dir = tmp_path / "queue"
+    failed_dir = tmp_path / "failed"
     report_dir = tmp_path / "reports"
     queue_dir.mkdir(parents=True)
     bad_payload = queue_dir / "bad.json"
@@ -110,17 +132,42 @@ def test_run_queue_once_invalid_json_writes_error_report(tmp_path: Path) -> None
     report = run_queue_once(
         queue_dir=queue_dir,
         report_dir=report_dir,
+        failed_dir=failed_dir,
         dispatch=fake_dispatch,
     )
 
-    assert report.status == "error"
+    assert report.status == "failed"
     assert report.error_type == "JSONDecodeError"
+    assert not bad_payload.exists()
+    assert (failed_dir / "bad.json").exists()
+    assert Path(report.report_file).exists()
+
+
+def test_run_queue_once_dispatch_error_moves_payload_to_failed(tmp_path: Path) -> None:
+    queue_dir = tmp_path / "queue"
+    failed_dir = tmp_path / "failed"
+    report_dir = tmp_path / "reports"
+    payload_file = write_payload(queue_dir)
+
+    report = run_queue_once(
+        queue_dir=queue_dir,
+        report_dir=report_dir,
+        failed_dir=failed_dir,
+        dispatch=failing_dispatch,
+    )
+
+    assert report.status == "failed"
+    assert report.error_type == "RuntimeError"
+    assert "dispatch failed" in report.error
+    assert not payload_file.exists()
+    assert (failed_dir / payload_file.name).exists()
     assert Path(report.report_file).exists()
 
 
 def test_queue_runner_main_outputs_json(tmp_path: Path, capsys) -> None:
     queue_dir = tmp_path / "queue"
     report_dir = tmp_path / "reports"
+    done_dir = tmp_path / "done"
     write_payload(queue_dir)
 
     code = main(
@@ -129,6 +176,8 @@ def test_queue_runner_main_outputs_json(tmp_path: Path, capsys) -> None:
             str(queue_dir),
             "--report-dir",
             str(report_dir),
+            "--done-dir",
+            str(done_dir),
             "--headless-json",
             "--exit-without-confirmation",
             "--timeout",
@@ -140,8 +189,9 @@ def test_queue_runner_main_outputs_json(tmp_path: Path, capsys) -> None:
 
     assert code == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["status"] == "reported"
+    assert output["status"] == "done"
     assert output["changed_files"] == ["QUEUE_TEST.md"]
+    assert Path(output["final_payload_file"]).parent == done_dir
 
 
 def test_queue_runner_main_rejects_invalid_timeout(tmp_path: Path, capsys) -> None:
@@ -159,5 +209,5 @@ def test_queue_runner_main_rejects_invalid_timeout(tmp_path: Path, capsys) -> No
 
     assert code == 2
     output = json.loads(capsys.readouterr().out)
-    assert output["status"] == "error"
+    assert output["status"] == "failed"
     assert "--timeout must be positive" in output["error"]

--- a/tools/skeleton_core/openhands_queue_runner.py
+++ b/tools/skeleton_core/openhands_queue_runner.py
@@ -1,7 +1,13 @@
 """Local OpenHands queue runner v0.
 
-Reads one JSON payload from a local queue directory, runs the existing
-OpenHands dispatch path, and writes a public-safe JSON report.
+Reads one JSON payload from a local queue directory, moves it through a local
+lifecycle, runs the existing OpenHands dispatch path, and writes a public-safe
+JSON report.
+
+Lifecycle:
+
+queue/*.json -> running/*.json -> done/*.json
+queue/*.json -> running/*.json -> failed/*.json
 
 This does not poll GitHub, mutate labels, merge, deploy, restart services,
 or read repo secrets.
@@ -11,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
@@ -29,6 +36,8 @@ class OpenHandsQueueRunReport(BaseModel):
     queue_version: str = OPENHANDS_QUEUE_RUNNER_VERSION
     status: str
     payload_file: str = ""
+    running_file: str = ""
+    final_payload_file: str = ""
     report_file: str = ""
     dispatch_status: str = ""
     result_status: str = ""
@@ -85,10 +94,27 @@ def _first_payload(queue_dir: Path) -> Path | None:
     return payloads[0] if payloads else None
 
 
+def _move_payload(source: Path, target_dir: Path) -> Path:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / source.name
+    if target.exists():
+        raise FileExistsError(f"Queue target already exists: {target}")
+    shutil.move(str(source), str(target))
+    return target
+
+
+def _default_state_dirs(queue_dir: Path) -> tuple[Path, Path, Path]:
+    base_dir = queue_dir.parent
+    return base_dir / "running", base_dir / "done", base_dir / "failed"
+
+
 def run_queue_once(
     *,
     queue_dir: Path,
     report_dir: Path,
+    running_dir: Path | None = None,
+    done_dir: Path | None = None,
+    failed_dir: Path | None = None,
     headless_json: bool = False,
     timeout_seconds: int = 300,
     exit_without_confirmation: bool = False,
@@ -96,17 +122,26 @@ def run_queue_once(
 ) -> OpenHandsQueueRunReport:
     """Run one local queue payload and write one JSON report."""
 
+    default_running_dir, default_done_dir, default_failed_dir = _default_state_dirs(queue_dir)
+    resolved_running_dir = running_dir or default_running_dir
+    resolved_done_dir = done_dir or default_done_dir
+    resolved_failed_dir = failed_dir or default_failed_dir
+
     queue_dir.mkdir(parents=True, exist_ok=True)
     report_dir.mkdir(parents=True, exist_ok=True)
+    resolved_running_dir.mkdir(parents=True, exist_ok=True)
+    resolved_done_dir.mkdir(parents=True, exist_ok=True)
+    resolved_failed_dir.mkdir(parents=True, exist_ok=True)
 
     payload_file = _first_payload(queue_dir)
     if payload_file is None:
         return OpenHandsQueueRunReport(status="empty")
 
-    report_file = report_dir / f"{payload_file.stem}.report.json"
+    running_file = _move_payload(payload_file, resolved_running_dir)
+    report_file = report_dir / f"{running_file.stem}.report.json"
 
     try:
-        payload = json.loads(payload_file.read_text(encoding="utf-8"))
+        payload = json.loads(running_file.read_text(encoding="utf-8"))
         dispatch_report = dispatch(
             payload,
             headless_json=headless_json,
@@ -119,18 +154,22 @@ def run_queue_once(
             encoding="utf-8",
         )
 
+        done_file = _move_payload(running_file, resolved_done_dir)
         summary = _extract_summary(dispatch_json)
         return OpenHandsQueueRunReport(
-            status="reported",
+            status="done",
             payload_file=str(payload_file),
+            running_file=str(running_file),
+            final_payload_file=str(done_file),
             report_file=str(report_file),
             **summary,
         )
     except Exception as exc:
         error_json = {
             "queue_version": OPENHANDS_QUEUE_RUNNER_VERSION,
-            "status": "error",
+            "status": "failed",
             "payload_file": str(payload_file),
+            "running_file": str(running_file),
             "error_type": type(exc).__name__,
             "error": str(exc),
         }
@@ -138,9 +177,16 @@ def run_queue_once(
             json.dumps(error_json, indent=2, sort_keys=True),
             encoding="utf-8",
         )
+
+        final_payload_file = ""
+        if running_file.exists():
+            final_payload_file = str(_move_payload(running_file, resolved_failed_dir))
+
         return OpenHandsQueueRunReport(
-            status="error",
+            status="failed",
             payload_file=str(payload_file),
+            running_file=str(running_file),
+            final_payload_file=final_payload_file,
             report_file=str(report_file),
             error_type=type(exc).__name__,
             error=str(exc),
@@ -151,6 +197,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run one local OpenHands queue item")
     parser.add_argument("--queue-dir", required=True, help="Directory with JSON payloads")
     parser.add_argument("--report-dir", required=True, help="Directory for JSON reports")
+    parser.add_argument("--running-dir", help="Directory for payload currently being processed")
+    parser.add_argument("--done-dir", help="Directory for successfully processed payloads")
+    parser.add_argument("--failed-dir", help="Directory for failed payloads")
     parser.add_argument(
         "--headless-json", action="store_true", help="Use guarded headless JSON run"
     )
@@ -170,7 +219,7 @@ def main(argv: Sequence[str] | None = None, *, dispatch: DispatchFn = _default_d
 
     if args.timeout <= 0:
         report = OpenHandsQueueRunReport(
-            status="error",
+            status="failed",
             error_type="ValueError",
             error="--timeout must be positive",
         )
@@ -180,6 +229,9 @@ def main(argv: Sequence[str] | None = None, *, dispatch: DispatchFn = _default_d
     report = run_queue_once(
         queue_dir=Path(args.queue_dir),
         report_dir=Path(args.report_dir),
+        running_dir=Path(args.running_dir) if args.running_dir else None,
+        done_dir=Path(args.done_dir) if args.done_dir else None,
+        failed_dir=Path(args.failed_dir) if args.failed_dir else None,
         headless_json=args.headless_json,
         timeout_seconds=args.timeout,
         exit_without_confirmation=args.exit_without_confirmation,
@@ -193,7 +245,7 @@ def main(argv: Sequence[str] | None = None, *, dispatch: DispatchFn = _default_d
             sort_keys=True,
         )
     )
-    return 2 if report.status == "error" else 0
+    return 2 if report.status == "failed" else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds lifecycle handling to the Local OpenHands Queue Runner.

Payloads now move through local state directories:

```text
queue/*.json -> running/*.json -> done/*.json
queue/*.json -> running/*.json -> failed/*.json
```

## Depends on

```text
#209 — Add OpenHands local queue runner
```

## Changed files

```text
tools/skeleton_core/openhands_queue_runner.py
tests/skeleton_core/test_openhands_queue_runner.py
```

## What changed

```text
Adds running/done/failed queue state directories
Moves payload to running before dispatch
Moves successful payloads to done
Moves invalid/error payloads to failed
Adds final_payload_file and running_file to queue report
Extends tests for done/failed lifecycle behavior
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_queue_runner.py tests/skeleton_core/test_openhands_dispatch_cli.py tests/skeleton_core/test_openhands_dispatch_cli_hook.py: 15 passed
```

## Safety

```text
local queue only
processes one payload at a time
does not poll GitHub
does not mutate labels
does not read .env
does not print API keys
does not push/merge/deploy from module
does not touch production/server/DB
uses existing bounded dispatch/collector/scope guards
```

## Boundary

This PR adds queue lifecycle only. Continuous daemon loop and GitHub issue bridge are separate follow-ups.