### PR TITLE
feat(skeleton): wire OpenHands route through live-run guard

### DIFF
--- a/tests/skeleton_core/test_openhands_runner_route.py
+++ b/tests/skeleton_core/test_openhands_runner_route.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from tools.skeleton_core.adapter_contract import AdapterTaskPacket, FuelPolicy
+from tools.skeleton_core.openhands_live_run_guard import OpenHandsLiveRunGuardReport
 from tools.skeleton_core.openhands_runner_route import (
     OpenHandsRunnerRouteConfig,
     load_openrouter_key,
@@ -71,6 +72,7 @@ def test_route_writes_task_and_runs_injected_runner(tmp_path: Path) -> None:
     assert calls[0][1]["LLM_API_KEY"] == "sk-or-test-value"
     assert "sk-or-test-value" not in report.model_dump_json()
     assert report.returncode == 0
+    assert report.live_run is None
     assert report.result.result_validation.status == "valid_adapter_result"
 
 
@@ -114,3 +116,123 @@ def test_route_failed_runner_returns_failed_result(tmp_path: Path) -> None:
     assert report.result.result.status == "failed"
     assert report.result.result_validation.status == "valid_adapter_result"
     assert report.stderr_tail == "failed"
+
+
+def test_route_uses_live_run_guard_report_for_success(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    calls: list[tuple[list[str], dict[str, str], OpenHandsRunnerRouteConfig]] = []
+
+    def fake_live_run(
+        command: list[str],
+        env: dict[str, str],
+        config: OpenHandsRunnerRouteConfig,
+    ) -> OpenHandsLiveRunGuardReport:
+        calls.append((command, env, config))
+        return OpenHandsLiveRunGuardReport(
+            status="completed",
+            returncode=0,
+            timed_out=False,
+            timeout_seconds=config.timeout_seconds,
+            stdout_log_path=str(tmp_path / "stdout.log"),
+            stderr_log_path=str(tmp_path / "stderr.log"),
+            stdout_tail="done",
+            stderr_tail="",
+        )
+
+    report = run_openhands_route(
+        valid_packet(),
+        config=OpenHandsRunnerRouteConfig(task_file=task_file, secret_file=secret_file),
+        live_run=fake_live_run,
+        changed_files=["tools/skeleton_core/openhands_runner_route.py"],
+        artifact_paths=["artifacts/openhands-runner-route-v0.diff"],
+    )
+
+    assert calls
+    assert calls[0][1]["LLM_API_KEY"] == "sk-or-test-value"
+    assert report.live_run is not None
+    assert report.returncode == 0
+    assert report.stdout_tail == "done"
+    assert report.result.result.status == "success"
+    assert report.result.result_validation.status == "valid_adapter_result"
+    assert "sk-or-test-value" not in report.model_dump_json()
+
+
+def test_route_maps_live_run_timeout_to_failed_report(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    def fake_live_run(
+        command: list[str],
+        env: dict[str, str],
+        config: OpenHandsRunnerRouteConfig,
+    ) -> OpenHandsLiveRunGuardReport:
+        return OpenHandsLiveRunGuardReport(
+            status="timeout",
+            returncode=None,
+            timed_out=True,
+            timeout_seconds=config.timeout_seconds,
+            stdout_log_path=str(tmp_path / "stdout.log"),
+            stderr_log_path=str(tmp_path / "stderr.log"),
+            stdout_tail="partial",
+            stderr_tail="slow",
+            cleanup_attempted=True,
+            cleanup_succeeded=True,
+            cleanup_command=["tmux", "-Lopenhands", "kill-session", "-t", "openhands-pool-test"],
+        )
+
+    report = run_openhands_route(
+        valid_packet(),
+        config=OpenHandsRunnerRouteConfig(
+            task_file=task_file,
+            secret_file=secret_file,
+            timeout_seconds=7,
+        ),
+        live_run=fake_live_run,
+        changed_files=[],
+        artifact_paths=[],
+    )
+
+    assert report.returncode is None
+    assert report.timed_out is True
+    assert report.live_run is not None
+    assert report.live_run.status == "timeout"
+    assert report.result.result.status == "failed"
+    assert report.result.result.stop_reason == "openhands_timeout"
+    assert report.result.result_validation.status == "valid_adapter_result"
+
+
+def test_route_maps_cleanup_failed_to_failed_report(tmp_path: Path) -> None:
+    secret_file = tmp_path / "openrouter.env"
+    task_file = tmp_path / "task.md"
+    secret_file.write_text("OPENROUTER_API_KEY='sk-or-test-value'\n", encoding="utf-8")
+
+    def fake_live_run(
+        command: list[str],
+        env: dict[str, str],
+        config: OpenHandsRunnerRouteConfig,
+    ) -> OpenHandsLiveRunGuardReport:
+        return OpenHandsLiveRunGuardReport(
+            status="cleanup_failed",
+            returncode=None,
+            timed_out=True,
+            timeout_seconds=config.timeout_seconds,
+            stdout_log_path=str(tmp_path / "stdout.log"),
+            stderr_log_path=str(tmp_path / "stderr.log"),
+            cleanup_attempted=True,
+            cleanup_succeeded=False,
+            cleanup_error="cleanup_returncode=1",
+        )
+
+    report = run_openhands_route(
+        valid_packet(),
+        config=OpenHandsRunnerRouteConfig(task_file=task_file, secret_file=secret_file),
+        live_run=fake_live_run,
+    )
+
+    assert report.result.result.status == "failed"
+    assert report.result.result.stop_reason == "openhands_cleanup_failed"
+    assert report.result.result_validation.status == "valid_adapter_result"

--- a/tools/skeleton_core/openhands_runner_route.py
+++ b/tools/skeleton_core/openhands_runner_route.py
@@ -1,6 +1,6 @@
 """OpenHands runner route v0 for Skeleton.
 
-This module bridges the OpenHands adapter to an injectable process runner.
+This module bridges the OpenHands adapter to a bounded live-run guard.
 It is designed so tests can validate behavior without launching real OpenHands.
 
 It does not merge, deploy, restart services, mutate GitHub labels, or read .env.
@@ -24,6 +24,11 @@ from tools.skeleton_core.openhands_adapter import (
     build_openhands_result,
     prepare_openhands_task,
 )
+from tools.skeleton_core.openhands_live_run_guard import (
+    OpenHandsLiveRunGuardConfig,
+    OpenHandsLiveRunGuardReport,
+    run_openhands_live_guard,
+)
 
 OPENHANDS_RUNNER_ROUTE_VERSION = "openhands_runner_route.v0"
 
@@ -38,6 +43,10 @@ class OpenHandsRunnerRouteConfig(BaseModel):
     task_file: Path = Path("/tmp/skeleton-openhands-task.md")
     secret_file: Path = DEFAULT_SECRET_FILE
     adapter_config: OpenHandsAdapterConfig = Field(default_factory=OpenHandsAdapterConfig)
+    timeout_seconds: int = 120
+    stdout_log_file: Path = Path("/tmp/skeleton-openhands-live-run.stdout.log")
+    stderr_log_file: Path = Path("/tmp/skeleton-openhands-live-run.stderr.log")
+    openhands_tmux_session_name: str | None = None
 
 
 class OpenHandsRunnerRouteReport(BaseModel):
@@ -48,12 +57,20 @@ class OpenHandsRunnerRouteReport(BaseModel):
     route_version: str = OPENHANDS_RUNNER_ROUTE_VERSION
     prepared: OpenHandsPreparedTask
     result: OpenHandsValidatedResult
-    returncode: int
+    returncode: int | None
     stdout_tail: str = ""
     stderr_tail: str = ""
+    timed_out: bool = False
+    stdout_log_path: str = ""
+    stderr_log_path: str = ""
+    live_run: OpenHandsLiveRunGuardReport | None = None
 
 
 RunnerFn = Callable[[list[str], dict[str, str]], subprocess.CompletedProcess[str]]
+LiveRunFn = Callable[
+    [list[str], dict[str, str], OpenHandsRunnerRouteConfig],
+    OpenHandsLiveRunGuardReport,
+]
 
 
 def _tail(value: str, limit: int = 4000) -> str:
@@ -89,8 +106,47 @@ def load_openrouter_key(secret_file: Path = DEFAULT_SECRET_FILE) -> str:
     return api_key
 
 
+def default_live_run(
+    command: list[str],
+    env: dict[str, str],
+    config: OpenHandsRunnerRouteConfig,
+) -> OpenHandsLiveRunGuardReport:
+    """Run OpenHands through the bounded live-run guard."""
+
+    def guarded_runner(
+        guarded_command: list[str],
+        timeout_seconds: int,
+    ) -> subprocess.CompletedProcess[str]:
+        merged_env = os.environ.copy()
+        merged_env.update(env)
+        return subprocess.run(
+            guarded_command,
+            env=merged_env,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+
+    api_key = env.get("LLM_API_KEY", "")
+    return run_openhands_live_guard(
+        command,
+        config=OpenHandsLiveRunGuardConfig(
+            timeout_seconds=config.timeout_seconds,
+            stdout_log_file=config.stdout_log_file,
+            stderr_log_file=config.stderr_log_file,
+            openhands_tmux_session_name=config.openhands_tmux_session_name,
+            secret_redaction_values=[api_key] if api_key else [],
+        ),
+        command_runner=guarded_runner,
+    )
+
+
 def default_runner(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    """Run OpenHands command with a merged environment."""
+    """Compatibility runner for injected unit tests.
+
+    Real route execution should use default_live_run.
+    """
 
     merged_env = os.environ.copy()
     merged_env.update(env)
@@ -103,18 +159,35 @@ def default_runner(command: list[str], env: dict[str, str]) -> subprocess.Comple
     )
 
 
+def _status_from_live_report(
+    live_report: OpenHandsLiveRunGuardReport,
+) -> tuple[str, str, str]:
+    if live_report.status == "completed" and live_report.returncode == 0:
+        return "success", "passed", "openhands_returncode=0"
+    if live_report.status == "no_changes":
+        return "blocked", "blocked", "openhands_no_changes"
+    if live_report.status == "timeout":
+        return "failed", "failed", "openhands_timeout"
+    if live_report.status == "cleanup_failed":
+        return "failed", "failed", "openhands_cleanup_failed"
+    if live_report.returncode is not None:
+        return "failed", "failed", f"openhands_returncode={live_report.returncode}"
+    return "failed", "failed", f"openhands_status={live_report.status}"
+
+
 def run_openhands_route(
     packet: AdapterTaskPacket,
     *,
     config: OpenHandsRunnerRouteConfig | None = None,
-    runner: RunnerFn = default_runner,
+    runner: RunnerFn | None = None,
+    live_run: LiveRunFn = default_live_run,
     changed_files: list[str] | None = None,
     artifact_paths: list[str] | None = None,
 ) -> OpenHandsRunnerRouteReport:
     """Prepare, run, and validate a bounded OpenHands task.
 
     `changed_files` and `artifact_paths` are supplied by the caller or a later
-    collector layer. This v0 route intentionally avoids scanning arbitrary files.
+    collector layer. This route intentionally avoids scanning arbitrary files.
     """
 
     resolved = config or OpenHandsRunnerRouteConfig()
@@ -124,10 +197,29 @@ def run_openhands_route(
 
     api_key = load_openrouter_key(resolved.secret_file)
     env = build_openhands_env(api_key, resolved.adapter_config)
-    completed = runner(prepared.command, env)
 
-    executor_status = "success" if completed.returncode == 0 else "failed"
-    validation_status = "passed" if completed.returncode == 0 else "failed"
+    live_report: OpenHandsLiveRunGuardReport | None = None
+
+    if runner is not None:
+        completed = runner(prepared.command, env)
+        returncode: int | None = completed.returncode
+        stdout_tail = _tail(completed.stdout or "")
+        stderr_tail = _tail(completed.stderr or "")
+        timed_out = False
+        stdout_log_path = ""
+        stderr_log_path = ""
+        executor_status = "success" if completed.returncode == 0 else "failed"
+        validation_status = "passed" if completed.returncode == 0 else "failed"
+        stop_reason = f"openhands_returncode={completed.returncode}"
+    else:
+        live_report = live_run(prepared.command, env, resolved)
+        returncode = live_report.returncode
+        stdout_tail = live_report.stdout_tail
+        stderr_tail = live_report.stderr_tail
+        timed_out = live_report.timed_out
+        stdout_log_path = live_report.stdout_log_path
+        stderr_log_path = live_report.stderr_log_path
+        executor_status, validation_status, stop_reason = _status_from_live_report(live_report)
 
     validated = build_openhands_result(
         packet,
@@ -136,13 +228,17 @@ def run_openhands_route(
         artifact_paths=artifact_paths or [],
         validation_status=validation_status,
         risk_flags=[],
-        stop_reason=f"openhands_returncode={completed.returncode}",
+        stop_reason=stop_reason,
     )
 
     return OpenHandsRunnerRouteReport(
         prepared=prepared,
         result=validated,
-        returncode=completed.returncode,
-        stdout_tail=_tail(completed.stdout or ""),
-        stderr_tail=_tail(completed.stderr or ""),
+        returncode=returncode,
+        stdout_tail=stdout_tail,
+        stderr_tail=stderr_tail,
+        timed_out=timed_out,
+        stdout_log_path=stdout_log_path,
+        stderr_log_path=stderr_log_path,
+        live_run=live_report,
     )


### PR DESCRIPTION
Closes #220.

Wires the OpenHands runner route through the bounded live-run guard.

Validation:
- python -m pytest tests/skeleton_core/test_openhands_runner_route.py -q → 8 passed
- python -m pytest -q → 428 passed
- python -m ruff check tools/skeleton_core tests/skeleton_core → passed
- python -m black --check tools/skeleton_core tests/skeleton_core → passed

Safety:
- no real OpenHands call in tests
- route uses injected live_run in tests
- timeout and cleanup statuses are mapped into structured route reports
- API key is not exposed in model_dump_json()
- no daemon changes
- no push/merge/deploy automation