### PR TITLE
Add queue commit preparation report

### DIFF
--- a/tests/skeleton_core/test_openhands_queue_runner.py
+++ b/tests/skeleton_core/test_openhands_queue_runner.py
@@ -440,3 +440,104 @@ def test_queue_only_local_validations_are_not_sent_to_dispatch(tmp_path: Path) -
     assert report.status == "done"
     assert "local_validations" not in seen_payload
     assert report.validation_status == "passed"
+
+
+def test_queue_done_result_includes_commit_preparation_ready(tmp_path: Path) -> None:
+    queue_dir = tmp_path / "queue"
+    done_dir = tmp_path / "done"
+    report_dir = tmp_path / "reports"
+    write_payload(queue_dir)
+
+    report = run_queue_once(
+        queue_dir=queue_dir,
+        report_dir=report_dir,
+        done_dir=done_dir,
+        headless_json=True,
+        timeout_seconds=17,
+        exit_without_confirmation=True,
+        dispatch=fake_dispatch,
+    )
+
+    assert report.status == "done"
+    assert report.commit_preparation.status == "ready"
+    assert report.commit_preparation.commit_files == ["QUEUE_TEST.md"]
+    assert report.commit_preparation.suggested_commit_message == (
+        "chore(skeleton): Queue runner test payload"
+    )
+    assert report.commit_preparation.blocked_reasons == []
+
+    report_json = json.loads(Path(report.report_file).read_text(encoding="utf-8"))
+    assert report_json["commit_preparation"]["status"] == "ready"
+    assert report_json["commit_preparation"]["commit_files"] == ["QUEUE_TEST.md"]
+
+
+def test_queue_failed_validation_blocks_commit_preparation(tmp_path: Path) -> None:
+    queue_dir = tmp_path / "queue"
+    failed_dir = tmp_path / "failed"
+    report_dir = tmp_path / "reports"
+    payload_file = write_payload(queue_dir)
+
+    payload_data = json.loads(payload_file.read_text(encoding="utf-8"))
+    payload_data["local_validations"] = [
+        {
+            "tool": "pytest",
+            "targets": ["../unsafe.py"],
+        }
+    ]
+    payload_file.write_text(json.dumps(payload_data), encoding="utf-8")
+
+    report = run_queue_once(
+        queue_dir=queue_dir,
+        report_dir=report_dir,
+        failed_dir=failed_dir,
+        headless_json=True,
+        timeout_seconds=17,
+        exit_without_confirmation=True,
+        dispatch=fake_dispatch,
+    )
+
+    assert report.status == "failed"
+    assert report.commit_preparation.status == "blocked"
+    assert "queue_status_not_done" in report.commit_preparation.blocked_reasons
+    assert "local_validations_not_passed" in report.commit_preparation.blocked_reasons
+
+
+def test_queue_no_changed_files_blocks_commit_preparation(tmp_path: Path) -> None:
+    queue_dir = tmp_path / "queue"
+    done_dir = tmp_path / "done"
+    report_dir = tmp_path / "reports"
+    write_payload(queue_dir)
+
+    def no_change_dispatch(
+        payload_dict: dict,
+        *,
+        headless_json: bool,
+        timeout_seconds: int,
+        exit_without_confirmation: bool,
+    ) -> dict:
+        return {
+            "status": "dispatched",
+            "route_report": {
+                "result": {
+                    "result": {
+                        "status": "blocked",
+                        "stop_reason": "no_allowed_file_changes",
+                        "changed_files": [],
+                    }
+                },
+                "collector_report": {
+                    "outside_allowed_changes": [],
+                },
+            },
+        }
+
+    report = run_queue_once(
+        queue_dir=queue_dir,
+        report_dir=report_dir,
+        done_dir=done_dir,
+        dispatch=no_change_dispatch,
+    )
+
+    assert report.commit_preparation.status == "blocked"
+    assert "dispatch_result_not_success" in report.commit_preparation.blocked_reasons
+    assert "no_changed_files" in report.commit_preparation.blocked_reasons

--- a/tools/skeleton_core/openhands_queue_runner.py
+++ b/tools/skeleton_core/openhands_queue_runner.py
@@ -35,6 +35,21 @@ from tools.skeleton_core.openhands_dispatch_cli import build_run_report
 OPENHANDS_QUEUE_RUNNER_VERSION = "openhands_queue_runner.v0"
 
 
+class OpenHandsQueueCommitPreparationReport(BaseModel):
+    """Public-safe commit preparation report.
+
+    This does not commit, push, merge, or open a PR. It only says whether the
+    queue result is ready for a later explicit commit step.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: str = "not_ready"
+    commit_files: list[str] = Field(default_factory=list)
+    suggested_commit_message: str = ""
+    blocked_reasons: list[str] = Field(default_factory=list)
+
+
 class OpenHandsQueueRunReport(BaseModel):
     """Public-safe report for one local queue item."""
 
@@ -53,6 +68,9 @@ class OpenHandsQueueRunReport(BaseModel):
     outside_allowed_changes: list[str] = Field(default_factory=list)
     validation_status: str = "not_run"
     validation_reports: list[LocalToolReport] = Field(default_factory=list)
+    commit_preparation: OpenHandsQueueCommitPreparationReport = Field(
+        default_factory=OpenHandsQueueCommitPreparationReport
+    )
     error_type: str = ""
     error: str = ""
 
@@ -131,6 +149,53 @@ def _run_local_validations(payload: dict[str, Any]) -> tuple[str, list[LocalTool
     return "failed", reports
 
 
+def _suggest_commit_message(payload: dict[str, Any]) -> str:
+    title = str(payload.get("title") or "").strip()
+    if not title:
+        return "chore(skeleton): apply queued OpenHands task"
+    cleaned = " ".join(title.split())
+    return f"chore(skeleton): {cleaned[:80]}"
+
+
+def _prepare_commit_report(
+    *,
+    payload: dict[str, Any],
+    final_status: str,
+    summary: dict[str, Any],
+    validation_status: str,
+) -> OpenHandsQueueCommitPreparationReport:
+    blocked_reasons: list[str] = []
+    changed_files = list(summary.get("changed_files") or [])
+    outside_allowed_changes = list(summary.get("outside_allowed_changes") or [])
+    result_status = str(summary.get("result_status") or "")
+
+    if final_status != "done":
+        blocked_reasons.append("queue_status_not_done")
+    if result_status != "success":
+        blocked_reasons.append("dispatch_result_not_success")
+    if validation_status not in {"not_run", "passed"}:
+        blocked_reasons.append("local_validations_not_passed")
+    if not changed_files:
+        blocked_reasons.append("no_changed_files")
+    if outside_allowed_changes:
+        blocked_reasons.append("outside_allowed_changes")
+
+    if blocked_reasons:
+        return OpenHandsQueueCommitPreparationReport(
+            status="blocked",
+            commit_files=changed_files,
+            suggested_commit_message="",
+            blocked_reasons=sorted(set(blocked_reasons)),
+        )
+
+    return OpenHandsQueueCommitPreparationReport(
+        status="ready",
+        commit_files=changed_files,
+        suggested_commit_message=_suggest_commit_message(payload),
+        blocked_reasons=[],
+    )
+
+
 def _extract_summary(report: dict[str, Any]) -> dict[str, Any]:
     route = report.get("route_report") or {}
     result_packet = route.get("result") or {}
@@ -199,6 +264,7 @@ def run_queue_once(
 
     try:
         payload = json.loads(running_file.read_text(encoding="utf-8"))
+
         dispatch_report = dispatch(
             _payload_for_dispatch(payload),
             headless_json=headless_json,
@@ -206,20 +272,36 @@ def run_queue_once(
             exit_without_confirmation=exit_without_confirmation,
         )
         dispatch_json = _as_jsonable(dispatch_report)
+
         validation_status, validation_reports = _run_local_validations(payload)
+        summary = _extract_summary(dispatch_json)
+
+        result_status = str(summary.get("result_status") or "")
+        outside_allowed_changes = list(summary.get("outside_allowed_changes") or [])
+        validation_ok = validation_status in {"not_run", "passed"}
+        dispatch_ok = result_status == "success"
+        scope_ok = not outside_allowed_changes
+
+        final_status = "done" if validation_ok and dispatch_ok and scope_ok else "failed"
+
+        commit_preparation = _prepare_commit_report(
+            payload=payload,
+            final_status=final_status,
+            summary=summary,
+            validation_status=validation_status,
+        )
 
         combined_report = {
             "dispatch_report": dispatch_json,
             "validation_status": validation_status,
             "validation_reports": [report.model_dump(mode="json") for report in validation_reports],
+            "commit_preparation": commit_preparation.model_dump(mode="json"),
         }
         report_file.write_text(
             json.dumps(combined_report, indent=2, sort_keys=True),
             encoding="utf-8",
         )
 
-        summary = _extract_summary(dispatch_json)
-        final_status = "done" if validation_status in {"not_run", "passed"} else "failed"
         final_dir = resolved_done_dir if final_status == "done" else resolved_failed_dir
         final_file = _move_payload(running_file, final_dir)
 
@@ -231,6 +313,7 @@ def run_queue_once(
             report_file=str(report_file),
             validation_status=validation_status,
             validation_reports=validation_reports,
+            commit_preparation=commit_preparation,
             **summary,
         )
     except Exception as exc:


### PR DESCRIPTION
## Summary

Adds commit preparation reporting to the OpenHands queue runner.

This does not commit, push, merge, or open PRs. It only produces a safe commit-ready plan after a successful queue task.

## Depends on

```text
#213 — Add queue local validations
```

## Changed files

```text
tools/skeleton_core/openhands_queue_runner.py
tests/skeleton_core/test_openhands_queue_runner.py
```

## What changed

```text
Adds OpenHandsQueueCommitPreparationReport
Adds commit_preparation to OpenHandsQueueRunReport
Marks commit_preparation.status=ready only when:
  queue status is done
  dispatch result is success
  local validations passed or were not configured
  changed_files is non-empty
  outside_allowed_changes is empty
Blocks commit preparation when result is not safe to commit
Adds suggested_commit_message from queue payload title
Writes commit_preparation into queue report JSON
Adds tests for ready, validation-blocked, and no-change blocked states
```

## Validation

```text
black: passed
ruff: passed
pytest tests/skeleton_core/test_openhands_queue_runner.py tests/skeleton_core/test_local_tool_runner.py tests/skeleton_core/test_openhands_dispatch_cli.py: 31 passed
```

## Safety

```text
does not commit
does not push
does not merge
does not open PRs
does not call GitHub API
does not mutate labels
does not read .env
does not print secrets
does not touch production/server/DB
only reports whether a later explicit commit step would be safe
```

## Boundary

This PR adds commit preparation reporting only. Actual commit creation remains a separate explicit opt-in follow-up.