### PR TITLE
Draft: add deep-diff-audit-pack CLI wiring

### DIFF
--- a/tests/skeleton_core/test_deep_diff_audit_pack_cli.py
+++ b/tests/skeleton_core/test_deep_diff_audit_pack_cli.py
@@ -1,0 +1,69 @@
+import json
+
+from tools.skeleton_core import cli
+
+
+def test_deep_diff_audit_pack_cli_prints_packet_json(tmp_path, capsys) -> None:
+    input_path = tmp_path / "packet_input.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "subject": {
+                    "repo": "alanua/jeeves",
+                    "issue_number": 178,
+                    "title": "CLI wiring for deep-diff audit packet builder",
+                },
+                "sources": [
+                    {
+                        "source_type": "issue_body",
+                        "source_ref": "alanua/jeeves#178",
+                        "content": "Already-prepared public-safe issue body excerpt.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["deep-diff-audit-pack", "--input", str(input_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["schema_version"] == "deep-diff-evidence-packet/v1"
+    assert payload["subject"]["repo"] == "alanua/jeeves"
+    assert payload["subject"]["issue_number"] == 178
+    assert payload["sources"][0]["source_ref"] == "alanua/jeeves#178"
+    assert payload["sources"][0]["excerpt"] == "Already-prepared public-safe issue body excerpt."
+
+
+def test_deep_diff_audit_pack_cli_returns_nonzero_for_validation_errors(tmp_path, capsys) -> None:
+    input_path = tmp_path / "packet_input.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "sources": [
+                    {
+                        "source_type": "issue_body",
+                        "source_ref": "alanua/jeeves#178",
+                        "content": "Missing subject should fail validation.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["deep-diff-audit-pack", "--input", str(input_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert payload["ok"] is False
+    assert payload["error"] == "input_validation_failed"
+    assert payload["input"].endswith("packet_input.json")
+    assert payload["detail"][0]["loc"] == ["subject"]

--- a/tools/skeleton_core/cli.py
+++ b/tools/skeleton_core/cli.py
@@ -102,6 +102,7 @@ SUBCOMMANDS = {
     "capability-request-broker",
     "checkpoint",
     "classify-queue",
+    "deep-diff-audit-pack",
     "decide",
     "format-preflight",
     "github-actions-runner-control",
@@ -368,6 +369,15 @@ def _subcommand_parser() -> argparse.ArgumentParser:
         help="Classify offline queue JSON items",
     )
     _add_input_arg(classify_queue_parser, "Path to public-safe queue JSON")
+
+    deep_diff_audit_pack_parser = subparsers.add_parser(
+        "deep-diff-audit-pack",
+        help="Build a public-safe deep-diff evidence packet from JSON",
+    )
+    _add_input_arg(
+        deep_diff_audit_pack_parser,
+        "Path to public-safe deep-diff evidence packet JSON",
+    )
 
     decide_parser = subparsers.add_parser("decide", help="Build a Skeleton task decision packet")
     _add_decide_args(decide_parser)
@@ -713,6 +723,12 @@ def _run_classify_queue(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_deep_diff_audit_pack(args: argparse.Namespace) -> int:
+    from tools.skeleton_core.cli_deep_diff_audit_pack import main as deep_diff_audit_pack_main
+
+    return deep_diff_audit_pack_main(["--input", str(args.input)])
+
+
 def _run_format_preflight(args: argparse.Namespace) -> int:
     try:
         if args.input is not None:
@@ -1032,6 +1048,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_checkpoint(args)
     if args.command == "classify-queue":
         return _run_classify_queue(args)
+    if args.command == "deep-diff-audit-pack":
+        return _run_deep_diff_audit_pack(args)
     if args.command == "format-preflight":
         return _run_format_preflight(args)
     if args.command == "github-actions-runner-control":

--- a/tools/skeleton_core/cli_deep_diff_audit_pack.py
+++ b/tools/skeleton_core/cli_deep_diff_audit_pack.py
@@ -1,0 +1,65 @@
+"""CLI wiring for the public-safe deep-diff audit packet builder."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from tools.skeleton_core.deep_diff_audit_pack import (
+    build_deep_diff_audit_pack_from_json,
+    packet_to_json_dict,
+)
+
+
+def _print_error(payload: dict[str, object]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2), file=sys.stderr, flush=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a public-safe deep-diff evidence packet from JSON."
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to public-safe deep-diff evidence packet JSON",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        raw_json = args.input.read_text(encoding="utf-8")
+    except OSError as err:
+        _print_error(
+            {
+                "ok": False,
+                "error": "input_read_failed",
+                "input": str(args.input),
+                "detail": str(err),
+            }
+        )
+        return 1
+
+    try:
+        packet = build_deep_diff_audit_pack_from_json(raw_json)
+    except ValidationError as err:
+        _print_error(
+            {
+                "ok": False,
+                "error": "input_validation_failed",
+                "input": str(args.input),
+                "detail": err.errors(include_url=False),
+            }
+        )
+        return 2
+
+    print(json.dumps(packet_to_json_dict(packet), ensure_ascii=False, indent=2), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Fresh rerun from current `main`.

Added the `deep-diff-audit-pack` CLI wiring so:

```bash
python -m tools.skeleton_core.cli deep-diff-audit-pack --input packet_input.json
```

now reads an already-prepared public-safe JSON input file and prints the deep-diff evidence packet as formatted JSON.

Behavior stays bounded to CLI wiring only:
- success: packet JSON to stdout
- input read failure: non-zero with useful error JSON
- input validation failure: non-zero with useful error JSON

## Files changed
- `tools/skeleton_core/cli.py`
- `tools/skeleton_core/cli_deep_diff_audit_pack.py`
- `tests/skeleton_core/test_deep_diff_audit_pack_cli.py`

## Validation run
```text
$ python -m pytest -q tests/skeleton_core/test_deep_diff_audit_pack.py tests/skeleton_core/test_deep_diff_audit_pack_cli.py
.......                                                                  [100%]
7 passed in 0.21s
```

```text
$ python -m ruff check tools/skeleton_core/deep_diff_audit_pack.py tools/skeleton_core/cli_deep_diff_audit_pack.py tools/skeleton_core/cli.py tests/skeleton_core/test_deep_diff_audit_pack.py tests/skeleton_core/test_deep_diff_audit_pack_cli.py
All checks passed!
```

```text
$ python -m black --check tools/skeleton_core/deep_diff_audit_pack.py tools/skeleton_core/cli_deep_diff_audit_pack.py tools/skeleton_core/cli.py tests/skeleton_core/test_deep_diff_audit_pack.py tests/skeleton_core/test_deep_diff_audit_pack_cli.py
All done! ✨ 🍰 ✨
5 files would be left unchanged.
```

```text
$ git diff --check
(exit 0, no output)
```

```text
$ git status --short
(exit 0, no output)
```

## Evidence collected
Preflight on a fresh clone of current `main` before edits:

```text
$ git fetch origin
$ git checkout main
Your branch is up to date with 'origin/main'.
Already on 'main'

$ git pull --ff-only
Already up to date.

$ git status --short
(exit 0, no output)

$ git rev-parse --short HEAD
da47a62

$ ls tools/skeleton_core/deep_diff_audit_pack.py
C:\Users\alanu\AppData\Local\Temp\jeeves-178-fresh-clone\tools\skeleton_core\deep_diff_audit_pack.py

$ ls tools/skeleton_core/cli.py
C:\Users\alanu\AppData\Local\Temp\jeeves-178-fresh-clone\tools\skeleton_core\cli.py
```

Behavior evidence covered by tests:
- CLI success path emits packet JSON through `tools.skeleton_core.cli` subcommand dispatch
- validation failure returns non-zero and emits structured error details

## Scope confirmation
- worked only inside the allowed files listed in the task packet
- did not change `tools/skeleton_core/deep_diff_audit_pack.py`
- no GitHub fetching
- no source collection from issues/PRs/files
- no runner execution
- no host-local script reads
- no systemd changes
- no environment or secret reads
- no external API calls
- no deploy
- draft PR only, no merge

## Known limitations
- This command wires only already-prepared public-safe JSON input into the existing builder.
- It does not collect sources, fetch GitHub data, or inspect runtime state.

## Next safe step
If reviewers want broader CLI assurance, the next bounded follow-up would be a separate subprocess-level smoke test for `python -m tools.skeleton_core.cli deep-diff-audit-pack ...`, still without adding any fetching or live-environment behavior.
