### PR TITLE
fix(skeleton): harden OpenHands bounded task instructions

### DIFF
--- a/tests/skeleton_core/test_openhands_adapter.py
+++ b/tests/skeleton_core/test_openhands_adapter.py
@@ -57,6 +57,9 @@ def test_task_text_contains_scope_and_boundaries() -> None:
     assert "Do not read .env, .git, .ssh" in text
     assert "Do not install packages" in text
     assert "Do not push, merge, deploy" in text
+    assert "always include security_risk" in text
+    assert 'security_risk="LOW"' in text
+    assert "Do not run demo commands" in text
 
 
 def test_command_is_exact_openhands_command() -> None:

--- a/tools/skeleton_core/openhands_adapter.py
+++ b/tools/skeleton_core/openhands_adapter.py
@@ -108,6 +108,12 @@ Hard boundaries:
 - Do not install packages.
 - Do not push, merge, deploy, restart services, or change labels.
 - Do not read or edit files outside the allowed files list.
+- Do not run demo commands such as echo Hello World.
+- Prefer file_editor for allowed file edits.
+- When calling any OpenHands tool, always include security_risk.
+- Use security_risk="LOW" for viewing or editing explicitly allowed documentation files.
+- Use security_risk="LOW" for harmless git status or git diff inspection.
+- Never use security_risk="HIGH" in this bounded smoke path.
 - Return changed files, validation result, git diff summary, and stop.
 """
 


### PR DESCRIPTION
Hardens the bounded OpenHands task instructions.

Scope:
- requires security_risk in OpenHands tool calls
- marks allowed documentation edits and harmless git inspection as LOW risk
- forbids demo commands such as echo Hello World
- keeps the bounded smoke path from using HIGH risk
- updates adapter test expectations

Validation already run before commit:
- pytest: 429 passed
- ruff: passed
- black --check: passed

No deployment.
No service changes.
No secrets.
No merge.