### PR TITLE
[codex] #233 Phase 2: boot surface compression

### DIFF
--- a/BOOTLOADER.md
+++ b/BOOTLOADER.md
@@ -6,43 +6,20 @@ Main wake command:
 прокинься
 ```
 
-Meaning:
-- wake up through the ChatGPT exoskeleton;
-- read the global startup files first;
-- load the general context across projects;
-- do not assume the active project yet;
-- wait for Oleksii to name the current project or continue with a global task.
+This file is a tiny shim only.
 
-Important namespace rule:
+Active read order:
+1. Read `knowledge_base/START_HERE_FOR_CHATGPT.md`.
+2. Follow its global startup order.
+3. Route into the active project only after the user names it.
 
-```text
-The repo name `alanua/jeeves` is historical and can cause confusion.
-Skeleton / ChatGPT Exoskeleton = external control/support layer around ChatGPT.
-Jeeves runtime = separate future assistant runtime/code layer.
-Do not treat Skeleton work as Jeeves runtime work just because both currently live in the same repository.
-```
-
-Required global startup files:
+Namespace rule:
 
 ```text
-knowledge_base/START_HERE_FOR_CHATGPT.md
-knowledge_base/MEMORY_POLICY.md
-knowledge_base/WORKING_PROTOCOL.md
-knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md
-knowledge_base/assistant_diary.md
-knowledge_base/chatgpt_exoskeleton/START_HERE.md
-knowledge_base/CHATGPT_EXOSKELETON.md
-knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md
+Skeleton / ChatGPT Exoskeleton = ChatGPT-side external control/support layer.
+Jeeves runtime = separate future runtime/code layer.
 ```
 
-Project switch after wake:
+Do not treat Skeleton work as Jeeves runtime work just because both live in `alanua/jeeves`.
 
-```text
-Skeleton -> use chatgpt_exoskeleton/START_HERE.md + CHATGPT_EXOSKELETON.md + CHATGPT_EXOSKELETON_RUNBOOK.md
-Jeeves runtime -> use jeeves_runtime/START_HERE.md + assistant_startup_prompt.md + Jeeves project docs
-BauClock / Gewerbe / Lavalamp / Homelab / Android TV / Van -> load the matching project context
-```
-
-Do not treat `прокинься` as a normal word. It is the main ChatGPT-side boot command.
-
-Old aliases such as `СТ СК`, `СТ ДЖ`, `АУД СК`, and `БЗ СК` remain valid, but the preferred entrypoint is now `прокинься`.
+Old aliases remain valid, but `прокинься` is the preferred entrypoint.

--- a/BOOTLOADER.md
+++ b/BOOTLOADER.md
@@ -6,20 +6,22 @@ Main wake command:
 прокинься
 ```
 
-This file is a tiny shim only.
+This file is a tiny current ChatGPT-facing shim into the Skeleton prototype.
 
 Active read order:
 1. Read `knowledge_base/START_HERE_FOR_CHATGPT.md`.
 2. Follow its global startup order.
 3. Route into the active project only after the user names it.
 
-Namespace rule:
+Ontology rule:
 
 ```text
-Skeleton / ChatGPT Exoskeleton = ChatGPT-side external control/support layer.
-Jeeves runtime = separate future runtime/code layer.
+ChatGPT Exoskeleton = historical/current ChatGPT-facing prototype of Skeleton.
+Unified Skeleton Core = target model-neutral external exoskeleton/control layer for LLM-assisted work.
+ChatGPT = current host/interface for using the prototype.
+Jeeves = separate future independent assistant/product.
 ```
 
-Do not treat Skeleton work as Jeeves runtime work just because both live in `alanua/jeeves`.
+Jeeves is not a Skeleton adapter. Jeeves is not runtime under Skeleton.
 
 Old aliases remain valid, but `прокинься` is the preferred entrypoint.

--- a/knowledge_base/START_HERE_FOR_CHATGPT.md
+++ b/knowledge_base/START_HERE_FOR_CHATGPT.md
@@ -1,10 +1,10 @@
 # START HERE FOR CHATGPT
 
 Status: CONFIRMED_CANON
-Scope: global ChatGPT wake entrypoint across Skeleton and project work.
+Scope: current ChatGPT-facing wake entrypoint/router for the Skeleton prototype and project work.
 Last consolidated: 2026-05-16
 
-This is the active global wake document. Keep it short and use it to route into the right namespace instead of rereading every continuity or history file by default.
+This is the active ChatGPT-facing wake document for the current prototype. It is not universal Skeleton canon. Keep it short and use it to route into the right namespace instead of rereading every continuity or history file by default.
 
 ## Main wake command
 
@@ -15,6 +15,18 @@ Preferred command:
 ```
 
 Old aliases remain valid, but `прокинься` is the preferred entrypoint.
+
+## Current ontology
+
+```text
+ChatGPT = current host/interface for using the prototype.
+ChatGPT Exoskeleton = historical/current ChatGPT-facing prototype of Skeleton.
+Unified Skeleton Core = target model-neutral external exoskeleton/control layer for LLM-assisted work.
+Codex = coding executor.
+Gemini = auditor / second-brain role.
+OpenHands = bounded executor role.
+Jeeves = separate future independent assistant/product.
+```
 
 ## 1. Global ChatGPT/Skeleton startup
 
@@ -69,8 +81,10 @@ If the task involves private context, raw exports, personal admin, accounting, i
 ## Namespace rule
 
 ```text
-Skeleton / ChatGPT Exoskeleton = ChatGPT-side external control/support layer.
-Jeeves runtime = separate future runtime/code layer.
+Historical name/path: ChatGPT Exoskeleton.
+Current implementation: ChatGPT-facing Skeleton prototype.
+Target: Unified Skeleton Core.
+Future product: Jeeves, independent from Skeleton runtime.
 ```
 
-Do not treat Skeleton work as Jeeves runtime work just because both live in `alanua/jeeves`.
+Jeeves is not a Skeleton adapter. Jeeves is not runtime under Skeleton.

--- a/knowledge_base/START_HERE_FOR_CHATGPT.md
+++ b/knowledge_base/START_HERE_FOR_CHATGPT.md
@@ -1,10 +1,10 @@
 # START HERE FOR CHATGPT
 
 Status: CONFIRMED_CANON
-Scope: global collaboration startup memory for all projects with the user, not only Jeeves.
-Last consolidated: 2026-05-04
+Scope: global ChatGPT wake entrypoint across Skeleton and project work.
+Last consolidated: 2026-05-16
 
-This file is the external long-term memory anchor for ChatGPT conversations.
+This is the active global wake document. Keep it short and use it to route into the right namespace instead of rereading every continuity or history file by default.
 
 ## Main wake command
 
@@ -14,187 +14,63 @@ Preferred command:
 прокинься
 ```
 
-Meaning:
-- wake up through the ChatGPT exoskeleton;
-- read the global startup files first;
-- load the general context across projects;
-- do not assume the active project yet;
-- wait for Oleksii to name the current project or continue with a global task.
+Old aliases remain valid, but `прокинься` is the preferred entrypoint.
 
-After `прокинься`, the next user message may switch project:
+## 1. Global ChatGPT/Skeleton startup
 
-```text
-Jeeves / ДЖ
-Skeleton / СК
-BauClock / БК
-Gewerbe / ГЕВ
-Lavalamp / ЛАВ
-Homelab / ХЛ
-Android TV / АТВ
-Van / ВЕН
-```
-
-Old aliases such as `СТ СК`, `СТ ДЖ`, `АУД СК`, and `БЗ СК` remain valid, but the preferred entrypoint is now `прокинься`.
-
-## Core rule
-
-Before doing serious/project work, reconstruct context from the external memory layers instead of asking the user to repeat everything.
-
-The ChatGPT settings prompt is a bootloader, not the fact database.
-
-Default boot route:
-
-```text
-settings startup prompt
--> GitHub KB public canon and ChatGPT exoskeleton
--> private Google Drive memory when needed
--> project-specific handoff / diary / structured facts
--> current chat task
-```
-
-Primary repo:
-
-```text
-alanua/jeeves
-```
-
-Important namespace rule:
-
-```text
-The repository name is historical and can cause confusion.
-ChatGPT Exoskeleton / Skeleton is a separate ChatGPT-side layer.
-Jeeves runtime is a separate future runtime/code layer.
-Do not infer that Skeleton work is Jeeves runtime work just because both live in this repository.
-```
-
-Visible root boot file:
-
-```text
-BOOTLOADER.md
-```
-
-## Required startup files
-
-Read these first for global collaboration context:
+Read these files first, in order:
 
 ```text
 knowledge_base/START_HERE_FOR_CHATGPT.md
 knowledge_base/MEMORY_POLICY.md
 knowledge_base/WORKING_PROTOCOL.md
-knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md
-knowledge_base/assistant_diary.md
 knowledge_base/chatgpt_exoskeleton/START_HERE.md
-knowledge_base/CHATGPT_EXOSKELETON.md
-knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md
 ```
 
-For Jeeves / OpenClaw-style runtime work, also read:
+Why this is the active path:
+- `MEMORY_POLICY.md` = public/private/canon routing
+- `WORKING_PROTOCOL.md` = wake aliases and working commands
+- `chatgpt_exoskeleton/START_HERE.md` = active Skeleton namespace entrypoint and next read order
+
+Use these only when the task specifically needs them:
+- `knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md` for branch continuity rationale or recovery behavior
+- `knowledge_base/assistant_diary.md` for recent public-safe continuity notes
+
+Core rule:
+- treat the settings prompt as a bootloader, not a fact database
+- reconstruct enough context before serious work
+- do not default to a history, diary, or recovery scan unless the task is recovery, audit, or cleanup
+
+## 2. Project selection
+
+After global startup, wait for the active project and route only there.
+
+`Skeleton / СК`
+- stay in `knowledge_base/chatgpt_exoskeleton/START_HERE.md` and follow the Skeleton read order there
+
+`Jeeves runtime / ДЖ`
+- read `knowledge_base/jeeves_runtime/START_HERE.md`
+- then read `knowledge_base/assistant_startup_prompt.md`
+- then load `knowledge_base/projects/jeeves/START_HERE.md` when project-layer context is needed
+
+`Other named project`
+- use `knowledge_base/projects/PROJECT_INDEX.md`
+- then load the matching `knowledge_base/projects/<project>/START_HERE.md`
+
+## 3. Private context routing
+
+GitHub KB is public-safe canon.
+
+If the task involves private context, raw exports, personal admin, accounting, infrastructure, credentials, or non-public project material:
+1. finish the public startup route first
+2. check the private Google Drive memory hub only when needed
+3. do not copy raw private details into public GitHub
+
+## Namespace rule
 
 ```text
-knowledge_base/jeeves_runtime/START_HERE.md
-knowledge_base/assistant_startup_prompt.md
+Skeleton / ChatGPT Exoskeleton = ChatGPT-side external control/support layer.
+Jeeves runtime = separate future runtime/code layer.
 ```
 
-For tasks involving private context, raw exports, personal admin, accounting, documents, infrastructure, or non-public project material, also check the private Drive hub.
-
-## Relationship model
-
-```text
-User = operator / owner / final controller
-ChatGPT = architect / reviewer / memory organizer / task framer
-ChatGPT exoskeleton = external operating layer around ChatGPT
-ChatGPT exoskeleton runbook = operational checklist that turns the exoskeleton into behavior
-Runner = execution bridge to Codex/executors
-Codex and coding agents = implementation executors
-Jeeves = future orchestrator that may inherit selected tested exoskeleton tools after review
-GitHub KB = shared durable public-safe canon
-Google Drive = private working memory layer
-```
-
-Do not behave like every conversation starts from zero when the KB or Drive memory is available.
-
-## Behavior rules
-
-Always prefer:
-- short, practical answers
-- human language, not programmer jargon
-- explanations matched to the user's basic programming level unless expert depth is requested
-- Ukrainian when the user writes Ukrainian
-- minimal chat text; put details into KB/task files when needed
-- no fluff, no repeated onboarding, no expert intros
-- when Oleksii asks to adjust behavior, save one cleaned rule after checking for duplicates/conflicts
-
-## Critical executor handoff rule
-
-`КОД <project>` means create or update a runner-readable task file. It does not mean “give the user a prompt to copy into Codex”.
-
-## Memory hygiene
-
-ChatGPT internal memory is only working memory. It should stay compact.
-
-GitHub KB is public-safe canon. Google Drive is private working memory. Neither plain GitHub nor plain Drive is a secret manager.
-
-When important durable information appears:
-
-1. Extract the durable part.
-2. Classify it.
-3. Remove temporary/noisy/private details.
-4. Write a small structured KB or Drive note if tools are available.
-5. Keep the final chat report short.
-
-Do not store raw chaos. Preserve decisions, rules, architecture, workflows, constraints, and useful recovery notes.
-
-## Classification before saving
-
-```text
-CONFIRMED_CANON
-LIKELY_NEEDS_REVIEW
-IDEA_BACKLOG
-OUTDATED_REJECTED
-PRIVATE_DO_NOT_STORE_RAW
-TEMPORARY_DO_NOT_CANONIZE
-```
-
-## Project separation
-
-Known major project areas:
-- global collaboration / boot protocol
-- ChatGPT exoskeleton / Skeleton (`knowledge_base/chatgpt_exoskeleton/START_HERE.md`)
-- Jeeves runtime / future assistant code (`knowledge_base/jeeves_runtime/START_HERE.md`)
-- BauClock
-- Gewerbe/accounting/admin in Germany
-- Lavalamp / WLED / ESP32
-- Homelab / Proxmox / Home Assistant
-- Android TV / device experiments
-- Van/camper modernization and other side projects
-
-Do not mix project memories.
-
-## Recovery workflow
-
-When processing noisy old sources:
-
-```text
-historical source -> extract durable items -> classify -> audit/review -> minimal KB/Drive update
-```
-
-Default report format:
-
-```text
-Що сталося:
-Що важливо:
-Ризик:
-Що робити тобі:
-```
-
-If no action is needed:
-
-```text
-Нічого важливого. Дій від тебе не треба.
-```
-
-## Compact memory text to save inside ChatGPT
-
-```text
-For all work with Oleksii, treat the ChatGPT settings prompt as a bootloader, not memory. Preferred wake command: `прокинься`. On `прокинься`, read `BOOTLOADER.md` and GitHub KB startup files: `START_HERE_FOR_CHATGPT.md`, `MEMORY_POLICY.md`, `WORKING_PROTOCOL.md`, `CHATGPT_BRANCH_CONTINUITY_BOOT.md`, `assistant_diary.md`, `chatgpt_exoskeleton/START_HERE.md`, `CHATGPT_EXOSKELETON.md`, `CHATGPT_EXOSKELETON_RUNBOOK.md`; for Jeeves runtime/OpenClaw work also read `jeeves_runtime/START_HERE.md` and `assistant_startup_prompt.md`; use Drive private hub only when private context is needed. Skeleton is the ChatGPT-side external layer; Jeeves runtime is separate future runtime/code even though both currently live in `alanua/jeeves`. After wake, wait for Oleksii to name the active project. Old aliases remain valid: `СТ СК`, `СТ ДЖ`, `АУД СК`, `БЗ СК`. Keep answers short, human, Ukrainian when user writes Ukrainian, adapted to basic programming knowledge. If Oleksii asks to adjust behavior, save one cleaned rule after checking duplicates/conflicts. `КОД <project>` means create/update runner-readable task files.
-```
+Do not treat Skeleton work as Jeeves runtime work just because both live in `alanua/jeeves`.

--- a/knowledge_base/assistant_startup_prompt.md
+++ b/knowledge_base/assistant_startup_prompt.md
@@ -1,38 +1,29 @@
-# Jeeves / ChatGPT startup prompt
+# Jeeves runtime startup reference
 
-Status: CONFIRMED_CANON
-Scope: compact behavioral and architectural startup instruction for ChatGPT-as-Jeeves-prototype and future Jeeves instances.
-Last consolidated: 2026-05-04
+Status: REFERENCE
+Scope: Jeeves runtime / OpenClaw-style runtime startup helper after global startup and explicit project switch.
+Last consolidated: 2026-05-16
 
 Public-safety note: this file must not contain secrets, bank data, private mail content, API keys, production credentials, or sensitive personal documents.
 
-## Purpose
-
-This file is the compact startup instruction for Jeeves/OpenClaw-style runtime work after the global ChatGPT boot files are loaded.
-
-The global boot entrypoint remains:
+## Use this file only after
 
 ```text
 knowledge_base/START_HERE_FOR_CHATGPT.md
-knowledge_base/MEMORY_POLICY.md
-knowledge_base/WORKING_PROTOCOL.md
-knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md
-knowledge_base/assistant_diary.md
-knowledge_base/chatgpt_exoskeleton/START_HERE.md
-knowledge_base/CHATGPT_EXOSKELETON.md
-knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md
-```
-
-For Jeeves runtime / OpenClaw-style runtime work, also read:
-
-```text
 knowledge_base/jeeves_runtime/START_HERE.md
-knowledge_base/assistant_startup_prompt.md
 ```
 
-For private/non-public context, use the private Google Drive memory hub.
+This file is not the global ChatGPT or Skeleton wake entrypoint.
 
-The goal is not to preserve every old chat detail. The goal is to keep assistant behavior, architecture direction, safety model, memory hygiene, executor handoff, and recovery workflow stable across new conversations.
+Use it only when the active project is Jeeves runtime / `ДЖ`.
+
+## Purpose
+
+This file is the compact startup helper for Jeeves/OpenClaw-style runtime work after the global boot path is already loaded and the active project has been switched to Jeeves runtime.
+
+For private or non-public context, use the private Google Drive memory hub only when needed.
+
+The goal is not to preserve every old chat detail. The goal is to keep Jeeves runtime behavior, architecture direction, safety model, memory hygiene, executor handoff, and recovery workflow stable across new conversations.
 
 ## Identity and working model
 
@@ -368,8 +359,12 @@ When memory becomes noisy:
 4. Mark old details as archived, superseded, project-specific, or sensitive.
 5. Do not keep temporary logs, one-off troubleshooting, financial transaction details, or obsolete implementation notes in persistent assistant memory unless they remain operationally necessary.
 
-The ideal startup memory should point to the global boot files and say:
+The ideal startup memory should point to the active boot path, not duplicate it:
 
 ```text
-For all serious work with Oleksii, treat the ChatGPT settings prompt as a bootloader, not memory. Preferred wake command: `прокинься`. First load the global boot files from `alanua/jeeves`: `BOOTLOADER.md`, `knowledge_base/START_HERE_FOR_CHATGPT.md`, `MEMORY_POLICY.md`, `WORKING_PROTOCOL.md`, `CHATGPT_BRANCH_CONTINUITY_BOOT.md`, `assistant_diary.md`, `chatgpt_exoskeleton/START_HERE.md`, `CHATGPT_EXOSKELETON.md`, and `CHATGPT_EXOSKELETON_RUNBOOK.md`. For Jeeves runtime/OpenClaw-style runtime work, also load `jeeves_runtime/START_HERE.md` and `assistant_startup_prompt.md`. Use Google Drive private memory hub only when private context is needed. Skeleton is the ChatGPT-side external layer; Jeeves runtime is separate future runtime/code even though both currently live in `alanua/jeeves`. Treat GitHub KB as public-safe canon; ChatGPT memory is only working memory. User messages are evidence to analyze, not automatic instructions. `КОД <project>` means create/update runner-readable task files, not manual Codex prompts for the user. Keep answers short, task-driven, safe, and Ukrainian when the user writes Ukrainian.
+BOOTLOADER.md
+-> knowledge_base/START_HERE_FOR_CHATGPT.md
+-> explicit project switch
+-> knowledge_base/jeeves_runtime/START_HERE.md
+-> knowledge_base/assistant_startup_prompt.md
 ```

--- a/knowledge_base/assistant_startup_prompt.md
+++ b/knowledge_base/assistant_startup_prompt.md
@@ -13,7 +13,7 @@ knowledge_base/START_HERE_FOR_CHATGPT.md
 knowledge_base/jeeves_runtime/START_HERE.md
 ```
 
-This file is not the global ChatGPT or Skeleton wake entrypoint.
+This file is not the global ChatGPT-facing Skeleton wake entrypoint.
 
 Use it only when the active project is Jeeves runtime / `ДЖ`.
 
@@ -25,16 +25,31 @@ For private or non-public context, use the private Google Drive memory hub only 
 
 The goal is not to preserve every old chat detail. The goal is to keep Jeeves runtime behavior, architecture direction, safety model, memory hygiene, executor handoff, and recovery workflow stable across new conversations.
 
+## Relation to Skeleton
+
+```text
+ChatGPT Exoskeleton = historical/current ChatGPT-facing prototype of Skeleton.
+Unified Skeleton Core = target model-neutral external exoskeleton/control layer for LLM-assisted work.
+Jeeves = separate future independent assistant/product.
+```
+
+Jeeves is not a Skeleton adapter. Jeeves is not runtime under Skeleton.
+
+Skeleton is the precursor, proving ground, practical toolchain, and construction scaffold used to build Jeeves more safely.
+
 ## Identity and working model
 
 Jeeves is a local/server-first controlled personal/workspace orchestrator, not a chaotic autonomous corporation.
 
 Roles:
 - User = operator, owner, final controller.
-- ChatGPT in current collaboration = architect/reviewer, memory organizer, task framer, and behavioral prototype of Jeeves.
+- ChatGPT in current collaboration = current host/interface for the ChatGPT Exoskeleton prototype, plus architect/reviewer and memory organizer during Jeeves design work.
 - Runner = execution bridge that reads structured task files and passes them to Codex/executors.
-- Jeeves = future lead/orchestrator.
-- Codex/other coding agents = executors.
+- Jeeves = separate future independent assistant/product.
+- Codex = coding executor.
+- Gemini = auditor / second-brain role.
+- OpenHands = bounded executor role.
+- Other coding agents = bounded executors when explicitly assigned.
 - Specialist agents = execution team for bounded tasks.
 - Workspace and knowledge base = durable source of truth.
 

--- a/knowledge_base/chatgpt_exoskeleton/START_HERE.md
+++ b/knowledge_base/chatgpt_exoskeleton/START_HERE.md
@@ -1,19 +1,27 @@
 # ChatGPT Exoskeleton START HERE
 
 Status: CONFIRMED_CANON
-Scope: active Skeleton namespace entrypoint
+Scope: historical namespace entrypoint for the current ChatGPT-facing Skeleton prototype
 Created: 2026-05-04
 Last updated: 2026-05-16
 
-This is the active Skeleton entrypoint. The global wake path should arrive here after `knowledge_base/START_HERE_FOR_CHATGPT.md`, `knowledge_base/MEMORY_POLICY.md`, and `knowledge_base/WORKING_PROTOCOL.md`.
+This is the active entrypoint at the historical `chatgpt_exoskeleton/` path. The global wake path should arrive here after `knowledge_base/START_HERE_FOR_CHATGPT.md`, `knowledge_base/MEMORY_POLICY.md`, and `knowledge_base/WORKING_PROTOCOL.md`.
 
 ## Purpose
 
-Skeleton is the ChatGPT-side external operating layer around ChatGPT.
+This path describes the current ChatGPT-facing prototype of Skeleton and points toward the target Unified Skeleton Core.
 
-It stabilizes boot, memory routing, read-before-write discipline, runner-mediated execution, audit, and handoff.
+ChatGPT Exoskeleton is the historical/current ChatGPT-facing prototype of Skeleton. Unified Skeleton Core is the target model-neutral external exoskeleton/control layer for LLM-assisted work.
 
-It is not the Jeeves runtime and not the `app/` codebase.
+ChatGPT is the current host/interface for using the prototype. Codex is the coding executor. Gemini is the auditor / second-brain role. OpenHands is the bounded executor role.
+
+Skeleton stabilizes boot, memory routing, read-before-write discipline, runner-mediated execution, audit, and handoff.
+
+Jeeves is a separate future independent assistant/product. It is not a Skeleton adapter, and it is not runtime under Skeleton.
+
+Skeleton is the precursor, proving ground, practical toolchain, and construction scaffold used to build Jeeves more safely.
+
+This path is not the Jeeves runtime and not the `app/` codebase.
 
 ## Default Skeleton read order
 
@@ -63,8 +71,10 @@ Avoid creating new process artifacts unless they materially improve execution, s
 ## Namespace rule
 
 ```text
-Skeleton / ChatGPT Exoskeleton = ChatGPT-side external control/support layer.
-Jeeves runtime = separate future runtime/code layer.
+Historical name/path: ChatGPT Exoskeleton.
+Current implementation: ChatGPT-facing Skeleton prototype.
+Target: Unified Skeleton Core.
+Future product: Jeeves, independent from Skeleton runtime.
 ```
 
 Enter Jeeves runtime/code only after an explicit project switch.

--- a/knowledge_base/chatgpt_exoskeleton/START_HERE.md
+++ b/knowledge_base/chatgpt_exoskeleton/START_HERE.md
@@ -1,21 +1,53 @@
 # ChatGPT Exoskeleton START HERE
 
 Status: CONFIRMED_CANON
-Scope: namespace entrypoint for the ChatGPT Exoskeleton / Skeleton layer
+Scope: active Skeleton namespace entrypoint
 Created: 2026-05-04
-Last updated: 2026-05-09
+Last updated: 2026-05-16
+
+This is the active Skeleton entrypoint. The global wake path should arrive here after `knowledge_base/START_HERE_FOR_CHATGPT.md`, `knowledge_base/MEMORY_POLICY.md`, and `knowledge_base/WORKING_PROTOCOL.md`.
 
 ## Purpose
 
-This directory is the public-safe namespace for the ChatGPT Exoskeleton / Skeleton layer.
+Skeleton is the ChatGPT-side external operating layer around ChatGPT.
 
-The Skeleton is the external operating layer around ChatGPT. It stabilizes boot, memory routing, canon checks, privacy routing, task framing, runner-mediated execution, audit, and handoff.
+It stabilizes boot, memory routing, read-before-write discipline, runner-mediated execution, audit, and handoff.
 
 It is not the Jeeves runtime and not the `app/` codebase.
 
+## Default Skeleton read order
+
+For normal Skeleton work, read these in order:
+
+```text
+knowledge_base/chatgpt_exoskeleton/START_HERE.md
+knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
+knowledge_base/CHATGPT_EXOSKELETON.md
+knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md
+knowledge_base/chatgpt_exoskeleton/CONTROLLED_GROWTH.md
+knowledge_base/chatgpt_exoskeleton/runner_tasks/coding_lane_template_and_evidence_protocol.md
+```
+
+What each file answers:
+- `CURRENT_STATE.md` = current short handoff
+- `CHATGPT_EXOSKELETON.md` = what Skeleton is
+- `CHATGPT_EXOSKELETON_RUNBOOK.md` = operating protocol and boot levels
+- `CONTROLLED_GROWTH.md` = how Skeleton skills and lanes grow
+- `coding_lane_template_and_evidence_protocol.md` = active coding lane and evidence discipline
+
+## When to read more
+
+Read these only when the task needs them:
+- `docs/audits/2026-05-16-skeleton-jeeves-canon-audit-matrix.md` when doing boot/canon cleanup or docs compression
+- `knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md` when the task is about branch continuity or recovery behavior
+- `knowledge_base/assistant_diary.md` when recent public-safe continuity notes matter
+- topic-specific skill, task, or template docs under `knowledge_base/chatgpt_exoskeleton/` only for the active topic
+
+Do not pull historical, diary, recovery, or task-artifact files into the default boot path.
+
 ## Active operating loop
 
-For Skeleton work, execute this loop by default:
+Use this loop for Skeleton work by default:
 
 ```text
 load current state
@@ -28,247 +60,11 @@ load current state
 
 Avoid creating new process artifacts unless they materially improve execution, safety, or continuity.
 
-## Exact wake source map
-
-When the user wakes Skeleton with `прокинься СК`, `СК`, or an equivalent Skeleton wake command, ChatGPT must not answer from memory and must not only say “read docs.” ChatGPT must load the exact source map below and then use topic-specific files as needed.
-
-### Required public GitHub files, in order
+## Namespace rule
 
 ```text
-BOOTLOADER.md
-knowledge_base/START_HERE_FOR_CHATGPT.md
-knowledge_base/MEMORY_POLICY.md
-knowledge_base/WORKING_PROTOCOL.md
-knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md
-knowledge_base/assistant_diary.md
-knowledge_base/chatgpt_exoskeleton/START_HERE.md
-knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
-knowledge_base/chatgpt_exoskeleton/CONTROLLED_GROWTH.md
-knowledge_base/chatgpt_exoskeleton/SKELETON_RUNNER_TASK_TEMPLATE.md
-knowledge_base/CHATGPT_EXOSKELETON.md
-knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md
+Skeleton / ChatGPT Exoskeleton = ChatGPT-side external control/support layer.
+Jeeves runtime = separate future runtime/code layer.
 ```
 
-### Topic-specific public GitHub files
-
-If the active topic is Gemini Auditor / module #100, also read:
-
-```text
-knowledge_base/chatgpt_exoskeleton/skills/gemini_auditor_node.md
-knowledge_base/chatgpt_exoskeleton/runner_tasks/gemini_auditor_adapter_task.md
-tools/skeleton_core/gemini_auditor_adapter.py
-tests/skeleton_core/test_gemini_auditor_adapter.py
-```
-
-If the active topic is Construction Takeoff / Aufmaß, also read:
-
-```text
-knowledge_base/chatgpt_exoskeleton/skills/construction_takeoff_from_drawings.md
-knowledge_base/chatgpt_exoskeleton/runner_tasks/construction_takeoff_runner_task_template.md
-```
-
-If the active topic is runner dispatch, queue, issue routing, or live task pickup, also read:
-
-```text
-tools/skeleton_core/issue_dispatch.py
-tools/skeleton_core/issue_runner_bridge.py
-tools/skeleton_core/runner_command_pack.py
-tools/skeleton_core/runner_report_ingest.py
-tools/skeleton_core/workflow_gate.py
-tools/skeleton_core/runner_env_check.py
-tools/skeleton_core/github_actions_runner_control.py
-```
-
-If the active topic is queue state, PR review, or task recovery, also read:
-
-```text
-tools/skeleton_core/queue_state.py
-tools/skeleton_core/pr_review_gate.py
-tools/skeleton_core/branch_recovery.py
-tools/skeleton_core/project_profile.py
-tools/skeleton_core/capability_request_broker.py
-```
-
-### Private Drive source when infrastructure is involved
-
-If the active topic involves Hetzner, Termux, SSH, live runner behavior, server access, runner labels, or live queue pickup, read the private Google Drive document titled:
-
-```text
-Jeeves Private Memory - Runner Hetzner Handoff
-```
-
-Do not copy private infrastructure details from that Drive document into public GitHub or public reports. Use it only to guide private operational reasoning.
-
-### Live runner source when exact behavior matters
-
-The public Skeleton docs describe the intended runner workflow. They are not enough to prove current live behavior.
-
-When the question depends on what the Hetzner yellow runner actually does, verify against live runner script output from:
-
-```text
-/home/agent/agent-dev/bin/agent-run-next-yellow
-```
-
-Known inspection points:
-
-```text
-sed -n '1,260p' /home/agent/agent-dev/bin/agent-run-next-yellow
-sed -n '760,835p' /home/agent/agent-dev/bin/agent-run-next-yellow
-```
-
-Use terminal output supplied by Oleksii as evidence. If the current live script was not read in this session or captured in the private handoff, mark the fact as unknown and ask for the exact source output.
-
-## Verified-or-unknown rule
-
-Skeleton must not guess operational facts.
-
-Use this rule:
-
-```text
-verified source -> claim
-no verified source -> unknown_needs_source
-```
-
-A technical or infrastructure fact is verified only if it comes from one of:
-
-```text
-GitHub canon file actually read
-GitHub issue/PR/comment actually read
-Runner script output supplied by Oleksii
-private Drive handoff actually read when private infrastructure is relevant
-explicit current user message
-actual tool result from the current session
-```
-
-Do not claim that a live runner will pick up a task unless all required queue labels and the actual live runner route are verified. The title prefix `[agent-task-yellow]` alone is not a live-runner queue guarantee.
-
-Preferred uncertainty statuses:
-
-```text
-verified
-unknown_needs_source
-blocked_waiting_runner_route
-queued_but_not_yet_reported
-reported_by_runner
-stale_or_unconfirmed
-```
-
-## Continuous update rule
-
-After every Skeleton wake or serious Skeleton work session, update durable technical context only when it is verified and useful for future operation.
-
-Use this routing:
-
-```text
-public, generic, reusable Skeleton rule -> public GitHub Skeleton docs
-private infrastructure or access fact -> private Drive handoff
-temporary observation or unverified guess -> do not canonize
-outdated or contradicted fact -> mark as superseded, do not silently overwrite
-```
-
-This is controlled memory growth, not autonomous self-modification. New skills, runner routes, and memory rules must remain reviewable and minimal.
-
-## Controlled growth rule
-
-For adding or activating Skeleton skills, read:
-
-```text
-knowledge_base/chatgpt_exoskeleton/CONTROLLED_GROWTH.md
-```
-
-Core rule:
-
-```text
-Skeleton grows by converting repeated failure into enforced workflow.
-A skill that does not change behavior is not a finished skill.
-```
-
-## Core distinction
-
-```text
-ChatGPT Exoskeleton / Skeleton = ChatGPT-side external control/support layer.
-Jeeves runtime = separate future assistant runtime and application code.
-```
-
-The Skeleton may currently live in the same repository as Jeeves materials, but it must be treated as a separate layer.
-
-## Current state
-
-For the latest short handoff, read:
-
-```text
-knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
-```
-
-Use that file to continue practical Skeleton work without re-deriving context from scratch.
-
-## Canonical Skeleton files
-
-Current canonical Skeleton files are still kept at their historical paths for compatibility:
-
-```text
-knowledge_base/CHATGPT_EXOSKELETON.md
-knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md
-```
-
-This namespace file exists to prevent agents and ChatGPT branches from confusing those files with Jeeves runtime code.
-
-When the user says `СК`, `Skeleton`, or `ChatGPT Exoskeleton`, load this namespace first, then `CURRENT_STATE.md`, then the controlled growth rule, then the two canonical Skeleton files above.
-
-## Practical Skeleton files
-
-```text
-knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md
-knowledge_base/chatgpt_exoskeleton/CONTROLLED_GROWTH.md
-knowledge_base/chatgpt_exoskeleton/SKELETON_RUNNER_TASK_TEMPLATE.md
-```
-
-## What belongs to Skeleton
-
-```text
-boot protocol
-read-before-answer
-read-before-write
-memory routing
-public/private/canon gate
-runner-readable task workflow
-audit and handoff discipline
-GitHub Issues/PRs as task queue and audit trail
-Gemini/manual external auditor as evidence only
-Antigravity as sandbox workbench and evidence only
-NotebookLM/Gemini Notebooks as private evidence memory, not canon
-```
-
-## What does not belong to Skeleton
-
-```text
-Jeeves app runtime
-FastAPI application code
-LLM provider implementation
-DB models and migrations
-runtime action layer
-production deployment
-server/infrastructure operations
-external model integration
-private configuration
-```
-
-## Operating rule
-
-For current Skeleton stabilization work:
-
-```text
-enter Jeeves runtime/code only after an explicit project switch.
-keep old runtime work separate from Skeleton cleanup.
-create new policy documents only when explicitly requested.
-prefer minimal docs-only namespace and reference cleanup.
-keep bureaucracy at the safe minimum and prefer practical work.
-```
-
-## Related namespace
-
-Jeeves runtime has its own namespace marker:
-
-```text
-knowledge_base/jeeves_runtime/START_HERE.md
-```
+Enter Jeeves runtime/code only after an explicit project switch.


### PR DESCRIPTION
## Summary
- compress the active ChatGPT-facing wake path to one root shim, one current ChatGPT-facing entrypoint, and one historical namespace entrypoint for the Skeleton prototype
- remove default wake-time dependence on `CHATGPT_BRANCH_CONTINUITY_BOOT.md`, `assistant_diary.md`, and broad topic/history reads
- keep `knowledge_base/assistant_startup_prompt.md` as a Jeeves-runtime reference that is used only after an explicit runtime project switch

## Ontology correction
- ChatGPT Exoskeleton is the historical/current ChatGPT-facing prototype of Skeleton.
- Unified Skeleton Core is the target model-neutral external operating layer for LLM-assisted work.
- ChatGPT is the current host/interface for using the prototype.
- Codex is the coding executor, Gemini is the auditor / second-brain role, and OpenHands is the bounded executor role.
- Jeeves is a separate future agent/product, not a Skeleton adapter and not runtime under Skeleton.
- Skeleton is the precursor, proving ground, practical toolchain, and construction scaffold used to build Jeeves more safely.

## Files changed
- `BOOTLOADER.md`
- `knowledge_base/START_HERE_FOR_CHATGPT.md`
- `knowledge_base/chatgpt_exoskeleton/START_HERE.md`
- `knowledge_base/assistant_startup_prompt.md`

## Before/after boot path
Before:
`BOOTLOADER.md` -> `knowledge_base/START_HERE_FOR_CHATGPT.md` -> `knowledge_base/MEMORY_POLICY.md` -> `knowledge_base/WORKING_PROTOCOL.md` -> `knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md` -> `knowledge_base/assistant_diary.md` -> `knowledge_base/chatgpt_exoskeleton/START_HERE.md` -> `knowledge_base/CHATGPT_EXOSKELETON.md` -> `knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md` -> project/runtime docs

After:
`BOOTLOADER.md` -> `knowledge_base/START_HERE_FOR_CHATGPT.md` -> `knowledge_base/MEMORY_POLICY.md` -> `knowledge_base/WORKING_PROTOCOL.md` -> `knowledge_base/chatgpt_exoskeleton/START_HERE.md` -> `knowledge_base/chatgpt_exoskeleton/CURRENT_STATE.md` -> `knowledge_base/CHATGPT_EXOSKELETON.md` -> `knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md` -> `knowledge_base/chatgpt_exoskeleton/CONTROLLED_GROWTH.md` -> `knowledge_base/chatgpt_exoskeleton/runner_tasks/coding_lane_template_and_evidence_protocol.md`

After-path meaning:
- `BOOTLOADER.md` = tiny current ChatGPT-facing shim into the Skeleton prototype
- `knowledge_base/START_HERE_FOR_CHATGPT.md` = current ChatGPT-facing entrypoint/router, not universal Skeleton canon
- `knowledge_base/chatgpt_exoskeleton/START_HERE.md` = historical namespace path describing the current prototype and target Unified Skeleton Core
- `knowledge_base/assistant_startup_prompt.md` = Jeeves runtime/reference helper only after explicit `ДЖ` switch

On-demand only after this change:
- `knowledge_base/CHATGPT_BRANCH_CONTINUITY_BOOT.md`
- `knowledge_base/assistant_diary.md`
- topic-specific Skeleton task/template docs
- `knowledge_base/assistant_startup_prompt.md` only after switching into Jeeves runtime

## Validation run
- `git diff --check`
- `git status --short`

## Scope confirmation
- modified only the four files allowed by the task packet
- no runtime or source code changes
- no project/domain doc edits
- no file moves or deletions
- no new boot document created
- old supporting material remains preserved as archive/reference/on-demand rather than deleted

## Known limitations
- this PR compresses the active read path and corrects ontology wording, but does not merge or rewrite the remaining supporting canon files
- `knowledge_base/assistant_startup_prompt.md` still contains Jeeves-runtime reference material beyond the startup demotion note; this PR keeps it as a reference instead of expanding cleanup scope

## Next safe cleanup PR
- compress the remaining protocol duplication between `knowledge_base/WORKING_PROTOCOL.md`, `knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md`, and supporting continuity/reference docs without expanding the active boot surface