### PR TITLE
fix(skeleton): pass OpenHands task as headless task argument

### DIFF
--- a/tests/skeleton_core/test_openhands_adapter.py
+++ b/tests/skeleton_core/test_openhands_adapter.py
@@ -35,7 +35,8 @@ def test_valid_packet_prepares_task() -> None:
 
     assert prepared.adapter_version == OPENHANDS_ADAPTER_VERSION
     assert prepared.task_validation.status == "valid_task_packet"
-    assert prepared.command[-2:] == ["-f", "/tmp/task.md"]
+    assert "--task" in prepared.command
+    assert "Create OpenHands adapter v0." in prepared.command[-1]
 
 
 def test_invalid_packet_returns_blocked_task_validation() -> None:
@@ -69,7 +70,7 @@ def test_command_is_exact_openhands_command() -> None:
         "--json",
         "--exit-without-confirmation",
         "--override-with-envs",
-        "-f",
+        "--task",
         "/tmp/task.md",
     ]
 

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -113,7 +113,7 @@ Hard boundaries:
 
 
 def build_openhands_command(
-    task_file: str,
+    task_text: str,
     config: OpenHandsAdapterConfig | None = None,
 ) -> list[str]:
     """Build the OpenHands CLI command."""
@@ -125,8 +125,8 @@ def build_openhands_command(
         "--json",
         "--exit-without-confirmation",
         "--override-with-envs",
-        "-f",
-        task_file,
+        "--task",
+        task_text,
     ]
 
 
@@ -162,9 +162,10 @@ def prepare_openhands_task(
     task_validation = validate_task_packet(packet)
     env_keys = sorted(build_openhands_env("__redacted__", resolved).keys())
 
+    task_text = build_openhands_task_text(packet)
     return OpenHandsPreparedTask(
-        task_text=build_openhands_task_text(packet),
-        command=build_openhands_command(task_file, resolved),
+        task_text=task_text,
+        command=build_openhands_command(task_text, resolved),
         env_keys=env_keys,
         task_validation=task_validation,
     )


### PR DESCRIPTION
Switches OpenHands headless execution from file context mode to explicit task mode.

Context:
- guarded smoke showed OpenHands treated `-f /tmp/skeleton-openhands-task.md` as file context
- OpenHands initialized and exited without editing files
- `--task` should pass the actual task instruction to the headless executor

Validation:
- python -m pytest tests/skeleton_core/test_openhands_adapter.py tests/skeleton_core/test_openhands_runner_route.py -q → 18 passed
- python -m pytest -q → 429 passed
- python -m ruff check tools/skeleton_core tests/skeleton_core → passed
- python -m black --check tools/skeleton_core tests/skeleton_core → passed

Safety:
- no real OpenHands call in tests
- no secret changes
- no daemon changes
- no push/merge/deploy automation
