### PR TITLE
fix(skeleton): use OpenRouter free routing model

### DIFF
--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -28,7 +28,7 @@ class OpenHandsAdapterConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     executable: str = "/home/agent/.local/bin/openhands"
-    model: str = "deepseek/deepseek-v4-flash:free"
+    model: str = "openrouter/free"
     base_url: str = "https://openrouter.ai/api/v1"
     suppress_banner: bool = True
 

--- a/tools/skeleton_core/openhands_issue_dispatch.py
+++ b/tools/skeleton_core/openhands_issue_dispatch.py
@@ -61,7 +61,7 @@ class OpenHandsIssuePayload(BaseModel):
     authority_level: str = "level_2_local_diff"
     risk_level: str = "yellow"
     fuel_provider: str = "openrouter"
-    fuel_model: str = "deepseek/deepseek-v4-flash:free"
+    fuel_model: str = "openrouter/free"
     fuel_max_usd: float = 1.0
 
 


### PR DESCRIPTION
Switches the default OpenHands/OpenRouter model from deepseek/deepseek-v4-flash:free to openrouter/free.

Context:
- new OpenRouter key is valid
- deepseek/deepseek-v4-flash:free returned upstream 429
- several concrete free models returned upstream 429
- openrouter/free returned a successful chat.completion with choices

Validation:
- python -m pytest tests/skeleton_core/test_openhands_adapter.py tests/skeleton_core/test_openhands_issue_dispatch.py tests/skeleton_core/test_openhands_dispatch_cli.py tests/skeleton_core/test_openhands_dispatch_cli_hook.py -q → 21 passed
- python -m pytest -q → 428 passed
- python -m ruff check tools/skeleton_core tests/skeleton_core → passed
- python -m black --check tools/skeleton_core tests/skeleton_core → passed

Safety:
- no real OpenHands call in tests
- no secret changes
- no daemon changes
- no push/merge/deploy automation