### PR TITLE
fix(skeleton): run OpenHands in headless JSON mode

### DIFF
--- a/tests/skeleton_core/test_openhands_adapter.py
+++ b/tests/skeleton_core/test_openhands_adapter.py
@@ -63,7 +63,15 @@ def test_command_is_exact_openhands_command() -> None:
 
     command = build_openhands_command("/tmp/task.md", config)
 
-    assert command == ["/bin/openhands", "--override-with-envs", "-f", "/tmp/task.md"]
+    assert command == [
+        "/bin/openhands",
+        "--headless",
+        "--json",
+        "--exit-without-confirmation",
+        "--override-with-envs",
+        "-f",
+        "/tmp/task.md",
+    ]
 
 
 def test_env_builder_keeps_secret_out_of_prepared_metadata() -> None:

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -121,6 +121,9 @@ def build_openhands_command(
     resolved = config or OpenHandsAdapterConfig()
     return [
         resolved.executable,
+        "--headless",
+        "--json",
+        "--exit-without-confirmation",
         "--override-with-envs",
         "-f",
         task_file,


### PR DESCRIPTION
Makes the OpenHands adapter build a headless JSON command instead of launching the default TUI.

Context:
- OpenHands defaults to textual UI mode.
- Guarded smoke showed timeout because the TUI waited for input.
- OpenHands help documents --headless and --json for non-UI operation.

Validation:
- python -m pytest tests/skeleton_core/test_openhands_adapter.py tests/skeleton_core/test_openhands_runner_route.py -q → 17 passed
- python -m pytest -q → 428 passed
- python -m ruff check tools/skeleton_core tests/skeleton_core → passed
- python -m black --check tools/skeleton_core tests/skeleton_core → passed

Safety:
- no real OpenHands call in tests
- keeps live-run guard in route
- no daemon changes
- no push/merge/deploy automation