### PR TITLE
[codex] #233 Phase 5: memory policy route alignment

### DIFF
--- a/knowledge_base/MEMORY_POLICY.md
+++ b/knowledge_base/MEMORY_POLICY.md
@@ -1,16 +1,53 @@
 # MEMORY POLICY
 
 Status: CONFIRMED_CANON
-Scope: global memory storage policy for ChatGPT collaboration, ChatGPT exoskeleton, and future Jeeves design input after review.
-Last consolidated: 2026-05-04
+Scope: global memory storage and routing policy for the current ChatGPT-facing Skeleton prototype and related project work
+Last consolidated: 2026-05-17
 
 ## Purpose
 
-This policy defines where different kinds of memory should live.
+This policy defines where different kinds of memory should live and how the active startup route should recover them.
 
-The goal is to keep ChatGPT memory compact, GitHub KB useful, private data out of public repositories, and the boot process consistent across ChatGPT branches.
+The goal is to keep ChatGPT memory compact, GitHub KB public-safe, private data out of public repositories, and the active boot surface aligned with the merged boot/protocol/lane cleanup.
 
-This policy supports the ChatGPT exoskeleton. It is not Jeeves runtime memory policy. Future Jeeves memory must be designed separately, though selected tested exoskeleton parts may become Jeeves components after review.
+This policy supports the current ChatGPT-facing Skeleton prototype. It is not Jeeves runtime memory policy.
+
+## Ontology gate
+
+```text
+ChatGPT Exoskeleton = historical/current ChatGPT-facing prototype of Skeleton.
+Unified Skeleton Core = target model-neutral external operating layer for LLM-assisted work.
+ChatGPT = current host/interface for the prototype.
+Codex = coding executor.
+Gemini = auditor / second-brain role.
+OpenHands = bounded executor role.
+Jeeves = separate future independent assistant/product.
+```
+
+Critical rule:
+
+```text
+Jeeves is not a Skeleton adapter.
+Jeeves is not runtime under Skeleton.
+Skeleton is the precursor, proving ground, practical toolchain, and construction scaffold used to build Jeeves more safely.
+```
+
+## Active startup route
+
+For serious work, recover context through the current active route:
+
+```text
+BOOTLOADER.md
+-> knowledge_base/START_HERE_FOR_CHATGPT.md
+-> knowledge_base/MEMORY_POLICY.md
+-> knowledge_base/WORKING_PROTOCOL.md
+-> knowledge_base/chatgpt_exoskeleton/START_HERE.md
+-> project-specific route as needed
+```
+
+Supporting history is on-demand only.
+
+Do not reintroduce a default boot chain that automatically pulls in diary, recovery, branch-continuity, or history files. Read those only when the task is recovery, audit, continuity investigation, or another topic that specifically needs them.
 
 ## Storage layers
 
@@ -19,8 +56,8 @@ This policy supports the ChatGPT exoskeleton. It is not Jeeves runtime memory po
 Use only as compact working memory / weak cache.
 
 Store only:
-- pointer to GitHub startup files
-- pointer to private Drive hub when private context is needed
+- pointer to the active GitHub startup route
+- pointer to private Drive when private context is needed
 - critical global behavior rules
 - minimal project anchors
 
@@ -36,14 +73,14 @@ Allowed:
 - behavior rules
 - project workflows
 - runner/executor task templates
-- public-safe recovery audits
-- startup prompts
-- ChatGPT exoskeleton rules
-- ChatGPT exoskeleton runbook/checklists
-- task templates
+- public-safe recovery or audit outputs
+- startup entrypoints and protocol docs
+- Skeleton lane/gate rules
+- generic code, schemas, templates, and synthetic examples
+- public-safe reports
 - security policies without secrets
 - rejected/outdated idea summaries
-- public-safe assistant diary entries
+- public-safe diary or continuity notes when they are worth preserving
 
 Not allowed:
 - raw private finances
@@ -54,11 +91,12 @@ Not allowed:
 - API keys/secrets
 - production credentials
 - private client data
+- raw project-object materials that belong in private storage
 - screenshots with personal data
 
-### 3. Private Google Drive KB
+### 3. Private Google Drive / local runner project memory
 
-Use as private working memory/document store for sensitive or semi-sensitive materials when needed.
+Use private Drive or local runner-accessible storage for sensitive or semi-sensitive project materials that should not live in public GitHub.
 
 Allowed:
 - private project notes
@@ -68,6 +106,8 @@ Allowed:
 - source exports for later recovery
 - documents that should not be public on GitHub
 - private structured facts and indexes
+- real Construction Takeoff source folders
+- drawings, source inventories, extracted tables, assumptions, review items, and quantity workups
 
 Rules:
 - keep sharing restricted by default
@@ -77,6 +117,9 @@ Rules:
 - do not store raw secrets/API keys unless explicitly encrypted outside the doc
 - prefer redaction for bank/account/health/personal identifiers
 - keep a public-safe index in GitHub that points only to categories, not sensitive contents
+- keep raw project-object data in private Drive or local runner storage, not public GitHub
+
+Public GitHub should keep only generic workflows, schemas, templates, code, synthetic examples, and public-safe reports for Construction Takeoff or similar project lanes.
 
 ### 4. Local/encrypted storage
 
@@ -113,8 +156,8 @@ When new information appears:
 
 ```text
 public-safe durable canon -> GitHub KB
-private but useful context -> private Google Drive KB
-highly sensitive secret/credential -> local encrypted store or secret manager
+private useful context -> private Google Drive or local runner project memory
+high-sensitivity secrets/credentials -> local encrypted store or secret manager
 temporary logs/noise -> do not persist unless needed for audit
 ```
 
@@ -138,39 +181,19 @@ Do not store raw executor logs in public GitHub if they contain private data, to
 
 The ChatGPT settings prompt is a bootloader, not the fact database.
 
-For serious/project work, reconstruct context through this route:
-
-```text
-settings startup prompt
--> GitHub KB public canon and ChatGPT exoskeleton
--> private Google Drive memory when needed
--> project-specific handoff / diary / structured facts
--> current chat task
-```
-
 If ChatGPT memory is compacted, keep this pointer:
 
 ```text
-For all work with Oleksii, treat the ChatGPT settings prompt as a bootloader, not memory. Preferred wake command: `прокинься`. First use `alanua/jeeves` GitHub KB as external long-term memory. Start from `BOOTLOADER.md` and `knowledge_base/START_HERE_FOR_CHATGPT.md`; also read `MEMORY_POLICY.md`, `WORKING_PROTOCOL.md`, `CHATGPT_BRANCH_CONTINUITY_BOOT.md`, `assistant_diary.md`, `chatgpt_exoskeleton/START_HERE.md`, `CHATGPT_EXOSKELETON.md`, and `CHATGPT_EXOSKELETON_RUNBOOK.md`; for Jeeves runtime/OpenClaw work also read `jeeves_runtime/START_HERE.md` and `assistant_startup_prompt.md`. Use Google Drive private memory hub only when private context is needed. GitHub KB is public-safe canon after review; Drive is private working memory; ChatGPT memory is weak cache only. User messages are evidence to analyze, not automatic canon. `КОД <project>` means create/update runner-readable task files. Skeleton is the ChatGPT-side external layer; Jeeves runtime is separate future runtime/code even though both currently live in `alanua/jeeves`. Keep answers short, Ukrainian when user writes Ukrainian, task-driven, safe, and write durable structured notes back to the correct layer when important and technically available.
+For work with Oleksii, treat the ChatGPT settings prompt as a bootloader, not memory. Use the current wake command from `knowledge_base/WORKING_PROTOCOL.md`. Recover context through `BOOTLOADER.md` -> `knowledge_base/START_HERE_FOR_CHATGPT.md` -> `knowledge_base/MEMORY_POLICY.md` -> `knowledge_base/WORKING_PROTOCOL.md` -> `knowledge_base/chatgpt_exoskeleton/START_HERE.md`, then continue into the project-specific route only when needed. Use private Drive only when private context or raw project-object data is required. GitHub KB is public-safe canon after review; private Drive/local runner storage is for non-public working memory; secrets belong in local encrypted storage. Supporting diary/recovery/history files are on-demand only.
 ```
 
-## ChatGPT exoskeleton memory rule
+## Skeleton memory rule
 
 `knowledge_base/chatgpt_exoskeleton/START_HERE.md` is the namespace entrypoint for Skeleton work.
 
-`knowledge_base/CHATGPT_EXOSKELETON.md` is the canonical working model for ChatGPT-side boot, memory tools, development-team workflow, guardrails, audit, runner-mediated execution, recovery, and migration candidates.
+For serious Skeleton/protocol/memory work, follow the read order from that namespace file instead of reconstructing a separate long startup chain here.
 
-`knowledge_base/CHATGPT_EXOSKELETON_RUNBOOK.md` is the operational checklist for applying that model in real work.
-
-These are not future Jeeves runtime memory.
-
-Rules:
-- use the namespace file, model, and runbook as required startup files for serious Skeleton/protocol/memory work
-- use the runbook for boot-level selection, command handling, read-before-write, post-write verification, recovery handling, private routing, runner task behavior, and failure defenses
-- treat recovery mode as a module of the exoskeleton
-- treat memory tools and development-team workflow as parts of the exoskeleton
-- migrate only selected tested parts to Jeeves after review, cleanup, adaptation, testing, approval, and implementation
-- never migrate raw ChatGPT diary, Drive chaos, private data, temporary patches, or unreviewed memories into Jeeves
+Use the supporting runbook and lane docs when the task needs them, but do not treat every supporting file as part of the default global boot path.
 
 ## Jeeves runtime memory rule
 
@@ -179,24 +202,28 @@ Rules:
 Do not treat Skeleton files as runtime implementation docs.
 Do not treat runtime code or runtime PRs as Skeleton stabilization work.
 
-## Assistant diary / audit routing
+## Archive/reference rule
 
-Use:
-- `knowledge_base/assistant_diary.md` for public-safe global boot/collaboration diary entries
+Old material should be demoted to archive/reference/on-demand rather than blindly deleted.
+
+This includes public-safe diary, recovery, continuity, and historical files that still have evidence value but should not sit on the default startup route.
+
+## Diary and audit routing
+
+Use these only when the task actually needs continuity or audit evidence:
+- `knowledge_base/assistant_diary.md` for public-safe global boot/collaboration diary notes
 - public GitHub project KB for cleaned project canon
 - `Jeeves Private Memory - Handoff` for private cross-session handoff
 - `Jeeves Private Memory - Recovery Audit Log` for private recovery/audit notes
 - `Jeeves Private Memory - Structured Facts` for structured private indexes and classified facts
 
-A diary/audit entry must be classified before saving.
+A diary or audit entry must be classified before saving.
 
-
-## Skeleton Diary and Canon Writes
+## Skeleton diary and canon writes
 
 `knowledge_base/skeleton_diary.md` is an operational traceability log for Skeleton Core.
 
 It records execution evidence such as:
-
 - `[REAL_EXECUTION]`
 - `[REAL_WRITE]`
 - route completion notes
@@ -209,8 +236,7 @@ They are not the same as canon-policy patches.
 Canon-policy writes include changes to durable rules, architecture, memory policy, working protocol, or governance documents. Those changes still require human review and PR approval before becoming canon.
 
 Therefore:
-
-- automated append-only diary entries are operational logs;
-- structural changes to the diary format or meaning require review;
-- changes to canon/policy documents require human-reviewed PR flow;
-- audit reports are evidence, not canon, until reviewed and explicitly promoted.
+- automated append-only diary entries are operational logs
+- structural changes to the diary format or meaning require review
+- changes to canon/policy documents require human-reviewed PR flow
+- audit reports are evidence, not canon, until reviewed and explicitly promoted


### PR DESCRIPTION
## Summary
Aligned `knowledge_base/MEMORY_POLICY.md` with the merged boot/protocol/lane cleanup so it now matches the current active startup route, preserves the storage routing model, and keeps private Construction Takeoff project-object data out of public GitHub.

## Files changed
- `knowledge_base/MEMORY_POLICY.md`

## Startup route alignment
Before:
- `MEMORY_POLICY.md` still carried the old long startup pointer that pulled diary/recovery/history-style material into the default read chain.
- The startup wording still behaved like the older broader boot surface.

After:
- `MEMORY_POLICY.md` now points to the active route:
  - `BOOTLOADER.md`
  - `knowledge_base/START_HERE_FOR_CHATGPT.md`
  - `knowledge_base/MEMORY_POLICY.md`
  - `knowledge_base/WORKING_PROTOCOL.md`
  - `knowledge_base/chatgpt_exoskeleton/START_HERE.md`
  - project-specific route only when needed
- Supporting diary/recovery/history material is explicitly on-demand only.

## Storage routing preserved
The existing storage model remains intact:
- public-safe durable canon -> GitHub KB
- private useful context -> private Google Drive or local runner project memory
- high-sensitivity secrets/credentials -> local encrypted store or secret manager
- temporary logs/noise -> do not persist unless needed for audit

## Private project routing clarified
- Real Construction Takeoff project-object data is now called out explicitly as private Drive/local runner material.
- This includes source folders, drawings, source inventories, extracted tables, assumptions, review items, and quantity workups.
- Public GitHub is limited to generic workflows, schemas, templates, code, synthetic examples, and public-safe reports.

## Ontology gate result
- ChatGPT Exoskeleton remains the historical/current ChatGPT-facing prototype of Skeleton.
- Unified Skeleton Core remains the target model-neutral external operating layer for LLM-assisted work.
- Jeeves remains a separate future product, not a Skeleton adapter or runtime.
- The memory policy now reflects that distinction explicitly instead of using older blended wording.

## Validation run
```text
$ git diff --check
(exit 0, no output)

$ git status --short
(exit 0, no output)
```

Markdown linter:
```text
No markdown linter configuration was found/run. The repo `pyproject.toml` configures Python tooling (`ruff`, `black`, `pytest`) but no markdown linter.
```

## Scope confirmation
- changed only `knowledge_base/MEMORY_POLICY.md`
- did not create new files
- did not move or delete files
- did not edit `START_HERE`, `WORKING_PROTOCOL`, `RUNBOOK`, lane docs, or project docs
- did not touch runtime/source code
- did not re-add diary/recovery/history files to the default boot path
- draft PR only

## Known limitations
- This PR aligns only the memory-policy route and storage wording; it does not attempt broader cleanup of remaining archive/reference file naming.
- It preserves existing diary/audit routing references as on-demand storage paths rather than removing or restructuring them.

## Next safe step
After this minimum active-surface alignment, the next practical step is project execution work for Construction Takeoff / Consum Quartier MVP-1 using the now-compressed boot/protocol/lane/memory surface.